### PR TITLE
feat(bpf): add dispatcher and tail-call chaining infrastructure

### DIFF
--- a/bpf/allow_dns.bpf.c
+++ b/bpf/allow_dns.bpf.c
@@ -98,4 +98,5 @@ int allow_dns(struct __sk_buff *skb)
     }
 
     tail_call_next(skb, slot);
+    return TC_ACT_OK;
 }

--- a/bpf/allow_dns.bpf.c
+++ b/bpf/allow_dns.bpf.c
@@ -6,6 +6,9 @@
 char LICENSE[] SEC("license") = "Dual BSD/GPL";
 
 const volatile __u32 input = 0; // approved DNS resolver IP (host byte order)
+const volatile __u32 slot = 0;  // position in the chain (set by userspace)
+
+DEFINE_PROG_ARRAY();
 
 #define DNS_PORT 53
 
@@ -94,5 +97,5 @@ int allow_dns(struct __sk_buff *skb)
         return TC_ACT_SHOT;
     }
 
-    return TC_ACT_OK;
+    tail_call_next(skb, slot);
 }

--- a/bpf/allow_ipv4.bpf.c
+++ b/bpf/allow_ipv4.bpf.c
@@ -6,6 +6,9 @@
 char LICENSE[] SEC("license") = "Dual BSD/GPL";
 
 const volatile __u32 input = 0; // address to allow (host byte order)
+const volatile __u32 slot = 0;  // position in the chain (set by userspace)
+
+DEFINE_PROG_ARRAY();
 
 SEC("tc")
 int allow_ipv4(struct __sk_buff *skb)
@@ -70,5 +73,5 @@ int allow_ipv4(struct __sk_buff *skb)
         return TC_ACT_SHOT;
     }
 
-    return TC_ACT_OK;
+    tail_call_next(skb, slot);
 }

--- a/bpf/allow_ipv4.bpf.c
+++ b/bpf/allow_ipv4.bpf.c
@@ -74,4 +74,5 @@ int allow_ipv4(struct __sk_buff *skb)
     }
 
     tail_call_next(skb, slot);
+    return TC_ACT_OK;
 }

--- a/bpf/allow_port.bpf.c
+++ b/bpf/allow_port.bpf.c
@@ -6,6 +6,9 @@
 char LICENSE[] SEC("license") = "Dual BSD/GPL";
 
 const volatile __u16 input = 0; // destination port to allow (host byte order)
+const volatile __u32 slot = 0;  // position in the chain (set by userspace)
+
+DEFINE_PROG_ARRAY();
 
 SEC("tc")
 int allow_port(struct __sk_buff *skb)
@@ -81,5 +84,5 @@ int allow_port(struct __sk_buff *skb)
         return TC_ACT_SHOT;
     }
 
-    return TC_ACT_OK;
+    tail_call_next(skb, slot);
 }

--- a/bpf/allow_port.bpf.c
+++ b/bpf/allow_port.bpf.c
@@ -85,4 +85,5 @@ int allow_port(struct __sk_buff *skb)
     }
 
     tail_call_next(skb, slot);
+    return TC_ACT_OK;
 }

--- a/bpf/commons.bpf.h
+++ b/bpf/commons.bpf.h
@@ -70,4 +70,28 @@ struct trace_event_raw_bpf_trace_printk___x
     while (0)
 #endif
 
+/// Tail call support for program chaining.
+///
+/// Programs that participate in a chain define a prog_array map and use
+/// tail_call_next() instead of returning TC_ACT_OK at the end of their
+/// allow path. When used standalone (no chain), the map is empty and
+/// bpf_tail_call silently fails, falling through to TC_ACT_OK.
+/// When used in a chain, userspace reuses the dispatcher's prog_array
+/// map FD via bpf_map__reuse_fd() before loading the program.
+
+#define DEFINE_PROG_ARRAY()                              \
+    struct {                                             \
+        __uint(type, BPF_MAP_TYPE_PROG_ARRAY);           \
+        __uint(key_size, sizeof(__u32));                  \
+        __uint(value_size, sizeof(__u32));                \
+        __uint(max_entries, 8);                           \
+    } prog_array SEC(".maps")
+
+/// Tail-call the next program in the chain.
+/// If the tail call fails (empty slot = end of chain), falls through
+/// to TC_ACT_OK — the packet passed all filters and is allowed.
+#define tail_call_next(skb, slot)                        \
+    bpf_tail_call(skb, &prog_array, (slot) + 1);        \
+    return TC_ACT_OK
+
 #endif // TRAFFICO_BPF_COMMONS_H

