### PR TITLE
fix: argp error exit code portability, bump bats

### DIFF
--- a/test/cli.bats
+++ b/test/cli.bats
@@ -49,9 +49,8 @@ teardown() {
     run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
     [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
     echo "# tc qdisc still there" >&3
-    run bpftool prog show name nop
-    OUT=${lines[0]##*: } >&3
-    [ "${OUT%%  *}" == "sched_cls" ]
+    run bpftool prog show --json name nop
+    [[ "$output" == *'"type":"sched_cls"'* ]]
     echo "# BPF program still there" >&3
     run ip netns exec "${NETNS}" tc qdisc del dev "${PEER}" clsact
 }

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -19,48 +19,48 @@ bats_require_minimum_version 1.7.0
 @test "invalid option" {
     run traffico -x
     [ ! $status -eq 0 ]
-    [ $status -eq 64 ]
+    [ $status -eq 1 ]
     [ "${lines[0]##*: }" == "invalid option -- 'x'" ]
 }
 
 @test "unrecognized option" {
     run traffico --xxxx
     [ ! $status -eq 0 ]
-    [ $status -eq 64 ]
+    [ $status -eq 1 ]
     [ "${lines[0]##*: }" == "unrecognized option '--xxxx'" ]
 }
 
 @test "missing program" {
     run traffico
     [ ! $status -eq 0 ]
-    [ $status -eq 64 ]
+    [ $status -eq 1 ]
     [ "${lines[0]}" == 'traffico: program name is mandatory' ]
 }
 
 @test "unavailable program" {
     run traffico xxx
     [ ! $status -eq 0 ]
-    [ $status -eq 64 ]
+    [ $status -eq 1 ]
     [ "${lines[0]}" == "traffico: argument 'xxx' is not a traffico program" ]
 }
 
 @test "unavailable network interface" {
     run traffico -i ciao
     [ ! $status -eq 0 ]
-    [ $status -eq 64 ]
+    [ $status -eq 1 ]
     [ "${lines[0]}" == "traffico: option '--ifname' requires an existing interface: got 'ciao'" ]
 }
 
 @test "unavailable network interface (long)" {
     run traffico --ifname ciao
     [ ! $status -eq 0 ]
-    [ $status -eq 64 ]
+    [ $status -eq 1 ]
     [ "${lines[0]}" == "traffico: option '--ifname' requires an existing interface: got 'ciao'" ]
 }
 
 @test "unsupported attach point" {
     run traffico --at wrong
     [ ! $status -eq 0 ]
-    [ $status -eq 64 ]
+    [ $status -eq 1 ]
     [ "${lines[0]}" == "traffico: option '--at' requires one of the following values: INGRESS|EGRESS" ]
 }

--- a/traffico.c
+++ b/traffico.c
@@ -13,6 +13,9 @@
 
 const char *argp_program_version = TOOL_NAME " 0.0";
 const char *argp_program_bug_address = "https://github.com/leodido/traffico/issues";
+// Visibility attribute needed to override glibc's weak symbol
+// when built with -fvisibility=hidden.
+__attribute__((visibility("default")))
 error_t argp_err_exit_status = 1;
 const char argp_program_doc[] =
     "\n"
@@ -155,8 +158,7 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
     case ARGP_KEY_END:
         if (state->arg_num == 0)
         {
-            print_log(state->err_stream, true, true, "program name is mandatory\n\n", NULL);
-            argp_state_help(state, state->err_stream, ARGP_HELP_STD_HELP | ARGP_HELP_EXIT_ERR);
+            argp_error(state, "program name is mandatory");
         }
         if (g_config.program == program_0)
         {
@@ -223,7 +225,7 @@ int main(int argc, char **argv)
     char buf[100];
     buf[sizeof(buf) - 1] = '\0';
 
-    // CLI
+    argp_err_exit_status = 1;
     err = argp_parse(&argp, argc, argv, ARGP_IN_ORDER, NULL, NULL);
     if (err)
     {

--- a/xmake.lua
+++ b/xmake.lua
@@ -30,7 +30,7 @@ target("traffico-cni")
 target_end()
 
 -- test
-add_requires("bats v1.7.0", { system = false })
+add_requires("bats v1.11.1", { system = false })
 add_requires("mini_httpd", { system = false })
 target("test")
     set_kind("phony")


### PR DESCRIPTION
## Description

### argp exit code fix (`traffico.c`)

`traffico` was exiting with inconsistent codes on argument errors across platforms. Three issues:

1. **`argp_err_exit_status = 1` never took effect.** xmake builds with `-fvisibility=hidden`, hiding the symbol from the dynamic linker. glibc's own copy (default: 64) was used instead. Fixed by adding `__attribute__((visibility(\"default\")))` and a runtime assignment in `main()` as fallback for glibc versions where the attribute alone doesn't work.

2. **`argp_state_help()` called `exit(0)` instead of `exit(1)`.** The \"missing program\" handler used `ARGP_HELP_STD_HELP | ARGP_HELP_EXIT_ERR`, but `ARGP_HELP_STD_HELP` includes `ARGP_HELP_EXIT_OK` which silently wins on some glibc versions. Replaced with `argp_error()` — the standard function for reporting errors from argp parsers.

3. **bpftool text output parsing was fragile.** The `--no-cleanup` test parsed `bpftool prog show` plain text, which varies across bpftool versions. Switched to `--json` output.

### bats bump (`xmake.lua`)

Bump bats from v1.7.0 to v1.11.1.

### Test changes (`test/cli.flags.bats`, `test/cli.bats`)

All 7 exit code assertions updated from 64 to 1. The `--no-cleanup` test now uses `bpftool --json`.

## How to test

```bash
xmake build -y

# Verify exit code
./build/linux/x86_64/release/traffico 2>/dev/null; echo $?
# Should print: 1

xmake run test
# All 14 tests should pass
```