### PR TITLE
feat: runtime-configurable BPF programs via rodata injection

### DIFF
--- a/api/api.$progname.h.in
+++ b/api/api.$progname.h.in
@@ -15,6 +15,35 @@ int ${OPERATION}${PROGNAME}(struct config *conf, after_attach_fn_t cb)
         return 1;
     }
 
+    // Set read-only data (between open and load)
+#if ${PROGNAME_WITH_RODATA}
+    if (conf->has_input)
+    {
+        struct bpf_map *rodata_map = obj->maps.rodata;
+        if (!rodata_map)
+        {
+            log_err(conf, "fail: .rodata map not found in skeleton\n");
+            goto destroy_${PROGNAME};
+        }
+        size_t rodata_sz = bpf_map__value_size(rodata_map);
+        void *rodata_buf = calloc(1, rodata_sz);
+        if (!rodata_buf)
+        {
+            log_err(conf, "fail: allocating rodata buffer\n");
+            goto destroy_${PROGNAME};
+        }
+        memcpy(rodata_buf, &conf->input.${PROGNAME_INPUT_FIELD}, sizeof(conf->input.${PROGNAME_INPUT_FIELD}));
+        err = bpf_map__set_initial_value(rodata_map, rodata_buf, rodata_sz);
+        free(rodata_buf);
+        if (err)
+        {
+            log_err(conf, "fail: setting .rodata map\n");
+            goto destroy_${PROGNAME};
+        }
+        log_out(conf, "done: setting rodata input\n");
+    }
+#endif
+
     err = ${PROGNAME}_bpf__load(obj);
     if (err)
     {

--- a/api/api.$progname.h.in
+++ b/api/api.$progname.h.in
@@ -1,6 +1,6 @@
 #include "${PROGNAME}.skel.h"
 
-int ${OPERATION}${PROGNAME}(struct config *conf, after_attach_fn_t cb, bpf_obj_fn_t obj_cb)
+int ${OPERATION}${PROGNAME}(struct config *conf, after_attach_fn_t cb)
 {
     int err;
     char buf[100];
@@ -13,15 +13,6 @@ int ${OPERATION}${PROGNAME}(struct config *conf, after_attach_fn_t cb, bpf_obj_f
     {
         log_err(conf, "fail: opening the eBPF skeleton\n");
         return 1;
-    }
-
-    if (obj_cb) {
-        err = obj_cb(obj);
-        if (err)
-        {
-            fprintf(stderr, "traffico: fail calling obj callback\n");
-            goto destroy_${PROGNAME};
-        }
     }
 
     err = ${PROGNAME}_bpf__load(obj);

--- a/api/api.h.in
+++ b/api/api.h.in
@@ -27,8 +27,15 @@ struct config
     bool cleanup_on_exit;
     program_t program;
     char *program_arg;
+    char *input_arg;
     FILE *err_stream;
     FILE *out_stream;
+
+    bool has_input;
+    union {
+        __u32 ip;
+        __u16 port;
+    } input;
 };
 
 typedef int (*after_attach_fn_t)(struct bpf_tc_hook hook, struct bpf_tc_opts opts);

--- a/api/api.h.in
+++ b/api/api.h.in
@@ -31,11 +31,9 @@ struct config
     FILE *out_stream;
 };
 
-typedef int (*bpf_obj_fn_t)(void *obj);
-
 typedef int (*after_attach_fn_t)(struct bpf_tc_hook hook, struct bpf_tc_opts opts);
 
-typedef int (*attach_fn_t)(struct config *conf, after_attach_fn_t cb, bpf_obj_fn_t obj_cb);
+typedef int (*attach_fn_t)(struct config *conf, after_attach_fn_t cb);
 
 /// logging
 int print_log(FILE *f, bool verbosity, bool prefix, const char *fmt, va_list argptr)
@@ -78,7 +76,7 @@ int exit_after_attach(struct bpf_tc_hook hook, struct bpf_tc_opts opts)
 }
 
 /// non-existing programs
