### PR TITLE
ci: add GitHub Actions workflow for build and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
             curl iproute2 iputils-ping
 
       - name: Install xmake
-        uses: xmake-io/github-action-setup-xmake@19d5bff7e8a05604925c02f20307db87adb5665b # v1.0.13
-        with:
-          xmake-version: "3.0.8"
+        run: |
+          curl -fsSL https://xmake.io/shget.text | bash
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Configure
         run: xmake f -y --generate-vmlinux=y --require-bpftool=y
@@ -50,7 +50,7 @@ jobs:
           pacman -Syy --noconfirm
           pacman -S --noconfirm \
             clang llvm gcc linux-headers bpf \
-            make cmake xmake \
+            make cmake xmake sudo \
             curl iproute2 iputils
 
       - name: Configure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           pacman -Syy --noconfirm
           pacman -S --noconfirm \
             clang llvm gcc linux-headers bpf \
-            make cmake xmake sudo \
+            make cmake xmake sudo diffutils \
             curl iproute2 iputils
 
       - name: Configure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ubuntu:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq \
+            clang llvm gcc \
+            linux-headers-$(uname -r) \
+            libelf-dev zlib1g-dev \
+            curl iproute2 iputils-ping
+
+      - name: Install xmake
+        uses: xmake-io/github-action-setup-xmake@19d5bff7e8a05604925c02f20307db87adb5665b # v1.0.13
+        with:
+          xmake-version: "3.0.8"
+
+      - name: Configure
+        run: xmake f -y --generate-vmlinux=y --require-bpftool=y
+
+      - name: Build
+        run: xmake build -y
+
+      - name: Test
+        run: xmake run test
+
+  archlinux:
+    runs-on: ubuntu-24.04
+    container:
+      image: archlinux:latest
+      options: --privileged
+    env:
+      XMAKE_ROOT: "y"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install system dependencies
+        run: |
+          pacman -Syy --noconfirm
+          pacman -S --noconfirm \
+            clang llvm gcc linux-headers bpf \
+            make cmake xmake \
+            curl iproute2 iputils
+
+      - name: Configure
+        run: xmake f -y --generate-vmlinux=y
+
+      - name: Build
+        run: xmake build -y
+
+      - name: Test
+        run: xmake run test


### PR DESCRIPTION
## Description

Add a CI workflow that builds and runs the full BATS test suite on every push to `main` and on pull requests.

Runs on `ubuntu-24.04` (kernel 6.17 with BTF support). Installs system dependencies (clang, llvm, gcc, linux-headers), sets up xmake, then builds with `--generate-vmlinux=y` and `--require-bpftool=y` (Ubuntu azure kernel packages don't ship bpftool), and runs all 14 tests.

Tests require root for network namespaces and BPF program loading — the xmake test target handles privilege escalation internally via `privilege.sudo`.

### Known issue

Test 9 (`cli: missing program`) fails on Ubuntu — it expects exit code 64 but gets a different value. This is a pre-existing test issue (likely `argp` behavior difference between Arch and Ubuntu), not a CI regression. 13/14 tests pass including both `block_private_ipv4` tests.

## How to test

Push to this branch or open a PR against `main` — the workflow triggers automatically.