### PR TITLE
feat(bpf): implement `block_port` and add tests

### DIFF
--- a/bpf/block_port.bpf.c
+++ b/bpf/block_port.bpf.c
@@ -43,7 +43,7 @@ int block_port(struct __sk_buff *skb)
         return TC_ACT_OK;
     }
 
-    // Only inspect TCP and UDP — both have dest port at the same offset
+    // Only inspect TCP and UDP (both have dest port at the same offset)
     if (ip_header->protocol != IPPROTO_TCP && ip_header->protocol != IPPROTO_UDP)
     {
         bpf_printk("block_port: [iph] protocol %d is not TCP/UDP: continue", ip_header->protocol);

--- a/bpf/block_port.bpf.c
+++ b/bpf/block_port.bpf.c
@@ -5,7 +5,7 @@
 
 char LICENSE[] SEC("license") = "Dual BSD/GPL";
 
-const volatile __u16 input = 0; // port to block (host byte order)
+const volatile __u16 input = 0; // destination port to block (host byte order)
 
 SEC("tc")
 int block_port(struct __sk_buff *skb)

--- a/bpf/block_port.bpf.c
+++ b/bpf/block_port.bpf.c
@@ -5,12 +5,66 @@
 
 char LICENSE[] SEC("license") = "Dual BSD/GPL";
 
-const volatile __u16 input = 0; // port to block
+const volatile __u16 input = 0; // port to block (host byte order)
 
 SEC("tc")
 int block_port(struct __sk_buff *skb)
 {
-    bpf_printk("TBD");
+    void *data_end = (void *)(unsigned long long)skb->data_end;
+    void *data = (void *)(unsigned long long)skb->data;
+
+    struct ethhdr *eth = data;
+    const int l3_offset = sizeof(*eth);
+
+    if (data + l3_offset > data_end)
+    {
+        bpf_printk("block_port: [eth] size length check hit: continue");
+        return TC_ACT_OK;
+    }
+
+    if (eth->h_proto != bpf_htons(ETH_P_IP))
+    {
+        bpf_printk("block_port: [eth] protocol is %d: continue", eth->h_proto);
+        return TC_ACT_OK;
+    }
+
+    struct iphdr *ip_header = data + l3_offset;
+    const int l4_offset = l3_offset + sizeof(*ip_header);
+
+    if (data + l4_offset > data_end)
+    {
+        bpf_printk("block_port: [iph] size length check hit: continue");
+        return TC_ACT_OK;
+    }
+
+    if (ip_is_fragment(skb, l3_offset))
+    {
+        bpf_printk("block_port: [iph] is fragment: continue");
+        return TC_ACT_OK;
+    }
+
+    // Only inspect TCP and UDP — both have dest port at the same offset
+    if (ip_header->protocol != IPPROTO_TCP && ip_header->protocol != IPPROTO_UDP)
+    {
+        bpf_printk("block_port: [iph] protocol %d is not TCP/UDP: continue", ip_header->protocol);
+        return TC_ACT_OK;
+    }
+
+    // Both TCP and UDP headers start with src_port (u16) then dst_port (u16)
+    if (data + l4_offset + 4 > data_end)
+    {
+        bpf_printk("block_port: [l4] size length check hit: continue");
+        return TC_ACT_OK;
+    }
+
+    __u16 *dst_port_ptr = (__u16 *)(data + l4_offset + 2);
+    __u16 dst_port = bpf_ntohs(*dst_port_ptr);
+
+    if (dst_port == input)
+    {
+        bpf_printk("block_port: [l4] destination port %d: block", dst_port);
+        return TC_ACT_SHOT;
+    }
 
     return TC_ACT_OK;
 }

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -81,6 +81,21 @@ teardown() {
     del_server
 }
 
+@test "block_port does not block other ports" {
+    new_server
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress block_port 9999 >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can still reach ${VETH_ADDR}:${SERVER_PORT} (blocked port 9999, not ${SERVER_PORT})" >&3
+    del_server
+}
+
 @test "block_private_ipv4 blocks ICMP packets" {
     run ip netns exec "${NETNS}" ping -W1 -4 -c1 10.22.1.2
     [ $status -eq 0 ]

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -19,6 +19,7 @@ teardown() {
     echo "# teardown:" >&3
 
     killall traffico &>/dev/null || true
+    del_server
     del_netdev
     del_netns "${NETNS}"
 }
@@ -78,7 +79,6 @@ teardown() {
     run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
     [ ! $status -eq 0 ]
     echo "# cannot reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
-    del_server
 }
 
 @test "block_port does not block other ports" {
@@ -93,7 +93,6 @@ teardown() {
     run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
     [ $status -eq 0 ]
     echo "# can still reach ${VETH_ADDR}:${SERVER_PORT} (blocked port 9999, not ${SERVER_PORT})" >&3
-    del_server
 }
 
 @test "block_private_ipv4 blocks ICMP packets" {

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -66,6 +66,21 @@ teardown() {
     [ $status -eq 1 ]
 }
 
+@test "block_port blocks specific port" {
+    new_server
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress block_port "${SERVER_PORT}" >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ ! $status -eq 0 ]
+    echo "# cannot reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
+    del_server
+}
+
 @test "block_private_ipv4 blocks ICMP packets" {
     run ip netns exec "${NETNS}" ping -W1 -4 -c1 10.22.1.2
     [ $status -eq 0 ]

--- a/test/cni.bats
+++ b/test/cni.bats
@@ -44,6 +44,25 @@ teardown() {
     echo "# cannot reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
 }
 
+@test "block_port via CNI" {
+    run curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can reach ${VETH_ADDR}:${SERVER_PORT}" >&3
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
+    echo "# installing block_port in the namespace" >&3
+    run ip netns exec "${NETNS}" bash -c "cat '$FIXTURE_ROOT/attach_block_port_in.json' | CNI_COMMAND=ADD traffico-cni"
+    [ $status -eq 0 ]
+    echo "# attach ok" >&3
+    run ip netns exec "${NETNS}" tc qdisc show dev peer0 clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    echo "# qdisc ok" >&3
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ ! $status -eq 0 ]
+    echo "# cannot reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
+}
+
 @test "block_private_ipv4" {
     run curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
     [ $status -eq 0 ]

--- a/test/cni.flags.bats
+++ b/test/cni.flags.bats
@@ -10,3 +10,15 @@ bats_require_minimum_version 1.7.0
     [ ! $status -eq 0 ]
     [[ "$output" == *'"msg":	"program does not accept input"'* ]]
 }
+
+@test "rejects missing input for block_ip" {
+    run bash -c 'echo '"'"'{"cniVersion":"0.4.0","name":"dummy","type":"traffico-cni","program":"block_ip","prevResult":{"cniVersion":"1.0.0","interfaces":[{"name":"lo"}],"ips":[],"routes":[],"dns":{}}}'"'"' | CNI_COMMAND=ADD traffico-cni'
+    [ ! $status -eq 0 ]
+    [[ "$output" == *"program requires an"*"input"*"field"* ]]
+}
+
+@test "rejects missing input for block_port" {
+    run bash -c 'echo '"'"'{"cniVersion":"0.4.0","name":"dummy","type":"traffico-cni","program":"block_port","prevResult":{"cniVersion":"1.0.0","interfaces":[{"name":"lo"}],"ips":[],"routes":[],"dns":{}}}'"'"' | CNI_COMMAND=ADD traffico-cni'
+    [ ! $status -eq 0 ]
+    [[ "$output" == *"program requires an"*"input"*"field"* ]]
+}

--- a/test/fixtures/cni/attach_block_port_in.json
+++ b/test/fixtures/cni/attach_block_port_in.json
@@ -1,0 +1,22 @@
+{
+    "cniVersion": "0.4.0",
+    "name": "dummy-network",
+    "prevResult": {
+        "cniVersion": "1.0.0",
+        "interfaces": [
+            {
+                "name": "peer0"
+            }
+        ],
+        "ips": [
+        ],
+        "routes": [
+        ],
+        "dns": {
+        }
+    },
+    "type": "traffico-cni",
+    "program": "block_port",
+    "input": "8787",
+    "attachPoint": "egress"
+}


### PR DESCRIPTION
Implements the `block_port` BPF program (previously a stub) and adds test coverage.

## block_port

Drops TCP/UDP packets whose destination port matches the runtime input value. Both protocols are handled since they share the same dest-port offset in the L4 header. Non-TCP/UDP protocols and IP fragments pass through.

## Tests (5 new, 29 total)

- **CLI functional**: `block_port` blocks traffic on a specific port in a netns
- **CLI negative**: blocking a different port doesn't affect the server port
- **CNI functional**: `block_port` via JSON config
- **CNI validation**: missing `input` field rejected for `block_ip` and `block_port`

## Known issue

See #35 — all BPF programs use a fixed 20-byte IP header size, which is wrong when IP options are present (IHL > 5). Low priority given IP options are rare on modern networks.