### PR TITLE
docs: document rodata offset-0 assumption and port 0 rejection

### DIFF
--- a/api/api.$progname.h.in
+++ b/api/api.$progname.h.in
@@ -15,7 +15,10 @@ int ${OPERATION}${PROGNAME}(struct config *conf, after_attach_fn_t cb)
         return 1;
     }
 
-    // Set read-only data (between open and load)
+    // Set read-only data (between open and load).
+    // Assumes each BPF program has exactly one const volatile global
+    // at offset 0 in .rodata. If a program adds more globals, this
+    // memcpy must account for their offsets.
 #if ${PROGNAME_WITH_RODATA}
     if (conf->has_input)
     {

--- a/api/input_parse.h
+++ b/api/input_parse.h
@@ -28,6 +28,8 @@ static int parse_input(struct config *conf, const char *input_str, const char **
     {
         char *endptr;
         unsigned long port = strtoul(input_str, &endptr, 10);
+        // Port 0 is rejected: the BPF rodata default is 0, so allowing it
+        // would be indistinguishable from "no input provided".
         if (*endptr != '\0' || port == 0 || port > 65535)
         {
             *err_msg = "invalid port number";


### PR DESCRIPTION
Two inline comments from the PR #6 review:

- **`api/api.$progname.h.in`**: Documents that the `memcpy` at offset 0 assumes each BPF program has exactly one `const volatile` global in `.rodata`.
- **`api/input_parse.h`**: Explains why port 0 is rejected — the BPF rodata default is `0`, making it indistinguishable from "no input provided".