### PR TITLE
chore: misc improvements (debug docs, libbpf logging, devcontainer, build paths)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,9 @@
 FROM docker.io/archlinux:latest
 
 RUN pacman -Syy --noconfirm
-RUN pacman -S --noconfirm nodejs clang llvm gcc linux-headers bpf unzip docker vi vim cmake
+RUN pacman -S --noconfirm nodejs clang llvm gcc linux-headers bpf unzip docker vi vim cmake gdb tree
 
 RUN pacman -S --noconfirm --needed git base-devel
-
-
 
 # user setup
 WORKDIR /tmp

--- a/README.txt
+++ b/README.txt
@@ -127,6 +127,14 @@ BUILD
 
     xmake -b bpf
 
+    In case you want to compile in debug mode:
+
+    xmake f -m debug
+
+    You will be able to read from the trace_pipe the logs of the BPF programs
+    and you will obtain the logs of libbpf into the stderr only if you compile
+    in debug mode.
+
 TEST
 
     To run the test suite you can do this:

--- a/api/api.$progname.h.in
+++ b/api/api.$progname.h.in
@@ -1,6 +1,8 @@
 #include "${PROGNAME}.skel.h"
 
-int ${OPERATION}${PROGNAME}(struct config *conf, after_attach_fn_t cb, bpf_obj_fn_t obj_cb)
+#define ${PROGNAME}_has_rodata ${PROGNAME_WITH_RODATA}
+
+int ${OPERATION}${PROGNAME}(struct config *conf, after_attach_fn_t cb, const void* rodata)
 {
     int err;
     char buf[100];
@@ -15,14 +17,28 @@ int ${OPERATION}${PROGNAME}(struct config *conf, after_attach_fn_t cb, bpf_obj_f
         return 1;
     }
 
-    if (obj_cb) {
-        err = obj_cb(obj);
-        if (err)
-        {
-            fprintf(stderr, "traffico: fail calling obj callback\n");
-            goto destroy_${PROGNAME};
-        }
+    // Set read-only data
+#if ${PROGNAME}_has_rodata
+    struct bpf_map *m = bpf_object__find_map_by_name(obj->obj, ".rodata");
+    if (!m || !bpf_map__is_internal(m))
+    {
+        log_err(conf, "fail: finding the .rodata map\n");
+        return 1;
     }
+    const char *m_name = bpf_map__name(m);
+    size_t m_size = bpf_map__value_size(m);
+    log_out(conf, "done: finding the %s map (size %d)\n", m_name, m_size);
+    err = bpf_map__set_initial_value(m, rodata, m_size);
+    if (err)
+    {
+        free(m);
+        log_err(conf, "fail: setting the %s map\n", m_name);
+        return 1;
+    }
+    log_out(conf, "done: setting the %s map\n", m_name);
+#else
+    log_out(conf, "done: moving on: no .rodata map\n");
+#endif
 
     err = ${PROGNAME}_bpf__load(obj);
     if (err)

--- a/api/api.h.in
+++ b/api/api.h.in
@@ -31,11 +31,9 @@ struct config
     FILE *out_stream;
 };
 
-typedef int (*bpf_obj_fn_t)(void *obj);
-
 typedef int (*after_attach_fn_t)(struct bpf_tc_hook hook, struct bpf_tc_opts opts);
 
-typedef int (*attach_fn_t)(struct config *conf, after_attach_fn_t cb, bpf_obj_fn_t obj_cb);
+typedef int (*attach_fn_t)(struct config *conf, after_attach_fn_t cb, const void* rodata);
 
 /// logging
 int print_log(FILE *f, bool verbosity, bool prefix, const char *fmt, va_list argptr)
@@ -78,7 +76,7 @@ int exit_after_attach(struct bpf_tc_hook hook, struct bpf_tc_opts opts)
 }
 
 /// non-existing programs
-int ${OPERATION}0(struct config *conf, after_attach_fn_t cb, bpf_obj_fn_t obj_cb)
+int ${OPERATION}0(struct config *conf, after_attach_fn_t cb, const void *rodata)
 {
     return 1;
 }
@@ -88,15 +86,13 @@ ${API}
 /// dispatch
 attach_fn_t attach_fn[NUM_PROGRAMS] = { ${PROGRAMS_OPS_AS_SYMBOLS} };
 
-int attach(struct config *conf, after_attach_fn_t cb, bpf_obj_fn_t obj_cb)
+int attach(struct config *conf, after_attach_fn_t cb, const void* rodata)
 {
     attach_fn_t fn = attach_fn[conf->program];
     if (fn) {
-        return fn(conf, cb, obj_cb);
+        return fn(conf, cb, rodata);
     }
-    return ${OPERATION}0(conf, cb, obj_cb);
+    return ${OPERATION}0(conf, cb, NULL);
 }
-
-
 
 #endif // TRAFFICO_API_H

--- a/api/xmake.lua
+++ b/api/xmake.lua
@@ -8,7 +8,7 @@ includes("../xmake/repos.lua")
 add_rules("mode.release", "mode.debug")
 
 -- target to generate API components for every BPF program
