### PR TITLE
chore: misc improvements (debug docs, libbpf logging, devcontainer, build paths)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,9 @@
 FROM docker.io/archlinux:latest
 
 RUN pacman -Syy --noconfirm
-RUN pacman -S --noconfirm nodejs clang llvm gcc linux-headers bpf unzip docker vi vim cmake
+RUN pacman -S --noconfirm nodejs clang llvm gcc linux-headers bpf unzip docker vi vim cmake gdb tree
 
 RUN pacman -S --noconfirm --needed git base-devel
-
-
 
 # user setup
 WORKDIR /tmp

--- a/README.txt
+++ b/README.txt
@@ -127,6 +127,14 @@ BUILD
 
     xmake -b bpf
 
+    In case you want to compile in debug mode:
+
+    xmake f -m debug
+
+    You will be able to read from the trace_pipe the logs of the BPF programs
+    and you will obtain the logs of libbpf into the stderr only if you compile
+    in debug mode.
+
 TEST
 
     To run the test suite you can do this:

--- a/bpf/block_ip.bpf.c
+++ b/bpf/block_ip.bpf.c
@@ -5,7 +5,6 @@
 
 char LICENSE[] SEC("license") = "Dual BSD/GPL";
 
-// TODO > make this easy to configure via config struct
 const volatile __u32 input = 0; // address to block (host byte order)
 
 SEC("tc")

--- a/bpf/block_port.bpf.c
+++ b/bpf/block_port.bpf.c
@@ -5,8 +5,7 @@
 
 char LICENSE[] SEC("license") = "Dual BSD/GPL";
 
-// TODO > make this easy to configure via config struct
-const volatile __u32 input = 0;
+const volatile __u16 input = 0; // port to block
 
 SEC("tc")
 int block_port(struct __sk_buff *skb)

--- a/bpf/block_private_ipv4.bpf.c
+++ b/bpf/block_private_ipv4.bpf.c
@@ -53,7 +53,7 @@ int block_private_ipv4(struct __sk_buff *skb)
 
     struct iphdr *ip_header = data + l3_offset;
     const int l4_offset = l3_offset + sizeof(*ip_header);
-    
+
     if (data + l4_offset > data_end)
     {
         bpf_printk("classifier: [iph] size lenght check hit: continue");

--- a/bpf/xmake.lua
+++ b/bpf/xmake.lua
@@ -8,7 +8,7 @@ rule("bpf")
     set_extensions(".bpf.c")
     on_config(function (target)
         assert(is_host("linux"), 'rule("bpf"): only supported on linux!')
-        local headerdir = path.join(target:autogendir(), "rules", "bpf")
+        local headerdir = path.join(target:autogendir())
         if not os.isdir(headerdir) then
             os.mkdir(headerdir)
         end
@@ -22,8 +22,8 @@ rule("bpf")
             bpftool = filecfg.bpftool
         end
 
-        local headerfile = path.join(target:autogendir(), "rules", "bpf", (path.filename(sourcefile):gsub("%.bpf%.c", ".skel.h")))
-        local objectfile = path.join(target:autogendir(), "rules", "bpf", (path.filename(sourcefile):gsub("%.bpf%.c", ".bpf.o")))
+        local headerfile = path.join(target:autogendir(), (path.filename(sourcefile):gsub("%.bpf%.c", ".skel.h")))
+        local objectfile = path.join(target:autogendir(), (path.filename(sourcefile):gsub("%.bpf%.c", ".bpf.o")))
         local targetarch
         if target:is_arch("x86_64", "i386") then
             targetarch = "__TARGET_ARCH_x86"

--- a/traffico.c
+++ b/traffico.c
@@ -202,6 +202,11 @@ void sig_handler(int signo)
 
 static int libbpf_print_fn(enum libbpf_print_level level, const char *format, va_list args)
 {
+#ifdef NDEBUG
+    // In release builds, only suppress debug-level verbosity
+    if (level == LIBBPF_DEBUG)
+        return 0;
+#endif
     return print_log(g_config.err_stream, level == LIBBPF_DEBUG && g_config.verbose, false, format, args);
 }
 


### PR DESCRIPTION
Miscellaneous improvements split out from PR #6.

## Commits

1. **`docs: insert instructions about the debug build`** — add debug build instructions to README.txt
2. **`build: suppress libbpf debug output in release mode`** — suppress `LIBBPF_DEBUG` messages in release builds while keeping `LIBBPF_WARN` and `LIBBPF_INFO` for diagnostics
3. **`new(.devcontainer): install gdb and tree`** — add debugging tools to devcontainer
4. **`build: simplify the output path for BPF artifacts`** — clean up skeleton output paths in xmake config