### PR TITLE
feat(bpf): implement `allow_port` program

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -116,6 +116,11 @@ BUILT-IN PROGRAMS
         by L2 or chain policy when needed. Localhost (127.0.0.0/8)
         traffic is always allowed.
 
+    allow_port
+        allow_port is a program that drops all TCP/UDP packets except those
+        with destination port equal to the input port number. Non-TCP/UDP
+        protocols (ICMP, etc.) are not affected.
+
     block_private_ipv4
         block_private_ipv4 is a program that can be used to block
         private IPv4 addresses subnets allowing only SSH access on port 22.

--- a/README.txt
+++ b/README.txt
@@ -117,9 +117,9 @@ BUILT-IN PROGRAMS
         traffic is always allowed.
 
     allow_port
-        allow_port is a program that drops all TCP/UDP packets except those
-        with destination port equal to the input port number. Non-TCP/UDP
-        protocols (ICMP, etc.) are not affected.
+        allow_port allows IPv4 TCP/UDP traffic to the input destination
+        port, drops the rest. Other protocols (ICMP, etc.) pass
+        through. Non-IPv4 traffic is blocked.
 
     block_private_ipv4
         block_private_ipv4 is a program that can be used to block

--- a/api/input_parse.h
+++ b/api/input_parse.h
@@ -25,6 +25,7 @@ static int parse_input(struct config *conf, const char *input_str, const char **
         conf->has_input = true;
         return 0;
     }
