### PR TITLE
build: bump minimum xmake to 2.9.2, migrate to `build.fence`, bump libbpf to v1.5.0

### DIFF
--- a/api/xmake.lua
+++ b/api/xmake.lua
@@ -1,5 +1,5 @@
 
-set_xmakever("2.6.1") -- Minimum version to compile BPF source correctly
+set_xmakever("2.9.2") -- Minimum version for build.fence policy and BPF source compilation
 
 -- includes
 includes("../xmake/repos.lua")

--- a/bpf/xmake.lua
+++ b/bpf/xmake.lua
@@ -1,4 +1,4 @@
-set_xmakever("2.6.1") -- Minimum version to compile BPF source correctly
+set_xmakever("2.9.2") -- Minimum version for build.fence policy and BPF source compilation
 
 -- includes
 includes("../xmake/repos.lua")
@@ -66,7 +66,7 @@ add_requires("libbpf v0.8.0", { system = false })
 -- probe
 target("bpf")
     set_kind("object")
-    set_policy("build.across_targets_in_parallel", false)
+    set_policy("build.fence", true)
     includes("../tools")
     add_deps("bpftool")
     includes("../vmlinux")

--- a/bpf/xmake.lua
+++ b/bpf/xmake.lua
@@ -61,7 +61,7 @@ set_toolchains("@llvm")
 
 -- requirements
 add_requires("linux-headers")
-add_requires("libbpf v0.8.0", { system = false })
+add_requires("libbpf v1.5.0", { system = false })
 
 -- probe
 target("bpf")

--- a/tools/xmake.lua
+++ b/tools/xmake.lua
@@ -1,4 +1,4 @@
-set_xmakever("2.6.1") -- Minimum version to compile BPF source correctly
+set_xmakever("2.9.2") -- Minimum version for build.fence policy and BPF source compilation
 
 -- options
 option("require-bpftool", {showmenu = true, default = false, description = "require bpftool package"})

--- a/vmlinux/xmake.lua
+++ b/vmlinux/xmake.lua
@@ -1,4 +1,4 @@
-set_xmakever("2.6.1") -- Minimum version to compile BPF source correctly
+set_xmakever("2.9.2") -- Minimum version for build.fence policy and BPF source compilation
 
 -- options
 --- run `xmake f --generate-vmlinux=y` to always generate vmlinux.h rather than assuming one exists in vmlinux/

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,4 +1,4 @@
-set_xmakever("2.6.1") -- Minimum version to compile BPF source correctly
+set_xmakever("2.9.2") -- Minimum version for build.fence policy and BPF source compilation
 
 -- includes
 includes("xmake/repos.lua")


### PR DESCRIPTION
## Description

Replace deprecated `build.across_targets_in_parallel` policy with `build.fence` (logic inverted: `false` → `true`). The old policy name produces a deprecation warning on every build with xmake 3.0+.

Bump `set_xmakever` from `2.6.1` to `2.9.2` across all 5 xmake.lua files, since `build.fence` was introduced in xmake 2.9.2.

Bump libbpf from v0.8.0 to v1.5.0. The old version cannot parse `BTF_KIND:19` (`TYPE_TAG`, kernel 5.17+) and `BTF_KIND:21` (`ENUM64`, kernel 6.0+), causing BPF program loading to fail on modern kernels. This fixes the `block_private_ipv4` tests.

Supersedes #18 (auto-closed when #17's base branch was deleted on merge).

## Related Issue(s)

Refs #13, #14

## How to test

```bash
xmake clean -a && xmake f --generate-vmlinux=y && xmake build -y
# Should produce no deprecation warning about build.across_targets_in_parallel

xmake run test
# All 14 BATS tests should pass (block_private_ipv4 was failing with libbpf v0.8.0)
```"