-int ${OPERATION}0(struct config *conf, after_attach_fn_t cb, bpf_obj_fn_t obj_cb)
+int ${OPERATION}0(struct config *conf, after_attach_fn_t cb)
 {
     return 1;
 }
@@ -88,13 +86,13 @@ ${API}
 /// dispatch
 attach_fn_t attach_fn[NUM_PROGRAMS] = { ${PROGRAMS_OPS_AS_SYMBOLS} };
 
-int attach(struct config *conf, after_attach_fn_t cb, bpf_obj_fn_t obj_cb)
+int attach(struct config *conf, after_attach_fn_t cb)
 {
     attach_fn_t fn = attach_fn[conf->program];
     if (fn) {
-        return fn(conf, cb, obj_cb);
+        return fn(conf, cb);
     }
-    return ${OPERATION}0(conf, cb, obj_cb);
+    return ${OPERATION}0(conf, cb);
 }
 
 

--- a/api/input_parse.h
+++ b/api/input_parse.h
@@ -1,0 +1,52 @@
+#ifndef TRAFFICO_INPUT_PARSE_H
+#define TRAFFICO_INPUT_PARSE_H
+
+#include <arpa/inet.h>
+#include <stdlib.h>
+
+#include "api.h"
+
+// Parse the input string and populate conf->input based on the selected program.
+// Returns 0 on success, -1 on error (with err_msg set to a static string).
+static int parse_input(struct config *conf, const char *input_str, const char **err_msg)
+{
+    switch (conf->program)
+    {
+    case program_block_ip:
+    {
+        struct in_addr addr;
+        if (inet_pton(AF_INET, input_str, &addr) != 1)
+        {
+            *err_msg = "invalid IP address";
+            return -1;
+        }
+        conf->input.ip = ntohl(addr.s_addr);
+        conf->has_input = true;
+        return 0;
+    }
+    case program_block_port:
+    {
+        char *endptr;
+        unsigned long port = strtoul(input_str, &endptr, 10);
+        if (*endptr != '\0' || port == 0 || port > 65535)
+        {
+            *err_msg = "invalid port number";
+            return -1;
+        }
+        conf->input.port = (__u16)port;
+        conf->has_input = true;
+        return 0;
+    }
+    default:
+        *err_msg = "program does not accept input";
+        return -1;
+    }
+}
+
+// Returns true if the given program requires an input argument.
+static inline bool program_requires_input(program_t program)
+{
+    return program == program_block_ip || program == program_block_port;
+}
+
+#endif // TRAFFICO_INPUT_PARSE_H

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -55,6 +55,17 @@ teardown() {
     run ip netns exec "${NETNS}" tc qdisc del dev "${PEER}" clsact
 }
 
