### PR TITLE
build: fix elfutils dependency build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,4 +14,5 @@ RUN echo '%vscode ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER vscode
 
 RUN git clone https://aur.archlinux.org/yay.git && cd yay && makepkg --noconfirm -si
-RUN yay --noconfirm -S xmake
+RUN curl -fsSL https://xmake.io/shget.text | bash -s dev
+RUN source $HOME/.xmake/profile

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,4 +1,4 @@
-set_xmakever("2.6.1") -- Minimum version to compile BPF source correctly
+set_xmakever("2.8.2") -- Minimum version to compile BPF source correctly
 
 -- includes
 includes("xmake/repos.lua")


### PR DESCRIPTION
Signed-off-by: Leo Di Donato <leodidonato@gmail.com>

The current `xmake` version (2.8.1) contains a regression in their autoconf module that does not let us (or anybody) build `elfutils` properly from their official xmake repository (which also got [fixes](https://github.com/xmake-io/xmake-repo/commit/48a59486191871dd3476e8cef84c8b9d35c105e9) after my issue disclosure).

This **WIP** PR (DO NOT MERGE) prepares changes for when `xmake v2.8.2` is officially released.

Next step:
- [ ] wait for `xmake` 2.8.2 and update the `.devcontainer/Dockerfile` to install it


Fixes #14
Refs https://github.com/xmake-io/xmake-repo/issues/2313