### PR TITLE
fix: compile on modern toolchains (GCC 14+)

### DIFF
--- a/traffico-cni.c
+++ b/traffico-cni.c
@@ -1,6 +1,8 @@
 #define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <strings.h>
 #include <cjson/cJSON.h>
 #include <fcntl.h>
 #include <sched.h>
@@ -43,19 +45,16 @@ void print_cni_error(struct cni_error *err)
     printf("%s\n", cJSON_Print(error_obj));
 }
 
-#define BUFFERSIZE 10
 int get_stdin(char **text)
 {
-    *text = calloc(1, 1);
-    char *buffer[BUFFERSIZE];
-    while (fgets(buffer, BUFFERSIZE, stdin))
+    size_t n = 0;
+    *text = NULL;
+    // '\0' delimiter: read until EOF (JSON input won't contain NUL bytes)
+    if (getdelim(text, &n, '\0', stdin) < 0)
     {
-        *text = realloc(*text, strlen(*text) + 1 + strlen(buffer));
-        if (*text == NULL)
-        {
-            return 1;
-        }
-        strncat(*text, buffer, strlen(buffer));
+        free(*text);
+        *text = NULL;
+        return 1;
     }
     return 0;
 }
@@ -108,9 +107,8 @@ int add_command()
     struct config config = {
         .verbose = false,
         .cleanup_on_exit = false,
+        .program = program_0,
     };
-
-    config.verbose = false;
 
     char *stdin_text;
     if (get_stdin(&stdin_text) != 0)
@@ -235,16 +233,16 @@ int add_command()
             break;
         }
     }
-    if (config.program == NULL)
+    if (config.program == program_0)
     {
         err.code = CNI_INVALID_NETWORK_CONFIG;
-        err.msg = "Unknwon program";
+        err.msg = "Unknown program";
         err.details = programName_str;
         print_cni_error(&err);
         return -1;
     }
 
-    strncpy(config.ifname, ifname->valuestring, strlen(ifname->valuestring));
+    snprintf(config.ifname, IF_NAMESIZE, "%s", ifname->valuestring);
 
     if (attach(&config, exit_after_attach, NULL) != 0)
     {

--- a/traffico.c
+++ b/traffico.c
@@ -1,9 +1,12 @@
 #include <signal.h>
 #include <stdio.h>
+#include <string.h>
+#include <strings.h>
 #include <errno.h>
 #include <net/if.h>
 #include <assert.h>
 #include <argp.h>
+#include <unistd.h>
 #include <bpf/libbpf.h>
 
 #include "api.h"
@@ -47,6 +50,45 @@ static struct config g_config;
 
 #define log_info(fmt, ...) \
     log_out(&g_config, fmt, ##__VA_ARGS__);
+
+int get_gateway_iface(char *interface)
+{
+    long dest, gateway;
+    char iface[IF_NAMESIZE];
+    char buf[4096];
+    FILE *file;
+
+    memset(iface, 0, sizeof(iface));
+    memset(buf, 0, sizeof(buf));
+
+    file = fopen("/proc/net/route", "r");
+    if (!file)
+    {
+        return -1;
+    }
+
+    while (fgets(buf, sizeof(buf), file))
+    {
+        if (sscanf(buf, "%s %lx %lx", iface, &dest, &gateway) == 3)
+        {
+            // default route
+            if (dest == 0)
+            {
+                // note > gateway variable contains the address of the gateway
+                strcpy(interface, iface);
+                fclose(file);
+                return 0;
+            }
+        }
+    }
+
+    // default route not found
+    if (file)
+    {
+        fclose(file);
+    }
+    return -1;
+}
 
 static error_t parse_cli(int key, char *arg, struct argp_state *state)
 {
@@ -148,45 +190,6 @@ static const struct argp argp = {
     .args_doc = "PROGRAM",
     .doc = argp_program_doc,
 };
-
-int get_gateway_iface(char *interface)
-{
-    long dest, gateway;
-    char iface[IF_NAMESIZE];
-    char buf[4096];
-    FILE *file;
-
-    memset(iface, 0, sizeof(iface));
-    memset(buf, 0, sizeof(buf));
-
-    file = fopen("/proc/net/route", "r");
-    if (!file)
-    {
-        return -1;
-    }
-
-    while (fgets(buf, sizeof(buf), file))
-    {
-        if (sscanf(buf, "%s %lx %lx", iface, &dest, &gateway) == 3)
-        {
-            // default route
-            if (dest == 0)
-            {
-                // note > gateway variable contains the address of the gateway
-                strcpy(interface, iface);
-                fclose(file);
-                return 0;
-            }
-        }
-    }
-
-    // default route not found
-    if (file)
-    {
-        fclose(file);
-    }
-    return -1;
-}
 
 static volatile sig_atomic_t g_stop;
 


### PR DESCRIPTION
## Description

GCC 14+ defaults to `-Werror=implicit-function-declaration`, breaking the build.

**traffico.c:**
- Add missing `<string.h>`, `<strings.h>` (`strcasecmp`, `strncasecmp`), `<unistd.h>` (`sleep`)
- Move `get_gateway_iface` definition above `parse_cli` to eliminate forward declaration

**traffico-cni.c:**
- Add missing `<string.h>` and `<strings.h>`
- Fix `char *buffer[BUFFERSIZE]` → `char buffer[BUFFERSIZE]` (was array of pointers, not chars)
- Fix `config.program == NULL` → `config.program == program_0` (enum, not pointer)
- Explicitly initialize `.program = program_0` in struct initializer
- Replace `strcat`/`realloc` loop in `get_stdin` with `getdelim` — the old pattern was O(n²), leaked on `realloc` failure, and `strcat` had no destination size awareness
- Set `*text = NULL` after `free` on `get_stdin` error path to prevent dangling pointer
- Fix `strncpy` with source length → `snprintf` with `IF_NAMESIZE` to prevent buffer overflow
- Fix `"Unknwon"` → `"Unknown"` typo
- Remove duplicate `config.verbose = false`

## How to test

```bash
xmake clean -a && xmake build -y
# Should produce zero warnings from traffico.c and traffico-cni.c
```