+    case program_allow_port:
     case program_block_port:
     {
         char *endptr;
@@ -49,7 +50,7 @@ static int parse_input(struct config *conf, const char *input_str, const char **
 // Returns true if the given program requires an input argument.
 static inline bool program_requires_input(program_t program)
 {
-    return program == program_allow_ipv4 || program == program_block_ipv4 || program == program_block_port;
+    return program == program_allow_ipv4 || program == program_allow_port || program == program_block_ipv4 || program == program_block_port;
 }
 
 #endif // TRAFFICO_INPUT_PARSE_H

--- a/bpf/allow_port.bpf.c
+++ b/bpf/allow_port.bpf.c
@@ -1,0 +1,70 @@
+#include "vmlinux.h"
+#include "commons.bpf.h"
+
+#include <bpf/bpf_endian.h>
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";
+
+const volatile __u16 input = 0; // destination port to allow (host byte order)
+
+SEC("tc")
+int allow_port(struct __sk_buff *skb)
+{
+    void *data_end = (void *)(unsigned long long)skb->data_end;
+    void *data = (void *)(unsigned long long)skb->data;
+
+    struct ethhdr *eth = data;
+    const int l3_offset = sizeof(*eth);
+
+    if (data + l3_offset > data_end)
+    {
+        bpf_printk("allow_port: [eth] size length check hit: continue");
+        return TC_ACT_OK;
+    }
+
+    if (eth->h_proto != bpf_htons(ETH_P_IP))
+    {
+        bpf_printk("allow_port: [eth] protocol is %d: continue", eth->h_proto);
+        return TC_ACT_OK;
+    }
+
+    struct iphdr *ip_header = data + l3_offset;
+    const int l4_offset = l3_offset + sizeof(*ip_header);
+
+    if (data + l4_offset > data_end)
+    {
+        bpf_printk("allow_port: [iph] size length check hit: continue");
+        return TC_ACT_OK;
+    }
+
+    if (ip_is_fragment(skb, l3_offset))
+    {
+        bpf_printk("allow_port: [iph] is fragment: continue");
+        return TC_ACT_OK;
+    }
+
+    // Only inspect TCP and UDP; let other protocols (ICMP, etc.) pass through
+    if (ip_header->protocol != IPPROTO_TCP && ip_header->protocol != IPPROTO_UDP)
+    {
+        bpf_printk("allow_port: [iph] protocol %d is not TCP/UDP: allow", ip_header->protocol);
+        return TC_ACT_OK;
+    }
+
+    // Both TCP and UDP headers start with src_port (u16) then dst_port (u16)
+    if (data + l4_offset + 4 > data_end)
+    {
+        bpf_printk("allow_port: [l4] size length check hit: continue");
+        return TC_ACT_OK;
+    }
+
+    __u16 *dst_port_ptr = (__u16 *)(data + l4_offset + 2); // skip 2-byte src_port
+    __u16 dst_port = bpf_ntohs(*dst_port_ptr);
+
+    if (dst_port != input)
+    {
+        bpf_printk("allow_port: [l4] destination port %d not allowed: block", dst_port);
+        return TC_ACT_SHOT;
+    }
+
+    return TC_ACT_OK;
+}

--- a/bpf/allow_port.bpf.c
+++ b/bpf/allow_port.bpf.c
@@ -18,10 +18,12 @@ int allow_port(struct __sk_buff *skb)
 
     if (data + l3_offset > data_end)
     {
-        bpf_printk("allow_port: [eth] size length check hit: continue");
-        return TC_ACT_OK;
+        bpf_printk("allow_port: [eth] size length check hit: block");
+        return TC_ACT_SHOT;
     }
 
+    // Passthrough: not IPv4 — port filtering doesn't apply.
+    // Non-IPv4 filtering is allow_ethertype's job.
     if (eth->h_proto != bpf_htons(ETH_P_IP))
     {
         bpf_printk("allow_port: [eth] protocol is %d: continue", eth->h_proto);
@@ -29,21 +31,34 @@ int allow_port(struct __sk_buff *skb)
     }
 
     struct iphdr *ip_header = data + l3_offset;
-    const int l4_offset = l3_offset + sizeof(*ip_header);
+    if (data + l3_offset + sizeof(*ip_header) > data_end)
+    {
+        bpf_printk("allow_port: [iph] size length check hit: block");
+        return TC_ACT_SHOT;
+    }
 
+    __u8 ihl = ip_header->ihl;
+    if (ihl < 5)
+    {
+        bpf_printk("allow_port: [iph] invalid IHL %d: block", ihl);
+        return TC_ACT_SHOT;
+    }
+
+    const int l4_offset = l3_offset + (ihl * 4);
     if (data + l4_offset > data_end)
     {
-        bpf_printk("allow_port: [iph] size length check hit: continue");
-        return TC_ACT_OK;
+        bpf_printk("allow_port: [iph] IHL extends beyond packet: block");
+        return TC_ACT_SHOT;
     }
 
-    if (ip_is_fragment(skb, l3_offset))
+    if (ip_is_subsequent_fragment(skb, l3_offset))
     {
-        bpf_printk("allow_port: [iph] is fragment: continue");
-        return TC_ACT_OK;
+        bpf_printk("allow_port: [iph] subsequent fragment: block");
+        return TC_ACT_SHOT;
     }
 
-    // Only inspect TCP and UDP; let other protocols (ICMP, etc.) pass through
+    // Passthrough: not TCP/UDP — port filtering doesn't apply.
+    // Protocol filtering is allow_proto's job.
     if (ip_header->protocol != IPPROTO_TCP && ip_header->protocol != IPPROTO_UDP)
     {
         bpf_printk("allow_port: [iph] protocol %d is not TCP/UDP: allow", ip_header->protocol);
@@ -53,8 +68,8 @@ int allow_port(struct __sk_buff *skb)
     // Both TCP and UDP headers start with src_port (u16) then dst_port (u16)
     if (data + l4_offset + 4 > data_end)
     {
-        bpf_printk("allow_port: [l4] size length check hit: continue");
-        return TC_ACT_OK;
+        bpf_printk("allow_port: [l4] size length check hit: block");
+        return TC_ACT_SHOT;
     }
 
     __u16 *dst_port_ptr = (__u16 *)(data + l4_offset + 2); // skip 2-byte src_port

--- a/bpf/allow_port.bpf.c
+++ b/bpf/allow_port.bpf.c
@@ -22,12 +22,12 @@ int allow_port(struct __sk_buff *skb)
         return TC_ACT_SHOT;
     }
 
-    // Passthrough: not IPv4 — port filtering doesn't apply.
-    // Non-IPv4 filtering is allow_ethertype's job.
+    // Fail closed for unsupported L3. IPv6 TCP/UDP has destination ports too,
+    // and passing it here would bypass this L4 allowlist.
     if (eth->h_proto != bpf_htons(ETH_P_IP))
     {
-        bpf_printk("allow_port: [eth] protocol is %d: continue", eth->h_proto);
-        return TC_ACT_OK;
+        bpf_printk("allow_port: [eth] unsupported ethertype %d: block", eth->h_proto);
+        return TC_ACT_SHOT;
     }
 
     struct iphdr *ip_header = data + l3_offset;
@@ -51,18 +51,18 @@ int allow_port(struct __sk_buff *skb)
         return TC_ACT_SHOT;
     }
 
-    if (ip_is_subsequent_fragment(skb, l3_offset))
-    {
-        bpf_printk("allow_port: [iph] subsequent fragment: block");
-        return TC_ACT_SHOT;
-    }
-
     // Passthrough: not TCP/UDP — port filtering doesn't apply.
     // Protocol filtering is allow_proto's job.
     if (ip_header->protocol != IPPROTO_TCP && ip_header->protocol != IPPROTO_UDP)
     {
         bpf_printk("allow_port: [iph] protocol %d is not TCP/UDP: allow", ip_header->protocol);
         return TC_ACT_OK;
+    }
+
+    if (ip_is_subsequent_fragment(skb, l3_offset))
+    {
+        bpf_printk("allow_port: [iph] subsequent TCP/UDP fragment: block");
+        return TC_ACT_SHOT;
     }
 
     // Both TCP and UDP headers start with src_port (u16) then dst_port (u16)

--- a/docs/README.md
+++ b/docs/README.md
@@ -120,6 +120,7 @@ Here's an example CNI config file featuring `traffico-cni`.
 | Program | Description |
 |---|---|
 | `allow_ipv4` | Allows IPv4 traffic to the input address, drops the rest. Non-IPv4 passes through for L2/chain policy. Localhost (127.0.0.0/8) always allowed. |
+| `allow_port` | Drops all TCP/UDP packets except those destined for the input port (non-TCP/UDP unaffected) |
 | `block_private_ipv4` | Blocks private IPv4 addresses subnets allowing only SSH access on port 22 |
 | `block_ipv4` | Drops packets with destination equal to the input IPv4 address |
 | `block_port` | Drops packets with the destination port equal to the input port number |

--- a/docs/README.md
+++ b/docs/README.md
@@ -120,7 +120,7 @@ Here's an example CNI config file featuring `traffico-cni`.
 | Program | Description |
 |---|---|
 | `allow_ipv4` | Allows IPv4 traffic to the input address, drops the rest. Non-IPv4 passes through for L2/chain policy. Localhost (127.0.0.0/8) always allowed. |
-| `allow_port` | Drops all TCP/UDP packets except those destined for the input port (non-TCP/UDP unaffected) |
+| `allow_port` | Allows IPv4 TCP/UDP traffic to the input port, drops the rest. Other protocols (ICMP, etc.) pass through. Non-IPv4 blocked. |
 | `block_private_ipv4` | Blocks private IPv4 addresses subnets allowing only SSH access on port 22 |
 | `block_ipv4` | Drops packets with destination equal to the input IPv4 address |
 | `block_port` | Drops packets with the destination port equal to the input port number |

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -132,6 +132,47 @@ teardown() {
     echo "# localhost still reachable (exempt from allow_ipv4)" >&3
 }
 
+@test "allow_port allows specific port" {
+    new_server
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_port "${SERVER_PORT}" >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can still reach ${VETH_ADDR}:${SERVER_PORT} (allowed port)" >&3
+}
+
+@test "allow_port blocks other ports" {
+    new_server
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_port 9999 >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ ! $status -eq 0 ]
+    echo "# cannot reach ${VETH_ADDR}:${SERVER_PORT} (only port 9999 allowed)" >&3
+}
+
+@test "allow_port does not block ICMP" {
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 0 ]
+    echo "# can ping ${VETH_ADDR} from the namespace" >&3
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_port 9999 >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 0 ]
+    echo "# can still ping ${VETH_ADDR} (ICMP not blocked by allow_port)" >&3
+}
+
 @test "block_private_ipv4 blocks ICMP packets" {
     run ip netns exec "${NETNS}" ping -W1 -4 -c1 10.22.1.2
     [ $status -eq 0 ]

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -89,6 +89,18 @@ bats_require_minimum_version 1.7.0
     [ "${lines[0]}" == "traffico: invalid IP address: 'not.an.ip'" ]
 }
 