--- a/bpf/commons.bpf.h
+++ b/bpf/commons.bpf.h
@@ -88,10 +88,9 @@ struct trace_event_raw_bpf_trace_printk___x
     } prog_array SEC(".maps")
 
 /// Tail-call the next program in the chain.
-/// If the tail call fails (empty slot = end of chain), falls through
-/// to TC_ACT_OK — the packet passed all filters and is allowed.
+/// If the tail call fails (empty slot = end of chain), execution
+/// continues to the next statement. Callers must return explicitly.
 #define tail_call_next(skb, slot)                        \
-    bpf_tail_call(skb, &prog_array, (slot) + 1);        \
-    return TC_ACT_OK
+    bpf_tail_call(skb, &prog_array, (slot) + 1)
 
 #endif // TRAFFICO_BPF_COMMONS_H

--- a/bpf/dispatcher.bpf.c
+++ b/bpf/dispatcher.bpf.c
@@ -1,0 +1,20 @@
+#include "vmlinux.h"
+#include "commons.bpf.h"
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+    __uint(key_size, sizeof(__u32));
+    __uint(value_size, sizeof(__u32));
+    __uint(max_entries, 8);
+} prog_array SEC(".maps");
+
+SEC("tc")
+int dispatcher(struct __sk_buff *skb)
+{
+    bpf_tail_call(skb, &prog_array, 0);
+
+    // Fallback: no programs in chain, allow packet
+    return TC_ACT_OK;
+}

--- a/bpf/xmake.lua
+++ b/bpf/xmake.lua
@@ -66,6 +66,7 @@ add_requires("libbpf v1.5.0", { system = false })
 -- probe
 target("bpf")
     set_kind("object")
+    set_symbols("none") -- BPF objects must not use -fvisibility=hidden (breaks libbpf map linkage)
     set_policy("build.fence", true)
     includes("../tools")
     add_deps("bpftool")

--- a/xmake/modules/api.lua
+++ b/xmake/modules/api.lua
@@ -11,13 +11,25 @@ local input_fields = {
     block_port = "port",
 }
 
+-- Internal BPF programs that are not user-facing.
+-- These are compiled and get skeletons but are excluded from the
+-- program list, enum, and dispatch table.
+local internal_programs = {
+    dispatcher = true,
+}
+
 -- get sourcefiles
 function _get_programs(target_name)
     local programs = {}
     for _, target in pairs(project.targets()) do
         if target:is_enabled() and target:name() == target_name then
             for _, src in pairs(target:sourcebatches()) do
-                table.join2(programs, src.sourcefiles)
+                for _, f in ipairs(src.sourcefiles) do
+                    local progname = string.match(path.basename(f), "(.+)%..+$")
+                    if not internal_programs[progname] then
+                        table.insert(programs, f)
+                    end
+                end
             end
         end
     end


### PR DESCRIPTION
## Description

BPF-side infrastructure for program chaining via tail calls. This is the first half of PR 4a from the dispatcher spec — BPF programs and build system only, no userspace attachment logic or CLI changes.

**Dispatcher program** (`bpf/dispatcher.bpf.c`): minimal TC program that owns a `BPF_MAP_TYPE_PROG_ARRAY` (max 8 entries) and tail-calls into slot 0. Fallback is `TC_ACT_OK` (no chain = allow all).

**Tail-call macros** (`bpf/commons.bpf.h`):
- `DEFINE_PROG_ARRAY()` — declares a per-program `prog_array` map (reused via `bpf_map__reuse_fd()` by userspace in the next PR)
- `tail_call_next(skb, slot)` — calls `bpf_tail_call(skb, &prog_array, slot + 1)` then falls through to `TC_ACT_OK` if the tail call fails (end of chain)

**Program changes**: `allow_ip`, `allow_port`, `allow_dns` gain a `const volatile __u32 slot` rodata field and replace their final `return TC_ACT_OK` with `tail_call_next(skb, slot)`. Backward compatible — in standalone mode the prog_array is empty, `bpf_tail_call` silently fails, falls through to `TC_ACT_OK`.

**Build system**:
- `set_symbols("none")` on the bpf target prevents `-fvisibility=hidden` which breaks libbpf map linkage
- `internal_programs` filter in `api.lua` excludes `dispatcher` from the generated enum and dispatch table

Depends on #43 (`allow_dns`) → #42 (`allow_port`) → #41 (`allow_ip`).

## How to test

```bash
xmake -y
sudo XMAKE_ROOT=y xmake run test
```

All 50 existing tests pass — standalone program behavior is unchanged. Chain tests come in the next PR (userspace `--chain` CLI + `attach_chain()`).