+@test "block_ip blocks specific IP" {
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 0 ]
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress block_ip "${VETH_ADDR}" >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 1 ]
+}
+
 @test "block_private_ipv4 blocks ICMP packets" {
     run ip netns exec "${NETNS}" ping -W1 -4 -c1 10.22.1.2
     [ $status -eq 0 ]

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -7,7 +7,7 @@ bats_require_minimum_version 1.7.0
 @test "help" {
     run traffico --help
     [ $status -eq 0 ]
-    [ "${lines[0]}" == 'Usage: traffico [OPTION...] PROGRAM' ]
+    [ "${lines[0]}" == 'Usage: traffico [OPTION...] PROGRAM [INPUT]' ]
 }
 
 @test "usage" {
@@ -63,4 +63,46 @@ bats_require_minimum_version 1.7.0
     [ ! $status -eq 0 ]
     [ $status -eq 1 ]
     [ "${lines[0]}" == "traffico: option '--at' requires one of the following values: INGRESS|EGRESS" ]
+}
+
+@test "missing input for block_ip" {
+    run traffico -i lo block_ip
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: program 'block_ip' requires an input argument" ]
+}
+
+@test "invalid IP for block_ip" {
+    run traffico -i lo block_ip not.an.ip
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: invalid IP address: 'not.an.ip'" ]
+}
+
+@test "missing input for block_port" {
+    run traffico -i lo block_port
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: program 'block_port' requires an input argument" ]
+}
+
+@test "invalid port for block_port" {
+    run traffico -i lo block_port abc
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: invalid port number: 'abc'" ]
+}
+
+@test "port out of range" {
+    run traffico -i lo block_port 99999
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: invalid port number: '99999'" ]
+}
+
+@test "input for program that doesn't need it" {
+    run traffico -i lo nop 1.2.3.4
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: program does not accept input: '1.2.3.4'" ]
+}
+
+@test "too many arguments" {
+    run traffico -i lo block_ip 1.2.3.4 extra
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: too many arguments" ]
 }

--- a/test/cni.bats
+++ b/test/cni.bats
@@ -25,6 +25,25 @@ teardown() {
     del_server
 }
 
+@test "block_ip via CNI" {
+    run curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can reach ${VETH_ADDR}:${SERVER_PORT}" >&3
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
+    echo "# installing block_ip in the namespace" >&3
+    run ip netns exec "${NETNS}" bash -c "cat '$FIXTURE_ROOT/attach_block_ip_in.json' | CNI_COMMAND=ADD traffico-cni"
+    [ $status -eq 0 ]
+    echo "# attach ok" >&3
+    run ip netns exec "${NETNS}" tc qdisc show dev peer0 clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    echo "# qdisc ok" >&3
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ ! $status -eq 0 ]
+    echo "# cannot reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
+}
+
 @test "block_private_ipv4" {
     run curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
     [ $status -eq 0 ]

--- a/test/cni.flags.bats
+++ b/test/cni.flags.bats
@@ -1,0 +1,12 @@
+#!/usr/bin/env bats
+
+load helpers
+fixtures cni
+export BATS_TEST_NAME_PREFIX=$(setsuite)
+bats_require_minimum_version 1.7.0
+
+@test "rejects input for program that doesn't need it" {
+    run bash -c 'echo '"'"'{"cniVersion":"0.4.0","name":"dummy","type":"traffico-cni","program":"nop","input":"1.2.3.4","prevResult":{"cniVersion":"1.0.0","interfaces":[{"name":"lo"}],"ips":[],"routes":[],"dns":{}}}'"'"' | CNI_COMMAND=ADD traffico-cni'
+    [ ! $status -eq 0 ]
+    [[ "$output" == *'"msg":	"program does not accept input"'* ]]
+}

--- a/test/fixtures/cni/attach_block_ip_in.json
+++ b/test/fixtures/cni/attach_block_ip_in.json
@@ -1,0 +1,22 @@
+{
+    "cniVersion": "0.4.0",
+    "name": "dummy-network",
+    "prevResult": {
+        "cniVersion": "1.0.0",
+        "interfaces": [
+            {
+                "name": "peer0"
+            }
+        ],
+        "ips": [
+        ],
+        "routes": [
+        ],
+        "dns": {
+        }
+    },
+    "type": "traffico-cni",
+    "program": "block_ip",
+    "input": "10.22.1.1",
+    "attachPoint": "egress"
+}

--- a/traffico-cni.c
+++ b/traffico-cni.c
@@ -244,7 +244,7 @@ int add_command()
 
     snprintf(config.ifname, IF_NAMESIZE, "%s", ifname->valuestring);
 
-    if (attach(&config, exit_after_attach, NULL) != 0)
+    if (attach(&config, exit_after_attach) != 0)
     {
         err.code = CNI_INVALID_NETWORK_CONFIG;
         err.msg = "Failed to attach BPF program";

--- a/traffico-cni.c
+++ b/traffico-cni.c
@@ -10,6 +10,7 @@
 #include <net/if.h>
 
 #include "api.h"
+#include "api/input_parse.h"
 
 enum cni_error_codes
 {
@@ -243,6 +244,36 @@ int add_command()
     }
 
     snprintf(config.ifname, IF_NAMESIZE, "%s", ifname->valuestring);
+
+    // Parse optional input field for programs with rodata
+    const cJSON *inputValue = NULL;
+    inputValue = cJSON_GetObjectItemCaseSensitive(jsonobj, "input");
+
+    if (inputValue != NULL && cJSON_IsString(inputValue))
+    {
+        const char *parse_err = NULL;
+        if (parse_input(&config, inputValue->valuestring, &parse_err) != 0)
+        {
+            err.code = CNI_INVALID_NETWORK_CONFIG;
+            err.msg = (char *)parse_err;
+            print_cni_error(&err);
+            return -1;
+        }
+    }
+    else if (inputValue != NULL)
+    {
+        err.code = CNI_INVALID_NETWORK_CONFIG;
+        err.msg = "'input' field must be a string";
+        print_cni_error(&err);
+        return -1;
+    }
+    else if (program_requires_input(config.program))
+    {
+        err.code = CNI_INVALID_NETWORK_CONFIG;
+        err.msg = "program requires an 'input' field";
+        print_cni_error(&err);
+        return -1;
+    }
 
     if (attach(&config, exit_after_attach) != 0)
     {

--- a/traffico.c
+++ b/traffico.c
@@ -10,6 +10,7 @@
 #include <bpf/libbpf.h>
 
 #include "api.h"
+#include "api/input_parse.h"
 
 const char *argp_program_version = TOOL_NAME " 0.0";
 const char *argp_program_bug_address = "https://github.com/leodido/traffico/issues";
@@ -144,15 +145,28 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
     // Arguments
     case ARGP_KEY_ARG:
         assert(arg);
-        for (p = 0; p < NUM_PROGRAMS; p++)
+        if (state->arg_num == 0)
         {
-            if (strcasecmp(arg, g_programs_name[p]) == 0)
+            // First positional arg: program name
+            g_config.program_arg = arg;
+            for (p = 0; p < NUM_PROGRAMS; p++)
             {
-                g_config.program = (program_t)p;
-                break;
+                if (strcasecmp(arg, g_programs_name[p]) == 0)
+                {
+                    g_config.program = (program_t)p;
+                    break;
+                }
             }
         }
-        g_config.program_arg = arg;
+        else if (state->arg_num == 1)
+        {
+            // Second positional arg: input value (parsed in ARGP_KEY_FINI)
+            g_config.input_arg = arg;
+        }
+        else
+        {
+            argp_error(state, "too many arguments");
+        }
         break;
 
     case ARGP_KEY_END:
@@ -178,6 +192,20 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
             g_config.ifindex = if_nametoindex(g_config.ifname);
             assert(g_config.ifindex != 0);
         }
+
+        // Parse input value based on the selected program
+        if (g_config.input_arg)
+        {
+            const char *err_msg = NULL;
+            if (parse_input(&g_config, g_config.input_arg, &err_msg) != 0)
+            {
+                argp_error(state, "%s: '%s'", err_msg, g_config.input_arg);
+            }
+        }
+        else if (program_requires_input(g_config.program))
+        {
+            argp_error(state, "program '%s' requires an input argument", g_programs_name[g_config.program]);
+        }
         break;
 
     default:
@@ -189,7 +217,7 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
 static const struct argp argp = {
     .options = argp_opts,
     .parser = parse_cli,
-    .args_doc = "PROGRAM",
+    .args_doc = "PROGRAM [INPUT]",
     .doc = argp_program_doc,
 };
 

--- a/traffico.c
+++ b/traffico.c
@@ -250,5 +250,5 @@ int main(int argc, char **argv)
 
     // Execute
     log_info("prog: %s\n", g_programs_name[g_config.program]);
-    return attach(&g_config, &await, NULL);
+    return attach(&g_config, &await);
 }

--- a/xmake/modules/api.lua
+++ b/xmake/modules/api.lua
@@ -1,5 +1,13 @@
 import("core.project.project")
 
+-- Map program names to their input union field in struct config.
+-- Programs in this table have const volatile rodata that can be
+-- configured at runtime via the input union in struct config.
+local input_fields = {
+    block_ip = "ip",
+    block_port = "port",
+}
+
 -- get sourcefiles
 function _get_programs(target_name)
     local programs = {}
@@ -30,7 +38,17 @@ function gen(target, source_target)
         local tempconf = path.join(os.tmpdir(), confname)
         os.tryrm(tempconf)
         os.cp(configfile_template_path, tempconf)
-        target:add("configfiles", tempconf, { variables = { PROGNAME = progname, OPERATION = "attach__" } })
+        local input_field = input_fields[progname]
+        local has_rodata = input_field and 1 or 0
+
+        target:add("configfiles", tempconf, {
+            variables = {
+                PROGNAME = progname,
+                OPERATION = "attach__",
+                PROGNAME_WITH_RODATA = has_rodata,
+                PROGNAME_INPUT_FIELD = input_field or "",
+            }
+        })
     end
 end
 
@@ -52,17 +70,22 @@ function main(target, components_target, banner)
     local op = vars[1].variables.OPERATION
     v["OPERATION"] = op
     
+    local descr = '"  - '
     local programs = {}
     table.insert(programs, "0")
-    for _, v in ipairs(vars) do
-        table.insert(programs, v.variables.PROGNAME)
+    for i, pv in ipairs(vars) do
+        table.insert(programs, pv.variables.PROGNAME)
+        descr = descr .. pv.variables.PROGNAME .. (pv.variables.PROGNAME_WITH_RODATA == 1 and ' [input]' or '')
+        if i ~= #vars then
+            descr = descr .. '\\n  - '
+        end
     end
     table.sort(programs)
     v["PROGRAMS_AS_SYMBOLS"] = 'program_' .. table.concat(programs, ", program_")
     v["PROGRAMS_AS_STRINGS"] = '"' .. table.concat(programs, '", "') .. '"'
     v["PROGRAMS_OPS_AS_SYMBOLS"] = op .. table.concat(programs, ', ' .. op)
     table.remove(programs, 1)
-    v["PROGRAMS_DESCRIPTION"] = '"  - ' .. table.concat(programs, '\\n  - ') .. '"'
+    v["PROGRAMS_DESCRIPTION"] = descr .. '"'
 
     local content = ""
     for i, c in ipairs(components) do


### PR DESCRIPTION
Closes #8, closes #9

Allow BPF programs to receive runtime parameters without recompilation. Programs with `const volatile` globals (like `block_ip`'s IP address) can now be configured at attach time via `bpf_map__set_initial_value()`.

## Changes

**API (`api/api.h.in`, `api/api.$progname.h.in`, `api/input_parse.h`, `xmake/modules/api.lua`)**
- Drop the unused `bpf_obj_fn_t` callback from the attach API
- Add `has_input` flag and `input` union (`__u32 ip`, `__u16 port`) to `struct config`
- Add `input_arg` field to `struct config` (separate from `program_arg`)
- Per-program template injects rodata between `open()` and `load()` when `has_input` is true
- `input_fields` table in `api.lua` maps program names to union members; programs in the table get rodata injection code
- Shared `input_parse.h` header with `parse_input()` and `program_requires_input()` — used by both CLI and CNI
- Programs with rodata are annotated with `[input]` in `--help` output

**CLI (`traffico.c`)**
- Second positional argument: `traffico block_ip 1.2.3.4`
- Per-program input parsing via shared `parse_input()`
- Validation: missing input, invalid format, unwanted input, too many args

**CNI (`traffico-cni.c`)**
- Optional `\"input\"` JSON field in network config
- Same parsing and validation via shared `parse_input()`

**Tests (23 total, 9 new)**
- 7 CLI validation tests (missing input for block_ip/block_port, invalid IP, invalid port, out-of-range port, unwanted input, too many args)
- 1 CLI functional test (`block_ip` blocks specific IP in netns)
- 1 CNI functional test (`block_ip` via JSON config)
- Updated `help` test assertion for new `PROGRAM [INPUT]` usage line

## Commits

1. `refactor(api): drop bpf_obj_fn_t callback`
2. `feat(api): inject rodata via bpf_map__set_initial_value`
3. `feat(cli): accept input as second positional argument`
4. `feat(cni): parse input from JSON config`
5. `test: rodata injection`