### PR TITLE
docs(bpf): clarify port offset magic number in `block_port`

### DIFF
--- a/bpf/block_port.bpf.c
+++ b/bpf/block_port.bpf.c
@@ -57,7 +57,7 @@ int block_port(struct __sk_buff *skb)
         return TC_ACT_OK;
     }
 
-    __u16 *dst_port_ptr = (__u16 *)(data + l4_offset + 2);
+    __u16 *dst_port_ptr = (__u16 *)(data + l4_offset + 2); // skip 2-byte src_port
     __u16 dst_port = bpf_ntohs(*dst_port_ptr);
 
     if (dst_port == input)


### PR DESCRIPTION
Cherry-pick of #36 which was merged into `feat/block-port-impl` after #34 had already landed on `main`.

Adds an inline comment explaining the `+ 2` offset — it skips the 2-byte source port field shared by TCP and UDP headers.