### PR TITLE
fix(bpf): typo 'lenght' -> 'length' in debug messages

### DIFF
--- a/bpf/block_ip.bpf.c
+++ b/bpf/block_ip.bpf.c
@@ -18,7 +18,7 @@ int block_ip(struct __sk_buff *skb)
 
     if (data + l3_offset > data_end)
     {
-        bpf_printk("block_ip: [eth] size lenght check hit: continue");
+        bpf_printk("block_ip: [eth] size length check hit: continue");
         return TC_ACT_OK;
     }
 
@@ -32,7 +32,7 @@ int block_ip(struct __sk_buff *skb)
     const int l4_offset = l3_offset + sizeof(*ip_header);
     if (data + l4_offset > data_end)
     {
-        bpf_printk("block_ip: [iph] size lenght check hit: continue");
+        bpf_printk("block_ip: [iph] size length check hit: continue");
         return TC_ACT_OK;
     }
 

--- a/bpf/block_private_ipv4.bpf.c
+++ b/bpf/block_private_ipv4.bpf.c
@@ -41,7 +41,7 @@ int block_private_ipv4(struct __sk_buff *skb)
 
     if (data + l3_offset > data_end)
     {
-        bpf_printk("classifier: [eth] size lenght check hit: continue");
+        bpf_printk("classifier: [eth] size length check hit: continue");
         return TC_ACT_OK;
     }
 
@@ -56,7 +56,7 @@ int block_private_ipv4(struct __sk_buff *skb)
 
     if (data + l4_offset > data_end)
     {
-        bpf_printk("classifier: [iph] size lenght check hit: continue");
+        bpf_printk("classifier: [iph] size length check hit: continue");
         return TC_ACT_OK;
     }
 
@@ -77,7 +77,7 @@ int block_private_ipv4(struct __sk_buff *skb)
 
     if (data + l7_offset > data_end)
     {
-        bpf_printk("classifier: [tcph] size lenght check hit: continue");
+        bpf_printk("classifier: [tcph] size length check hit: continue");
         return TC_ACT_OK;
     }
 


### PR DESCRIPTION
Fixes "lenght" → "length" in 5 `bpf_printk` messages across `block_ip.bpf.c` and `block_private_ipv4.bpf.c`.