### PR TITLE
fix(bpf): correct 192.168.0.0/16 netmask

### DIFF
--- a/bpf/block_private_ipv4.bpf.c
+++ b/bpf/block_private_ipv4.bpf.c
@@ -25,7 +25,7 @@ static struct subnet blocked_subnets[] = {
     //  192.168.0.0/16
     {
         .subnet = 0xC0A80000,  // 192.168.0.0
-        .netmask = 0xFFF00000, // 255.240.0.0
+        .netmask = 0xFFFF0000, // 255.255.0.0
     },
 };
 


### PR DESCRIPTION
The `192.168.0.0/16` subnet entry in `block_private_ipv4` had netmask `0xFFF00000` (`/12`), which matched `192.160.0.0–192.175.255.255` instead of `192.168.0.0–192.168.255.255`.

Fixed to `0xFFFF0000` (`/16`).