### PR TITLE
fix(devcontainer): add cmake to system packages

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/archlinux:latest
 
 RUN pacman -Syy --noconfirm
-RUN pacman -S --noconfirm nodejs clang llvm gcc linux-headers bpf unzip docker vi vim
+RUN pacman -S --noconfirm nodejs clang llvm gcc linux-headers bpf unzip docker vi vim cmake
 
 RUN pacman -S --noconfirm --needed git base-devel
 


### PR DESCRIPTION
## Description

Add `cmake` to the devcontainer's pacman install line. Without it, `xmake build -y` fails when installing the `cjson` dependency (cJSON uses cmake as its build system).

## How to test

Rebuild the devcontainer, then:

```bash
xmake clean -a && xmake f --generate-vmlinux=y && xmake build -y
```

Should complete without `cmake not found!` errors.