### PR TITLE
docs: remove "not yet implemented'"notes from `block_port`

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -47,7 +47,7 @@ USAGE
         Programs that accept runtime input (marked [input] in --help) take it
         as a second positional argument:
             traffico --ifname=eth0 block_ip 10.0.0.1
-            traffico --ifname=eth0 block_port 443  (not yet implemented)
+            traffico --ifname=eth0 block_port 443
 
     traffico-cni
         traffico-cni is a meta CNI plugin that allows the traffico programs to be used in CNI.
@@ -118,7 +118,7 @@ BUILT-IN PROGRAMS
         block_ip is a program that drops packets with destination equal to the
         input IPv4 address.
 
-    block_port (not yet implemented)
+    block_port
         block_port is a program that drops packets with the destination port
         equal to the input port number.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,7 +46,7 @@ Programs that accept runtime input (marked `[input]` in `--help`) take it as a s
 
 ```bash
 traffico --ifname=eth0 block_ip 10.0.0.1
-traffico --ifname=eth0 block_port 443  # not yet implemented
+traffico --ifname=eth0 block_port 443
 ```
 
 ### traffico-cni
@@ -121,7 +121,7 @@ Here's an example CNI config file featuring `traffico-cni`.
 |---|---|
 | `block_private_ipv4` | Blocks private IPv4 addresses subnets allowing only SSH access on port 22 |
 | `block_ip` | Drops packets with destination equal to the input IPv4 address |
-| `block_port` | Drops packets with the destination port equal to the input port number (not yet implemented) |
+| `block_port` | Drops packets with the destination port equal to the input port number |
 | `nop` | A simple program that does nothing |
 
 ## Build


### PR DESCRIPTION
## Description

Remove "(not yet implemented)" from `block_port` references in both `README.txt` and `docs/README.md`. `block_port` is implemented in #34.

## How to test

```bash
grep -rn "not yet implemented" README.txt docs/README.md
# Should return nothing
```