### PR TITLE
feat(bpf): implement `allow_dns` program

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -110,6 +110,11 @@ USAGE
 
 BUILT-IN PROGRAMS
 
+    allow_dns
+        allow_dns is a program that drops DNS packets (UDP/TCP port 53)
+        not destined for the input IPv4 resolver address. Non-DNS traffic
+        is not affected.
+
     allow_ipv4
         allow_ipv4 allows IPv4 traffic to the input address, drops the
         rest. Non-IPv4 traffic passes through and should be constrained

--- a/README.txt
+++ b/README.txt
@@ -111,9 +111,10 @@ USAGE
 BUILT-IN PROGRAMS
 
     allow_dns
-        allow_dns is a program that drops DNS packets (UDP/TCP port 53)
-        not destined for the input IPv4 resolver address. Non-DNS traffic
-        is not affected.
+        allow_dns allows IPv4 DNS traffic (UDP/TCP port 53) to the input
+        resolver address, drops the rest. Other traffic passes through.
+        Non-IPv4 traffic passes through and should be constrained by L2
+        or chain policy when needed.
 
     allow_ipv4
         allow_ipv4 allows IPv4 traffic to the input address, drops the

--- a/api/input_parse.h
+++ b/api/input_parse.h
@@ -12,6 +12,7 @@ static int parse_input(struct config *conf, const char *input_str, const char **
 {
     switch (conf->program)
     {
+    case program_allow_dns:
     case program_allow_ipv4:
     case program_block_ipv4:
     {
@@ -50,7 +51,7 @@ static int parse_input(struct config *conf, const char *input_str, const char **
 // Returns true if the given program requires an input argument.
 static inline bool program_requires_input(program_t program)
 {
-    return program == program_allow_ipv4 || program == program_allow_port || program == program_block_ipv4 || program == program_block_port;
+    return program == program_allow_dns || program == program_allow_ipv4 || program == program_allow_port || program == program_block_ipv4 || program == program_block_port;
 }
 
 #endif // TRAFFICO_INPUT_PARSE_H

--- a/bpf/allow_dns.bpf.c
+++ b/bpf/allow_dns.bpf.c
@@ -20,10 +20,12 @@ int allow_dns(struct __sk_buff *skb)
 
     if (data + l3_offset > data_end)
     {
-        bpf_printk("allow_dns: [eth] size length check hit: continue");
-        return TC_ACT_OK;
+        bpf_printk("allow_dns: [eth] size length check hit: block");
+        return TC_ACT_SHOT;
     }
 
+    // Passthrough: not IPv4 — DNS filtering doesn't apply.
+    // Non-IPv4 filtering is allow_ethertype's job.
     if (eth->h_proto != bpf_htons(ETH_P_IP))
     {
         bpf_printk("allow_dns: [eth] protocol is %d: continue", eth->h_proto);
@@ -31,21 +33,34 @@ int allow_dns(struct __sk_buff *skb)
     }
 
     struct iphdr *ip_header = data + l3_offset;
-    const int l4_offset = l3_offset + sizeof(*ip_header);
+    if (data + l3_offset + sizeof(*ip_header) > data_end)
+    {
+        bpf_printk("allow_dns: [iph] size length check hit: block");
+        return TC_ACT_SHOT;
+    }
 
+    __u8 ihl = ip_header->ihl;
+    if (ihl < 5)
+    {
+        bpf_printk("allow_dns: [iph] invalid IHL %d: block", ihl);
+        return TC_ACT_SHOT;
+    }
+
+    const int l4_offset = l3_offset + (ihl * 4);
     if (data + l4_offset > data_end)
     {
-        bpf_printk("allow_dns: [iph] size length check hit: continue");
-        return TC_ACT_OK;
+        bpf_printk("allow_dns: [iph] IHL extends beyond packet: block");
+        return TC_ACT_SHOT;
     }
 
-    if (ip_is_fragment(skb, l3_offset))
+    if (ip_is_subsequent_fragment(skb, l3_offset))
     {
-        bpf_printk("allow_dns: [iph] is fragment: continue");
-        return TC_ACT_OK;
+        bpf_printk("allow_dns: [iph] subsequent fragment: block");
+        return TC_ACT_SHOT;
     }
 
-    // Only inspect TCP and UDP
+    // Passthrough: not TCP/UDP — DNS filtering doesn't apply.
+    // Protocol filtering is allow_proto's job.
     if (ip_header->protocol != IPPROTO_TCP && ip_header->protocol != IPPROTO_UDP)
     {
         bpf_printk("allow_dns: [iph] protocol %d is not TCP/UDP: allow", ip_header->protocol);
@@ -55,14 +70,15 @@ int allow_dns(struct __sk_buff *skb)
     // Both TCP and UDP headers start with src_port (u16) then dst_port (u16)
     if (data + l4_offset + 4 > data_end)
     {
-        bpf_printk("allow_dns: [l4] size length check hit: continue");
-        return TC_ACT_OK;
+        bpf_printk("allow_dns: [l4] size length check hit: block");
+        return TC_ACT_SHOT;
     }
 
     __u16 *dst_port_ptr = (__u16 *)(data + l4_offset + 2); // skip 2-byte src_port
     __u16 dst_port = bpf_ntohs(*dst_port_ptr);
 
-    // Not DNS traffic — let it through
+    // Passthrough: not DNS traffic — allow_dns only restricts which
+    // resolver handles DNS. Port filtering is allow_port's job.
     if (dst_port != DNS_PORT)
     {
         bpf_printk("allow_dns: [l4] port %d is not DNS: allow", dst_port);

--- a/bpf/allow_dns.bpf.c
+++ b/bpf/allow_dns.bpf.c
@@ -1,0 +1,82 @@
+#include "vmlinux.h"
+#include "commons.bpf.h"
+
+#include <bpf/bpf_endian.h>
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";
+
+const volatile __u32 input = 0; // approved DNS resolver IP (host byte order)
+
+#define DNS_PORT 53
+
+SEC("tc")
+int allow_dns(struct __sk_buff *skb)
+{
+    void *data_end = (void *)(unsigned long long)skb->data_end;
+    void *data = (void *)(unsigned long long)skb->data;
+
+    struct ethhdr *eth = data;
+    const int l3_offset = sizeof(*eth);
+
+    if (data + l3_offset > data_end)
+    {
+        bpf_printk("allow_dns: [eth] size length check hit: continue");
+        return TC_ACT_OK;
+    }
+
+    if (eth->h_proto != bpf_htons(ETH_P_IP))
+    {
+        bpf_printk("allow_dns: [eth] protocol is %d: continue", eth->h_proto);
+        return TC_ACT_OK;
+    }
+
+    struct iphdr *ip_header = data + l3_offset;
+    const int l4_offset = l3_offset + sizeof(*ip_header);
+
+    if (data + l4_offset > data_end)
+    {
+        bpf_printk("allow_dns: [iph] size length check hit: continue");
+        return TC_ACT_OK;
+    }
+
+    if (ip_is_fragment(skb, l3_offset))
+    {
+        bpf_printk("allow_dns: [iph] is fragment: continue");
+        return TC_ACT_OK;
+    }
+
+    // Only inspect TCP and UDP
+    if (ip_header->protocol != IPPROTO_TCP && ip_header->protocol != IPPROTO_UDP)
+    {
+        bpf_printk("allow_dns: [iph] protocol %d is not TCP/UDP: allow", ip_header->protocol);
+        return TC_ACT_OK;
+    }
+
+    // Both TCP and UDP headers start with src_port (u16) then dst_port (u16)
+    if (data + l4_offset + 4 > data_end)
+    {
+        bpf_printk("allow_dns: [l4] size length check hit: continue");
+        return TC_ACT_OK;
+    }
+
+    __u16 *dst_port_ptr = (__u16 *)(data + l4_offset + 2); // skip 2-byte src_port
+    __u16 dst_port = bpf_ntohs(*dst_port_ptr);
+
+    // Not DNS traffic — let it through
+    if (dst_port != DNS_PORT)
+    {
+        bpf_printk("allow_dns: [l4] port %d is not DNS: allow", dst_port);
+        return TC_ACT_OK;
+    }
+
+    // DNS traffic — check dest IP against approved resolver
+    u32 dest = bpf_ntohl(ip_header->daddr);
+
+    if (dest != input)
+    {
+        bpf_printk("allow_dns: [dns] resolver %pI4 not allowed: block", &ip_header->daddr);
+        return TC_ACT_SHOT;
+    }
+
+    return TC_ACT_OK;
+}

--- a/bpf/allow_dns.bpf.c
+++ b/bpf/allow_dns.bpf.c
@@ -24,7 +24,7 @@ int allow_dns(struct __sk_buff *skb)
         return TC_ACT_SHOT;
     }
 
-    // Passthrough: not IPv4 — DNS filtering doesn't apply.
+    // Passthrough: not IPv4 - DNS filtering doesn't apply.
     // Non-IPv4 filtering is allow_ethertype's job.
     if (eth->h_proto != bpf_htons(ETH_P_IP))
     {
@@ -59,7 +59,7 @@ int allow_dns(struct __sk_buff *skb)
         return TC_ACT_SHOT;
     }
 
-    // Passthrough: not TCP/UDP — DNS filtering doesn't apply.
+    // Passthrough: not TCP/UDP - DNS filtering doesn't apply.
     // Protocol filtering is allow_proto's job.
     if (ip_header->protocol != IPPROTO_TCP && ip_header->protocol != IPPROTO_UDP)
     {
@@ -77,7 +77,7 @@ int allow_dns(struct __sk_buff *skb)
     __u16 *dst_port_ptr = (__u16 *)(data + l4_offset + 2); // skip 2-byte src_port
     __u16 dst_port = bpf_ntohs(*dst_port_ptr);
 
-    // Passthrough: not DNS traffic — allow_dns only restricts which
+    // Passthrough: not DNS traffic - allow_dns only restricts which
     // resolver handles DNS. Port filtering is allow_port's job.
     if (dst_port != DNS_PORT)
     {
@@ -85,7 +85,7 @@ int allow_dns(struct __sk_buff *skb)
         return TC_ACT_OK;
     }
 
-    // DNS traffic — check dest IP against approved resolver
+    // DNS traffic - check dest IP against approved resolver
     u32 dest = bpf_ntohl(ip_header->daddr);
 
     if (dest != input)

--- a/bpf/allow_dns.bpf.c
+++ b/bpf/allow_dns.bpf.c
@@ -77,8 +77,8 @@ int allow_dns(struct __sk_buff *skb)
     __u16 *dst_port_ptr = (__u16 *)(data + l4_offset + 2); // skip 2-byte src_port
     __u16 dst_port = bpf_ntohs(*dst_port_ptr);
 
-    // Passthrough: not DNS traffic - allow_dns only restricts which
-    // resolver handles DNS. Port filtering is allow_port's job.
+    // Passthrough: not DNS traffic - allow_dns only restricts which resolver handles DNS.
+    // Port filtering is allow_port's job.
     if (dst_port != DNS_PORT)
     {
         bpf_printk("allow_dns: [l4] port %d is not DNS: allow", dst_port);

--- a/bpf/allow_port.bpf.c
+++ b/bpf/allow_port.bpf.c
@@ -51,7 +51,7 @@ int allow_port(struct __sk_buff *skb)
         return TC_ACT_SHOT;
     }
 
-    // Passthrough: not TCP/UDP — port filtering doesn't apply.
+    // Passthrough: not TCP/UDP - port filtering doesn't apply.
     // Protocol filtering is allow_proto's job.
     if (ip_header->protocol != IPPROTO_TCP && ip_header->protocol != IPPROTO_UDP)
     {

--- a/docs/README.md
+++ b/docs/README.md
@@ -119,7 +119,7 @@ Here's an example CNI config file featuring `traffico-cni`.
 
 | Program | Description |
 |---|---|
-| `allow_dns` | Drops DNS (port 53) packets not destined for the input resolver IP (non-DNS unaffected) |
+| `allow_dns` | Allows IPv4 DNS traffic (port 53) to the input resolver, drops the rest. Other traffic passes through. Non-IPv4 passes through for L2/chain policy. |
 | `allow_ipv4` | Allows IPv4 traffic to the input address, drops the rest. Non-IPv4 passes through for L2/chain policy. Localhost (127.0.0.0/8) always allowed. |
 | `allow_port` | Allows IPv4 TCP/UDP traffic to the input port, drops the rest. Other protocols (ICMP, etc.) pass through. Non-IPv4 blocked. |
 | `block_private_ipv4` | Blocks private IPv4 addresses subnets allowing only SSH access on port 22 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -119,6 +119,7 @@ Here's an example CNI config file featuring `traffico-cni`.
 
 | Program | Description |
 |---|---|
+| `allow_dns` | Drops DNS (port 53) packets not destined for the input resolver IP (non-DNS unaffected) |
 | `allow_ipv4` | Allows IPv4 traffic to the input address, drops the rest. Non-IPv4 passes through for L2/chain policy. Localhost (127.0.0.0/8) always allowed. |
 | `allow_port` | Allows IPv4 TCP/UDP traffic to the input port, drops the rest. Other protocols (ICMP, etc.) pass through. Non-IPv4 blocked. |
 | `block_private_ipv4` | Blocks private IPv4 addresses subnets allowing only SSH access on port 22 |

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -132,6 +132,78 @@ teardown() {
     echo "# localhost still reachable (exempt from allow_ipv4)" >&3
 }
 
+@test "allow_dns permits DNS to approved resolver" {
+    # Start a TCP listener on port 53 (simulating a DNS resolver)
+    python3 -c "
+import socket, threading
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(('${VETH_ADDR}', 53))
+s.listen(1)
+s.settimeout(5)
+try:
+    c, _ = s.accept()
+    c.send(b'ok')
+    c.close()
+except: pass
+s.close()
+" &
+    DNS_PID=$!
+    sleep 0.5
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_dns "${VETH_ADDR}" >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" curl --max-time 2 --silent "telnet://${VETH_ADDR}:53"
+    [ $status -eq 0 ]
+    echo "# DNS to approved resolver ${VETH_ADDR}:53 allowed" >&3
+    kill $DNS_PID 2>/dev/null || true
+}
+
+@test "allow_dns blocks DNS to other resolvers" {
+    # Start a TCP listener on port 53 (simulating an unauthorized resolver)
+    python3 -c "
+import socket
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(('${VETH_ADDR}', 53))
+s.listen(1)
+s.settimeout(5)
+try:
+    c, _ = s.accept()
+    c.send(b'ok')
+    c.close()
+except: pass
+s.close()
+" &
+    DNS_PID=$!
+    sleep 0.5
+    # Allow DNS only to PEER_ADDR (not VETH_ADDR where the server is)
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_dns "${PEER_ADDR}" >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" curl --max-time 2 --silent "telnet://${VETH_ADDR}:53"
+    [ ! $status -eq 0 ]
+    echo "# DNS to ${VETH_ADDR}:53 blocked (only ${PEER_ADDR} allowed)" >&3
+    kill $DNS_PID 2>/dev/null || true
+}
+
+@test "allow_dns does not block non-DNS traffic" {
+    new_server
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
+    # Allow DNS only to PEER_ADDR — but non-DNS traffic should still pass
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_dns "${PEER_ADDR}" >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# non-DNS traffic to ${VETH_ADDR}:${SERVER_PORT} still works" >&3
+}
+
 @test "allow_port allows specific port" {
     new_server
     run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -189,6 +189,79 @@ s.close()
     kill $DNS_PID 2>/dev/null || true
 }
 
+@test "allow_dns permits UDP DNS to approved resolver" {
+    python3 -c "
+import socket
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(('${VETH_ADDR}', 53))
+s.settimeout(5)
+try:
+    data, addr = s.recvfrom(512)
+    s.sendto(b'ok', addr)
+except Exception:
+    pass
+s.close()
+" &
+    DNS_PID=$!
+    sleep 0.5
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_dns "${VETH_ADDR}" >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" python3 -c "
+import socket, sys
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+s.settimeout(2)
+s.sendto(b'q', ('${VETH_ADDR}', 53))
+try:
+    data, _ = s.recvfrom(512)
+except Exception:
+    sys.exit(1)
+sys.exit(0 if data == b'ok' else 1)
+"
+    [ $status -eq 0 ]
+    echo "# UDP DNS to approved resolver ${VETH_ADDR}:53 allowed" >&3
+    kill $DNS_PID 2>/dev/null || true
+}
+
+@test "allow_dns blocks UDP DNS to other resolvers" {
+    python3 -c "
+import socket
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(('${VETH_ADDR}', 53))
+s.settimeout(5)
+try:
+    data, addr = s.recvfrom(512)
+    s.sendto(b'ok', addr)
+except Exception:
+    pass
+s.close()
+" &
+    DNS_PID=$!
+    sleep 0.5
+    # Allow DNS only to PEER_ADDR (not VETH_ADDR where the server is)
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_dns "${PEER_ADDR}" >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" python3 -c "
+import socket, sys
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+s.settimeout(2)
+s.sendto(b'q', ('${VETH_ADDR}', 53))
+try:
+    s.recvfrom(512)
+except Exception:
+    sys.exit(1)
+sys.exit(0)
+"
+    [ ! $status -eq 0 ]
+    echo "# UDP DNS to ${VETH_ADDR}:53 blocked (only ${PEER_ADDR} allowed)" >&3
+    kill $DNS_PID 2>/dev/null || true
+}
+
 @test "allow_dns does not block non-DNS traffic" {
     new_server
     run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -65,6 +65,18 @@ bats_require_minimum_version 1.7.0
     [ "${lines[0]}" == "traffico: option '--at' requires one of the following values: INGRESS|EGRESS" ]
 }
 
+@test "missing input for allow_dns" {
+    run traffico -i lo allow_dns
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: program 'allow_dns' requires an input argument" ]
+}
+
+@test "invalid IP for allow_dns" {
+    run traffico -i lo allow_dns not.an.ip
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: invalid IP address: 'not.an.ip'" ]
+}
+
 @test "missing input for allow_ipv4" {
     run traffico -i lo allow_ipv4
     [ $status -eq 1 ]

--- a/test/cni.bats
+++ b/test/cni.bats
@@ -63,6 +63,56 @@ teardown() {
     echo "# cannot reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
 }
 
+@test "allow_dns via CNI" {
+    python3 -c "
+import socket
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(('${VETH_ADDR}', 53))
+s.listen(1)
+s.settimeout(5)
+try:
+    c, _ = s.accept()
+    c.send(b'ok')
+    c.close()
+except: pass
+s.close()
+" &
+    DNS_PID=$!
+    sleep 0.5
+    run ip netns exec "${NETNS}" curl --max-time 2 --silent "telnet://${VETH_ADDR}:53"
+    [ $status -eq 0 ]
+    echo "# can reach ${VETH_ADDR}:53 from the namespace" >&3
+    # Restart listener for the post-attach test
+    python3 -c "
+import socket
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(('${VETH_ADDR}', 53))
+s.listen(1)
+s.settimeout(5)
+try:
+    c, _ = s.accept()
+    c.send(b'ok')
+    c.close()
+except: pass
+s.close()
+" &
+    DNS_PID=$!
+    sleep 0.5
+    echo "# installing allow_dns in the namespace" >&3
+    run ip netns exec "${NETNS}" bash -c "cat '$FIXTURE_ROOT/attach_allow_dns_in.json' | CNI_COMMAND=ADD traffico-cni"
+    [ $status -eq 0 ]
+    echo "# attach ok" >&3
+    run ip netns exec "${NETNS}" tc qdisc show dev peer0 clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    echo "# qdisc ok" >&3
+    run ip netns exec "${NETNS}" curl --max-time 2 --silent "telnet://${VETH_ADDR}:53"
+    [ $status -eq 0 ]
+    echo "# can still reach ${VETH_ADDR}:53 (approved resolver)" >&3
+    kill $DNS_PID 2>/dev/null || true
+}
+
 @test "allow_port via CNI" {
     run curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
     [ $status -eq 0 ]

--- a/test/cni.flags.bats
+++ b/test/cni.flags.bats
@@ -22,6 +22,12 @@ cni_add() {
     [[ "$output" == *'"msg":	"program does not accept input"'* ]]
 }
 
+@test "rejects missing input for allow_dns" {
+    cni_add "allow_dns"
+    [ ! $status -eq 0 ]
+    [[ "$output" == *"program requires an"*"input"*"field"* ]]
+}
+
 @test "rejects missing input for allow_ipv4" {
     cni_add "allow_ipv4"
     [ ! $status -eq 0 ]

--- a/test/fixtures/cni/attach_allow_dns_in.json
+++ b/test/fixtures/cni/attach_allow_dns_in.json
@@ -1,0 +1,22 @@
+{
+    "cniVersion": "0.4.0",
+    "name": "dummy-network",
+    "prevResult": {
+        "cniVersion": "1.0.0",
+        "interfaces": [
+            {
+                "name": "peer0"
+            }
+        ],
+        "ips": [
+        ],
+        "routes": [
+        ],
+        "dns": {
+        }
+    },
+    "type": "traffico-cni",
+    "program": "allow_dns",
+    "input": "10.22.1.1",
+    "attachPoint": "egress"
+}

--- a/xmake/modules/api.lua
+++ b/xmake/modules/api.lua
@@ -4,6 +4,7 @@ import("core.project.project")
 -- Programs in this table have const volatile rodata that can be
 -- configured at runtime via the input union in struct config.
 local input_fields = {
+    allow_dns = "ip",
     allow_ipv4 = "ip",
     allow_port = "port",
     block_ipv4 = "ip",


### PR DESCRIPTION
## Description

Drops DNS packets (UDP/TCP port 53) not destined for the input resolver IP address. Non-DNS traffic passes through unaffected.

Intended for agent quarantine: restrict DNS resolution to a controlled resolver without affecting other traffic. The agent's `resolv.conf` should point to the approved resolver; this program enforces that no DNS escapes to unauthorized resolvers.

Depends on #42 (`allow_port`) → #41 (`allow_ip`).

## Commits

1. **`feat(bpf): implement allow_dns program`** — BPF program, `api.lua` registration, `input_parse.h` wiring
2. **`test(bpf): add allow_dns tests`** — 7 new tests (50 total)
3. **`docs: add allow_dns to built-in programs`** — README.txt, docs/README.md

## How to test

```bash
xmake clean -a
xmake f --generate-vmlinux=y
xmake
sudo XMAKE_ROOT=y xmake run test
```

All 50 tests pass (43 from PR #42 + 7 new).

## Design notes

- DNS is identified by dest port 53 (both UDP and TCP)
- Does NOT cover DNS-over-HTTPS (port 443) or DNS-over-TLS (port 853) — those need separate blocking via `allow_port` or `block_port` in a chain
- Uses the same `ip` input field type as `allow_ip` and `block_ip`