+@test "missing input for allow_port" {
+    run traffico -i lo allow_port
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: program 'allow_port' requires an input argument" ]
+}
+
+@test "invalid port for allow_port" {
+    run traffico -i lo allow_port abc
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: invalid port number: 'abc'" ]
+}
+
 @test "missing input for block_port" {
     run traffico -i lo block_port
     [ $status -eq 1 ]

--- a/test/cni.bats
+++ b/test/cni.bats
@@ -63,6 +63,25 @@ teardown() {
     echo "# cannot reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
 }
 
+@test "allow_port via CNI" {
+    run curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can reach ${VETH_ADDR}:${SERVER_PORT}" >&3
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
+    echo "# installing allow_port in the namespace" >&3
+    run ip netns exec "${NETNS}" bash -c "cat '$FIXTURE_ROOT/attach_allow_port_in.json' | CNI_COMMAND=ADD traffico-cni"
+    [ $status -eq 0 ]
+    echo "# attach ok" >&3
+    run ip netns exec "${NETNS}" tc qdisc show dev peer0 clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    echo "# qdisc ok" >&3
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can still reach ${VETH_ADDR}:${SERVER_PORT} (allowed port)" >&3
+}
+
 @test "block_port via CNI" {
     run curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
     [ $status -eq 0 ]

--- a/test/cni.flags.bats
+++ b/test/cni.flags.bats
@@ -28,6 +28,12 @@ cni_add() {
     [[ "$output" == *"program requires an"*"input"*"field"* ]]
 }
 
+@test "rejects missing input for allow_port" {
+    cni_add "allow_port"
+    [ ! $status -eq 0 ]
+    [[ "$output" == *"program requires an"*"input"*"field"* ]]
+}
+
 @test "rejects missing input for block_ipv4" {
     cni_add "block_ipv4"
     [ ! $status -eq 0 ]

--- a/test/fixtures/cni/attach_allow_port_in.json
+++ b/test/fixtures/cni/attach_allow_port_in.json
@@ -1,0 +1,22 @@
+{
+    "cniVersion": "0.4.0",
+    "name": "dummy-network",
+    "prevResult": {
+        "cniVersion": "1.0.0",
+        "interfaces": [
+            {
+                "name": "peer0"
+            }
+        ],
+        "ips": [
+        ],
+        "routes": [
+        ],
+        "dns": {
+        }
+    },
+    "type": "traffico-cni",
+    "program": "allow_port",
+    "input": "8787",
+    "attachPoint": "egress"
+}

--- a/xmake/modules/api.lua
+++ b/xmake/modules/api.lua
@@ -5,6 +5,7 @@ import("core.project.project")
 -- configured at runtime via the input union in struct config.
 local input_fields = {
     allow_ipv4 = "ip",
+    allow_port = "port",
     block_ipv4 = "ip",
     block_port = "port",
 }


### PR DESCRIPTION
## Description

Allowlist-mode BPF program that drops all TCP/UDP packets except those with destination port equal to the input port number. Non-TCP/UDP protocols (ICMP, etc.) pass through unaffected.

This is the inverse of `block_port`: instead of blocking one port, it allows only one port and drops all other TCP/UDP traffic. Intended for agent quarantine scenarios where an agent should only communicate on a specific proxy port.

Depends on #41 (`allow_ip`).

## Commits

1. **`feat(bpf): implement allow_port program`** — BPF program, `api.lua` registration, `input_parse.h` wiring
2. **`test(bpf): add allow_port tests`** — 7 new tests (43 total)
3. **`docs: add allow_port to built-in programs`** — README.txt, docs/README.md

## How to test

```bash
xmake clean -a
xmake f --generate-vmlinux=y
xmake
sudo XMAKE_ROOT=y xmake run test
```

All 43 tests pass (36 from PR #41 + 7 new).