-target("every.api")
+target("every-api")
     set_kind("headeronly")
     includes("../bpf")
     add_deps("bpf")
@@ -23,10 +23,10 @@ target("every.api")
 -- target to generate the API
 target("api")
     set_kind("headeronly")
-    add_deps("every.api")
+    add_deps("every-api")
     on_config(function(target)
         import("xmake.modules.api", { rootdir = os.projectdir() })
-        api(target, "every.api", true)
+        api(target, "every-api", true)
 
         import("actions.config.configfiles", { alias = "gen_configfiles", rootdir = os.programdir() })
         gen_configfiles()

--- a/bpf/block_ip.bpf.c
+++ b/bpf/block_ip.bpf.c
@@ -5,7 +5,6 @@
 
 char LICENSE[] SEC("license") = "Dual BSD/GPL";
 
-// TODO > make this easy to configure via config struct
 const volatile __u32 input = 0; // address to block (host byte order)
 
 SEC("tc")

--- a/bpf/block_port.bpf.c
+++ b/bpf/block_port.bpf.c
@@ -5,8 +5,7 @@
 
 char LICENSE[] SEC("license") = "Dual BSD/GPL";
 
-// TODO > make this easy to configure via config struct
-const volatile __u32 input = 0;
+const volatile __u16 input = 0; // port to block
 
 SEC("tc")
 int block_port(struct __sk_buff *skb)

--- a/bpf/block_private_ipv4.bpf.c
+++ b/bpf/block_private_ipv4.bpf.c
@@ -53,7 +53,7 @@ int block_private_ipv4(struct __sk_buff *skb)
 
     struct iphdr *ip_header = data + l3_offset;
     const int l4_offset = l3_offset + sizeof(*ip_header);
-    
+
     if (data + l4_offset > data_end)
     {
         bpf_printk("classifier: [iph] size lenght check hit: continue");

--- a/bpf/xmake.lua
+++ b/bpf/xmake.lua
@@ -8,7 +8,7 @@ rule("bpf")
     set_extensions(".bpf.c")
     on_config(function (target)
         assert(is_host("linux"), 'rule("bpf"): only supported on linux!')
-        local headerdir = path.join(target:autogendir(), "rules", "bpf")
+        local headerdir = path.join(target:autogendir())
         if not os.isdir(headerdir) then
             os.mkdir(headerdir)
         end
@@ -22,8 +22,8 @@ rule("bpf")
             bpftool = filecfg.bpftool
         end
 
-        local headerfile = path.join(target:autogendir(), "rules", "bpf", (path.filename(sourcefile):gsub("%.bpf%.c", ".skel.h")))
-        local objectfile = path.join(target:autogendir(), "rules", "bpf", (path.filename(sourcefile):gsub("%.bpf%.c", ".bpf.o")))
+        local headerfile = path.join(target:autogendir(), (path.filename(sourcefile):gsub("%.bpf%.c", ".skel.h")))
+        local objectfile = path.join(target:autogendir(), (path.filename(sourcefile):gsub("%.bpf%.c", ".bpf.o")))
         local targetarch
         if target:is_arch("x86_64", "i386") then
             targetarch = "__TARGET_ARCH_x86"

--- a/traffico.c
+++ b/traffico.c
@@ -202,7 +202,11 @@ void sig_handler(int signo)
 
 static int libbpf_print_fn(enum libbpf_print_level level, const char *format, va_list args)
 {
+#ifndef NDEBUG
     return print_log(g_config.err_stream, level == LIBBPF_DEBUG && g_config.verbose, false, format, args);
+#else
+    return 0;
+#endif
 }
 
 int await(struct bpf_tc_hook hook, struct bpf_tc_opts opts)

--- a/traffico.c
+++ b/traffico.c
@@ -249,5 +249,8 @@ int main(int argc, char **argv)
 
     // Execute
     log_info("prog: %s\n", g_programs_name[g_config.program]);
-    return attach(&g_config, &await, NULL);
+    __u32 input = 16843010;
+    __u8 *val = malloc(4);
+    memcpy(val, &input, 4); // memset(val, 1, 4);
+    return attach(&g_config, &await, val);
 }


### PR DESCRIPTION
Miscellaneous improvements split out from PR #6 to keep that PR focused on rodata injection.

## Commits

1. **`docs: insert instructions about the debug build`** — add debug build instructions to README.txt
2. **`update: output libbpf logs only in debug mode`** — gate libbpf log output behind `NDEBUG` preprocessor flag
3. **`new(.devcontainer): install gdb and tree`** — add debugging tools to devcontainer
4. **`build: simplify the output path for BPF artifacts`** — clean up skeleton output paths in xmake config
5. **`SAVEPOINT: 2022-06-07 @ 15:33:40`** — snapshot of WIP state from original development

Note: commit 2 silences all libbpf output (including warnings/errors) in release builds. This may warrant a follow-up to only suppress `LIBBPF_DEBUG` level while keeping `LIBBPF_WARN` and `LIBBPF_INFO`."