### PR TITLE
feat: chain attachment CLI and userspace logic

### DIFF
--- a/api/chain.h
+++ b/api/chain.h
@@ -55,19 +55,26 @@ static int set_chain_rodata(struct bpf_map *rodata_map,
                             const void *input_val, size_t input_sz,
                             __u32 slot)
 {
+    if (!rodata_map)
+        return -EINVAL;
+
     size_t rodata_sz = bpf_map__value_size(rodata_map);
+
+    // Validate that the input fits in the rodata map
+    if (input_sz > rodata_sz)
+        return -ENOSPC;
+
+    size_t slot_offset = (input_sz + 3) & ~3;
+    if (slot_offset + sizeof(__u32) > rodata_sz)
+        return -ENOSPC;
+
     void *buf = calloc(1, rodata_sz);
     if (!buf)
         return -ENOMEM;
 
     // Layout: input at offset 0, slot at offset aligned to 4 bytes after input
     memcpy(buf, input_val, input_sz);
-    // slot is always a __u32 placed after the input field, aligned to 4 bytes
-    size_t slot_offset = (input_sz + 3) & ~3;
-    if (slot_offset + sizeof(__u32) <= rodata_sz)
-    {
-        memcpy((char *)buf + slot_offset, &slot, sizeof(slot));
-    }
+    memcpy((char *)buf + slot_offset, &slot, sizeof(slot));
 
     int err = bpf_map__set_initial_value(rodata_map, buf, rodata_sz);
     free(buf);

--- a/api/chain.h
+++ b/api/chain.h
@@ -1,0 +1,410 @@
+#ifndef TRAFFICO_CHAIN_H
+#define TRAFFICO_CHAIN_H
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <bpf/bpf.h>
+#include <bpf/libbpf.h>
+
+#include "api.h"
+#include "dispatcher.skel.h"
+#include "allow_dns.skel.h"
+#include "allow_ipv4.skel.h"
+#include "allow_port.skel.h"
+
+#define MAX_CHAIN_LEN 8
+#define BPFFS_BASE "/sys/fs/bpf/traffico"
+
+/// A single entry in a chain: program type + input value.
+struct chain_entry
+{
+    program_t program;
+    bool has_input;
+    union {
+        __u32 ip;
+        __u16 port;
+    } input;
+};
+
+/// Ensure a directory exists, creating parents as needed.
+static int ensure_dir(const char *dir)
+{
+    char tmp[256];
+    char *p = NULL;
+    snprintf(tmp, sizeof(tmp), "%s", dir);
+    for (p = tmp + 1; *p; p++)
+    {
+        if (*p == '/')
+        {
+            *p = '\0';
+            mkdir(tmp, 0755);
+            *p = '/';
+        }
+    }
+    return mkdir(tmp, 0755) == 0 || errno == EEXIST ? 0 : -errno;
+}
+
+/// Set rodata for a program's skeleton map.
+/// Writes the input value at offset 0 and the slot index at the
+/// appropriate offset in the rodata buffer.
+static int set_chain_rodata(struct bpf_map *rodata_map,
+                            const void *input_val, size_t input_sz,
+                            __u32 slot)
+{
+    size_t rodata_sz = bpf_map__value_size(rodata_map);
+    void *buf = calloc(1, rodata_sz);
+    if (!buf)
+        return -ENOMEM;
+
+    // Layout: input at offset 0, slot at offset aligned to 4 bytes after input
+    memcpy(buf, input_val, input_sz);
+    // slot is always a __u32 placed after the input field, aligned to 4 bytes
+    size_t slot_offset = (input_sz + 3) & ~3;
+    if (slot_offset + sizeof(__u32) <= rodata_sz)
+    {
+        memcpy((char *)buf + slot_offset, &slot, sizeof(slot));
+    }
+
+    int err = bpf_map__set_initial_value(rodata_map, buf, rodata_sz);
+    free(buf);
+    return err;
+}
+
+/// Load a chain program, set its rodata, reuse the dispatcher's prog_array,
+/// and insert it into the prog_array at the given slot.
+static int load_chain_program(struct config *conf,
+                              struct chain_entry *entry,
+                              int prog_array_fd,
+                              __u32 slot)
+{
+    int err;
+    char buf[100];
+    buf[sizeof(buf) - 1] = '\0';
+
+    switch (entry->program)
+    {
+    case program_allow_ipv4:
+    {
+        struct allow_ipv4_bpf *obj = allow_ipv4_bpf__open();
+        if (!obj)
+        {
+            log_err(conf, "fail: opening allow_ipv4 skeleton\n");
+            return 1;
+        }
+
+        // Reuse dispatcher's prog_array
+        err = bpf_map__reuse_fd(obj->maps.prog_array, prog_array_fd);
+        if (err)
+        {
+            log_err(conf, "fail: reusing prog_array for allow_ipv4v4v4\n");
+            allow_ipv4_bpf__destroy(obj);
+            return 1;
+        }
+
+        // Set rodata
+        if (entry->has_input)
+        {
+            err = set_chain_rodata(obj->maps.rodata,
+                                   &entry->input.ip, sizeof(entry->input.ip),
+                                   slot);
+            if (err)
+            {
+                log_err(conf, "fail: setting rodata for allow_ipv4v4\n");
+                allow_ipv4_bpf__destroy(obj);
+                return 1;
+            }
+        }
+
+        err = allow_ipv4_bpf__load(obj);
+        if (err)
+        {
+            libbpf_strerror(err, buf, sizeof(buf));
+            log_err(conf, "fail: loading allow_ipv4: %s\n", buf);
+            allow_ipv4_bpf__destroy(obj);
+            return 1;
+        }
+
+        int prog_fd = bpf_program__fd(obj->progs.allow_ipv4);
+        err = bpf_map_update_elem(prog_array_fd, &slot, &prog_fd, BPF_ANY);
+        if (err)
+        {
+            log_err(conf, "fail: inserting allow_ipv4 into prog_array slot %d\n", slot);
+            allow_ipv4_bpf__destroy(obj);
+            return 1;
+        }
+
+        log_out(conf, "done: loaded allow_ipv4 at slot %d\n", slot);
+        // Note: we intentionally do NOT destroy obj here — the kernel
+        // holds a reference to the program via prog_array, but the
+        // skeleton's maps/progs FDs must stay open until pinned.
+        // For now, we leak the skeleton. Pinning is handled separately.
+        break;
+    }
+    case program_allow_port:
+    {
+        struct allow_port_bpf *obj = allow_port_bpf__open();
+        if (!obj)
+        {
+            log_err(conf, "fail: opening allow_port skeleton\n");
+            return 1;
+        }
+
+        err = bpf_map__reuse_fd(obj->maps.prog_array, prog_array_fd);
+        if (err)
+        {
+            log_err(conf, "fail: reusing prog_array for allow_port\n");
+            allow_port_bpf__destroy(obj);
+            return 1;
+        }
+
+        if (entry->has_input)
+        {
+            err = set_chain_rodata(obj->maps.rodata,
+                                   &entry->input.port, sizeof(entry->input.port),
+                                   slot);
+            if (err)
+            {
+                log_err(conf, "fail: setting rodata for allow_port\n");
+                allow_port_bpf__destroy(obj);
+                return 1;
+            }
+        }
+
+        err = allow_port_bpf__load(obj);
+        if (err)
+        {
+            libbpf_strerror(err, buf, sizeof(buf));
+            log_err(conf, "fail: loading allow_port: %s\n", buf);
+            allow_port_bpf__destroy(obj);
+            return 1;
+        }
+
+        int prog_fd = bpf_program__fd(obj->progs.allow_port);
+        err = bpf_map_update_elem(prog_array_fd, &slot, &prog_fd, BPF_ANY);
+        if (err)
+        {
+            log_err(conf, "fail: inserting allow_port into prog_array slot %d\n", slot);
+            allow_port_bpf__destroy(obj);
+            return 1;
+        }
+
+        log_out(conf, "done: loaded allow_port at slot %d\n", slot);
+        break;
+    }
+    case program_allow_dns:
+    {
+        struct allow_dns_bpf *obj = allow_dns_bpf__open();
+        if (!obj)
+        {
+            log_err(conf, "fail: opening allow_dns skeleton\n");
+            return 1;
+        }
+
+        err = bpf_map__reuse_fd(obj->maps.prog_array, prog_array_fd);
+        if (err)
+        {
+            log_err(conf, "fail: reusing prog_array for allow_dns\n");
+            allow_dns_bpf__destroy(obj);
+            return 1;
+        }
+
+        if (entry->has_input)
+        {
+            err = set_chain_rodata(obj->maps.rodata,
+                                   &entry->input.ip, sizeof(entry->input.ip),
+                                   slot);
+            if (err)
+            {
+                log_err(conf, "fail: setting rodata for allow_dns\n");
+                allow_dns_bpf__destroy(obj);
+                return 1;
+            }
+        }
+
+        err = allow_dns_bpf__load(obj);
+        if (err)
+        {
+            libbpf_strerror(err, buf, sizeof(buf));
+            log_err(conf, "fail: loading allow_dns: %s\n", buf);
+            allow_dns_bpf__destroy(obj);
+            return 1;
+        }
+
+        int prog_fd = bpf_program__fd(obj->progs.allow_dns);
+        err = bpf_map_update_elem(prog_array_fd, &slot, &prog_fd, BPF_ANY);
+        if (err)
+        {
+            log_err(conf, "fail: inserting allow_dns into prog_array slot %d\n", slot);
+            allow_dns_bpf__destroy(obj);
+            return 1;
+        }
+
+        log_out(conf, "done: loaded allow_dns at slot %d\n", slot);
+        break;
+    }
+    default:
+        log_err(conf, "fail: program '%s' does not support chaining\n",
+                g_programs_name[entry->program]);
+        return 1;
+    }
+
+    return 0;
+}
+
+/// Attach a chain of programs using the dispatcher + tail calls.
+///
+/// 1. Load and attach the dispatcher to TC
+/// 2. For each entry: load the program, set rodata, insert into prog_array
+/// 3. Pin prog_array to bpffs for persistence
+int attach_chain(struct config *conf,
+                 struct chain_entry *entries, int chain_len,
+                 after_attach_fn_t cb)
+{
+    int err;
+    char buf[100];
+    buf[sizeof(buf) - 1] = '\0';
+
+    if (chain_len < 1 || chain_len > MAX_CHAIN_LEN)
+    {
+        log_err(conf, "fail: chain length %d out of range [1, %d]\n",
+                chain_len, MAX_CHAIN_LEN);
+        return 1;
+    }
+
+    // 1. Load and attach the dispatcher
+    struct dispatcher_bpf *dispatcher = dispatcher_bpf__open();
+    if (!dispatcher)
+    {
+        log_err(conf, "fail: opening dispatcher skeleton\n");
+        return 1;
+    }
+
+    err = dispatcher_bpf__load(dispatcher);
+    if (err)
+    {
+        libbpf_strerror(err, buf, sizeof(buf));
+        log_err(conf, "fail: loading dispatcher: %s\n", buf);
+        goto destroy;
+    }
+
+    DECLARE_LIBBPF_OPTS(bpf_tc_hook, hook,
+                        .ifindex = conf->ifindex,
+                        .attach_point = conf->attach_point);
+    err = bpf_tc_hook_create(&hook);
+    if (err && err != -EEXIST)
+    {
+        libbpf_strerror(err, buf, sizeof(buf));
+        log_err(conf, "fail: creating the qdisc: %s\n", buf);
+        goto destroy;
+    }
+
+    int dispatcher_fd = bpf_program__fd(dispatcher->progs.dispatcher);
+    DECLARE_LIBBPF_OPTS(bpf_tc_opts, opts,
+                        .prog_fd = dispatcher_fd,
+                        .flags = BPF_TC_F_REPLACE);
+    err = bpf_tc_attach(&hook, &opts);
+    if (err)
+    {
+        libbpf_strerror(err, buf, sizeof(buf));
+        log_err(conf, "fail: attaching dispatcher: %s\n", buf);
+        goto cleanup_hook;
+    }
+    log_out(conf, "done: attached dispatcher\n");
+
+    // 2. Get the prog_array map FD from the dispatcher
+    int prog_array_fd = bpf_map__fd(dispatcher->maps.prog_array);
+    if (prog_array_fd < 0)
+    {
+        log_err(conf, "fail: getting prog_array fd\n");
+        goto cleanup_hook;
+    }
+
+    // 3. Pin prog_array to bpffs for persistence (best-effort).
+    //    In CLI mode the process stays alive holding FDs, so pinning
+    //    is not required. It only matters for CNI where the process
+    //    exits after attach. If bpffs is not mounted we continue.
+    char pin_dir[256];
+    char pin_path[256];
+    bool pinned = false;
+    snprintf(pin_dir, sizeof(pin_dir), "%s/%s", BPFFS_BASE, conf->ifname);
+    snprintf(pin_path, sizeof(pin_path), "%s/prog_array", pin_dir);
+    err = ensure_dir(pin_dir);
+    if (err)
+    {
+        log_out(conf, "warn: cannot create pin directory %s: %s (continuing without pinning)\n",
+                pin_dir, strerror(-err));
+    }
+    else
+    {
+        // Remove stale pin if it exists
+        unlink(pin_path);
+        err = bpf_map__pin(dispatcher->maps.prog_array, pin_path);
+        if (err)
+        {
+            libbpf_strerror(err, buf, sizeof(buf));
+            log_out(conf, "warn: pinning prog_array failed: %s (continuing without pinning)\n", buf);
+        }
+        else
+        {
+            pinned = true;
+            log_out(conf, "done: pinned prog_array to %s\n", pin_path);
+        }
+    }
+
+    // 4. Load each chain program
+    for (int i = 0; i < chain_len; i++)
+    {
+        err = load_chain_program(conf, &entries[i], prog_array_fd, (__u32)i);
+        if (err)
+        {
+            log_err(conf, "fail: loading chain program at slot %d\n", i);
+            goto cleanup_pins;
+        }
+    }
+
+    log_out(conf, "done: chain of %d programs attached\n", chain_len);
+
+    // 5. Callback (e.g., wait for signal in CLI mode)
+    err = cb(hook, opts);
+
+    // 6. Cleanup
+    if (conf->cleanup_on_exit)
+    {
+        goto cleanup_pins;
+    }
+
+    // If not cleaning up, just destroy the skeleton (FDs are pinned)
+    dispatcher_bpf__destroy(dispatcher);
+    return 0;
+
+cleanup_pins:
+    if (conf->cleanup_on_exit && pinned)
+    {
+        unlink(pin_path);
+        // Remove pin directory (ignore errors — may not be empty)
+        rmdir(pin_dir);
+    }
+
+cleanup_hook:
+    if (conf->cleanup_on_exit)
+    {
+        opts.prog_fd = opts.prog_id = 0;
+        opts.flags = 0;
+        bpf_tc_detach(&hook, &opts);
+        log_out(conf, "done: detached dispatcher\n");
+
+        hook.attach_point |= BPF_TC_INGRESS;
+        bpf_tc_hook_destroy(&hook);
+        log_out(conf, "done: destroyed qdisc\n");
+    }
+
+destroy:
+    dispatcher_bpf__destroy(dispatcher);
+    return err < 0 ? -err : err;
+}
+
+#endif // TRAFFICO_CHAIN_H

--- a/api/chain.h
+++ b/api/chain.h
@@ -100,7 +100,7 @@ static int load_chain_program(struct config *conf,
         err = bpf_map__reuse_fd(obj->maps.prog_array, prog_array_fd);
         if (err)
         {
-            log_err(conf, "fail: reusing prog_array for allow_ipv4v4v4\n");
+            log_err(conf, "fail: reusing prog_array for allow_ipv4\n");
             allow_ipv4_bpf__destroy(obj);
             return 1;
         }
@@ -113,7 +113,7 @@ static int load_chain_program(struct config *conf,
                                    slot);
             if (err)
             {
-                log_err(conf, "fail: setting rodata for allow_ipv4v4\n");
+                log_err(conf, "fail: setting rodata for allow_ipv4\n");
                 allow_ipv4_bpf__destroy(obj);
                 return 1;
             }

--- a/api/chain.h
+++ b/api/chain.h
@@ -255,11 +255,24 @@ static int load_chain_program(struct config *conf,
     return 0;
 }
 
+/// Returns true if the given program supports chaining.
+static inline bool program_supports_chaining(program_t program)
+{
+    return program == program_allow_ipv4 ||
+           program == program_allow_port ||
+           program == program_allow_dns;
+}
+
 /// Attach a chain of programs using the dispatcher + tail calls.
 ///
-/// 1. Load and attach the dispatcher to TC
-/// 2. For each entry: load the program, set rodata, insert into prog_array
-/// 3. Pin prog_array to bpffs for persistence
+/// 1. Validate all chain entries before touching TC
+/// 2. Load and attach the dispatcher to TC
+/// 3. For each entry: load the program, set rodata, insert into prog_array
+/// 4. Pin prog_array to bpffs for persistence
+///
+/// On failure, always cleans up resources created by this call,
+/// regardless of cleanup_on_exit. The --no-cleanup flag only preserves
+/// state after a successful attach.
 int attach_chain(struct config *conf,
                  struct chain_entry *entries, int chain_len,
                  after_attach_fn_t cb)
@@ -275,7 +288,18 @@ int attach_chain(struct config *conf,
         return 1;
     }
 
-    // 1. Load and attach the dispatcher
+    // 1. Validate all chain entries before attaching anything
+    for (int i = 0; i < chain_len; i++)
+    {
+        if (!program_supports_chaining(entries[i].program))
+        {
+            log_err(conf, "fail: program '%s' does not support chaining\n",
+                    g_programs_name[entries[i].program]);
+            return 1;
+        }
+    }
+
+    // 2. Load and attach the dispatcher
     struct dispatcher_bpf *dispatcher = dispatcher_bpf__open();
     if (!dispatcher)
     {
@@ -355,52 +379,68 @@ int attach_chain(struct config *conf,
         }
     }
 
-    // 4. Load each chain program
+    // 5. Load each chain program
     for (int i = 0; i < chain_len; i++)
     {
         err = load_chain_program(conf, &entries[i], prog_array_fd, (__u32)i);
         if (err)
         {
             log_err(conf, "fail: loading chain program at slot %d\n", i);
-            goto cleanup_pins;
+            // Always clean up on failure — a partial chain with an
+            // attached dispatcher is worse than no chain at all.
+            goto cleanup_failure;
         }
     }
 
     log_out(conf, "done: chain of %d programs attached\n", chain_len);
 
-    // 5. Callback (e.g., wait for signal in CLI mode)
+    // 6. Callback (e.g., wait for signal in CLI mode)
     err = cb(hook, opts);
 
-    // 6. Cleanup
+    // 7. Cleanup after callback returns (normal exit path)
     if (conf->cleanup_on_exit)
     {
-        goto cleanup_pins;
+        goto cleanup_success;
     }
 
     // If not cleaning up, just destroy the skeleton (FDs are pinned)
     dispatcher_bpf__destroy(dispatcher);
     return 0;
 
-cleanup_pins:
-    if (conf->cleanup_on_exit && pinned)
+cleanup_failure:
+    // On failure, always clean up regardless of --no-cleanup.
+    // A partially attached chain is a security risk.
+    if (pinned)
     {
         unlink(pin_path);
-        // Remove pin directory (ignore errors — may not be empty)
+        rmdir(pin_dir);
+    }
+    opts.prog_fd = opts.prog_id = 0;
+    opts.flags = 0;
+    bpf_tc_detach(&hook, &opts);
+    log_out(conf, "done: detached dispatcher (failure cleanup)\n");
+    hook.attach_point |= BPF_TC_INGRESS;
+    bpf_tc_hook_destroy(&hook);
+    log_out(conf, "done: destroyed qdisc (failure cleanup)\n");
+    dispatcher_bpf__destroy(dispatcher);
+    return err < 0 ? -err : err;
+
+cleanup_success:
+    if (pinned)
+    {
+        unlink(pin_path);
         rmdir(pin_dir);
     }
 
 cleanup_hook:
-    if (conf->cleanup_on_exit)
-    {
-        opts.prog_fd = opts.prog_id = 0;
-        opts.flags = 0;
-        bpf_tc_detach(&hook, &opts);
-        log_out(conf, "done: detached dispatcher\n");
+    opts.prog_fd = opts.prog_id = 0;
+    opts.flags = 0;
+    bpf_tc_detach(&hook, &opts);
+    log_out(conf, "done: detached dispatcher\n");
 
-        hook.attach_point |= BPF_TC_INGRESS;
-        bpf_tc_hook_destroy(&hook);
-        log_out(conf, "done: destroyed qdisc\n");
-    }
+    hook.attach_point |= BPF_TC_INGRESS;
+    bpf_tc_hook_destroy(&hook);
+    log_out(conf, "done: destroyed qdisc\n");
 
 destroy:
     dispatcher_bpf__destroy(dispatcher);

--- a/api/chain.h
+++ b/api/chain.h
@@ -273,13 +273,13 @@ static inline bool program_supports_chaining(program_t program)
 /// Attach a chain of programs using the dispatcher + tail calls.
 ///
 /// 1. Validate all chain entries before touching TC
-/// 2. Load and attach the dispatcher to TC
-/// 3. For each entry: load the program, set rodata, insert into prog_array
-/// 4. Pin prog_array to bpffs for persistence
+/// 2. Load the dispatcher (off-path, not yet attached to TC)
+/// 3. Get prog_array FD, pin it (best-effort)
+/// 4. Load each chain program and populate prog_array
+/// 5. Attach the fully populated dispatcher to TC
 ///
-/// On failure, always cleans up resources created by this call,
-/// regardless of cleanup_on_exit. The --no-cleanup flag only preserves
-/// state after a successful attach.
+/// Pre-attach failures leave existing TC state untouched.
+/// The --no-cleanup flag only preserves state after a successful attach.
 int attach_chain(struct config *conf,
                  struct chain_entry *entries, int chain_len,
                  after_attach_fn_t cb)
@@ -306,7 +306,9 @@ int attach_chain(struct config *conf,
         }
     }
 
-    // 2. Load and attach the dispatcher
+    // 2. Load the dispatcher and populate its prog_array before replacing
+    // any live TC filter. Until slot 0 is populated, dispatcher falls back to
+    // TC_ACT_OK, so attaching it early creates a fail-open window.
     struct dispatcher_bpf *dispatcher = dispatcher_bpf__open();
     if (!dispatcher)
     {
@@ -322,45 +324,23 @@ int attach_chain(struct config *conf,
         goto destroy;
     }
 
-    DECLARE_LIBBPF_OPTS(bpf_tc_hook, hook,
-                        .ifindex = conf->ifindex,
-                        .attach_point = conf->attach_point);
-    err = bpf_tc_hook_create(&hook);
-    if (err && err != -EEXIST)
-    {
-        libbpf_strerror(err, buf, sizeof(buf));
-        log_err(conf, "fail: creating the qdisc: %s\n", buf);
-        goto destroy;
-    }
+    char pin_dir[256];
+    char pin_path[256];
+    bool pinned = false;
 
-    int dispatcher_fd = bpf_program__fd(dispatcher->progs.dispatcher);
-    DECLARE_LIBBPF_OPTS(bpf_tc_opts, opts,
-                        .prog_fd = dispatcher_fd,
-                        .flags = BPF_TC_F_REPLACE);
-    err = bpf_tc_attach(&hook, &opts);
-    if (err)
-    {
-        libbpf_strerror(err, buf, sizeof(buf));
-        log_err(conf, "fail: attaching dispatcher: %s\n", buf);
-        goto cleanup_hook;
-    }
-    log_out(conf, "done: attached dispatcher\n");
-
-    // 2. Get the prog_array map FD from the dispatcher
+    // 3. Get the prog_array map FD from the dispatcher
     int prog_array_fd = bpf_map__fd(dispatcher->maps.prog_array);
     if (prog_array_fd < 0)
     {
         log_err(conf, "fail: getting prog_array fd\n");
-        goto cleanup_hook;
+        err = -ENOENT;
+        goto destroy;
     }
 
-    // 3. Pin prog_array to bpffs for persistence (best-effort).
+    // 4. Pin prog_array to bpffs for persistence (best-effort).
     //    In CLI mode the process stays alive holding FDs, so pinning
     //    is not required. It only matters for CNI where the process
     //    exits after attach. If bpffs is not mounted we continue.
-    char pin_dir[256];
-    char pin_path[256];
-    bool pinned = false;
     snprintf(pin_dir, sizeof(pin_dir), "%s/%s", BPFFS_BASE, conf->ifname);
     snprintf(pin_path, sizeof(pin_path), "%s/prog_array", pin_dir);
     err = ensure_dir(pin_dir);
@@ -386,25 +366,48 @@ int attach_chain(struct config *conf,
         }
     }
 
-    // 5. Load each chain program
+    // 5. Load each chain program before attaching the dispatcher.
     for (int i = 0; i < chain_len; i++)
     {
         err = load_chain_program(conf, &entries[i], prog_array_fd, (__u32)i);
         if (err)
         {
             log_err(conf, "fail: loading chain program at slot %d\n", i);
-            // Always clean up on failure — a partial chain with an
-            // attached dispatcher is worse than no chain at all.
-            goto cleanup_failure;
+            goto cleanup_pre_attach;
         }
     }
 
+    // 6. Attach the fully populated dispatcher. bpf_tc_attach() is the
+    // first point at which packets can enter this chain.
+    DECLARE_LIBBPF_OPTS(bpf_tc_hook, hook,
+                        .ifindex = conf->ifindex,
+                        .attach_point = conf->attach_point);
+    err = bpf_tc_hook_create(&hook);
+    if (err && err != -EEXIST)
+    {
+        libbpf_strerror(err, buf, sizeof(buf));
+        log_err(conf, "fail: creating the qdisc: %s\n", buf);
+        goto cleanup_pre_attach;
+    }
+
+    int dispatcher_fd = bpf_program__fd(dispatcher->progs.dispatcher);
+    DECLARE_LIBBPF_OPTS(bpf_tc_opts, opts,
+                        .prog_fd = dispatcher_fd,
+                        .flags = BPF_TC_F_REPLACE);
+    err = bpf_tc_attach(&hook, &opts);
+    if (err)
+    {
+        libbpf_strerror(err, buf, sizeof(buf));
+        log_err(conf, "fail: attaching dispatcher: %s\n", buf);
+        goto cleanup_hook;
+    }
+    log_out(conf, "done: attached dispatcher\n");
     log_out(conf, "done: chain of %d programs attached\n", chain_len);
 
-    // 6. Callback (e.g., wait for signal in CLI mode)
+    // 7. Callback (e.g., wait for signal in CLI mode)
     err = cb(hook, opts);
 
-    // 7. Cleanup after callback returns (normal exit path)
+    // 8. Cleanup after callback returns (normal exit path)
     if (conf->cleanup_on_exit)
     {
         goto cleanup_success;
@@ -414,21 +417,13 @@ int attach_chain(struct config *conf,
     dispatcher_bpf__destroy(dispatcher);
     return 0;
 
-cleanup_failure:
-    // On failure, always clean up regardless of --no-cleanup.
-    // A partially attached chain is a security risk.
+cleanup_pre_attach:
+    // Pre-attach failure: do not touch existing TC state.
     if (pinned)
     {
         unlink(pin_path);
         rmdir(pin_dir);
     }
-    opts.prog_fd = opts.prog_id = 0;
-    opts.flags = 0;
-    bpf_tc_detach(&hook, &opts);
-    log_out(conf, "done: detached dispatcher (failure cleanup)\n");
-    hook.attach_point |= BPF_TC_INGRESS;
-    bpf_tc_hook_destroy(&hook);
-    log_out(conf, "done: destroyed qdisc (failure cleanup)\n");
     dispatcher_bpf__destroy(dispatcher);
     return err < 0 ? -err : err;
 
@@ -442,8 +437,10 @@ cleanup_success:
 cleanup_hook:
     opts.prog_fd = opts.prog_id = 0;
     opts.flags = 0;
-    bpf_tc_detach(&hook, &opts);
-    log_out(conf, "done: detached dispatcher\n");
+    if (bpf_tc_detach(&hook, &opts) == 0)
+    {
+        log_out(conf, "done: detached dispatcher\n");
+    }
 
     hook.attach_point |= BPF_TC_INGRESS;
     bpf_tc_hook_destroy(&hook);

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -318,6 +318,49 @@ sys.exit(0)
     echo "# can still ping ${VETH_ADDR} (ICMP not blocked by allow_port)" >&3
 }
 
+@test "chain allow_ip+allow_port allows matching traffic" {
+    new_server
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ip:${VETH_ADDR},allow_port:${SERVER_PORT}" >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can still reach ${VETH_ADDR}:${SERVER_PORT} (chain allows it)" >&3
+}
+
+@test "chain allow_ip+allow_port blocks non-matching IP" {
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 0 ]
+    echo "# can ping ${VETH_ADDR} from the namespace" >&3
+    # Allow only PEER_ADDR (not VETH_ADDR) on any port
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ip:${PEER_ADDR},allow_port:8787" >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 1 ]
+    echo "# cannot ping ${VETH_ADDR} (chain blocks wrong IP)" >&3
+}
+
+@test "chain allow_ip+allow_port blocks non-matching port" {
+    new_server
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
+    # Allow VETH_ADDR but only port 9999 (not SERVER_PORT)
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ip:${VETH_ADDR},allow_port:9999" >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ ! $status -eq 0 ]
+    echo "# cannot reach ${VETH_ADDR}:${SERVER_PORT} (chain blocks wrong port)" >&3
+}
+
 @test "block_private_ipv4 blocks ICMP packets" {
     run ip netns exec "${NETNS}" ping -W1 -4 -c1 10.22.1.2
     [ $status -eq 0 ]

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -318,12 +318,12 @@ sys.exit(0)
     echo "# can still ping ${VETH_ADDR} (ICMP not blocked by allow_port)" >&3
 }
 
-@test "chain allow_ip+allow_port allows matching traffic" {
+@test "chain allow_ipv4+allow_port allows matching traffic" {
     new_server
     run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
     [ $status -eq 0 ]
     echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
-    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ip:${VETH_ADDR},allow_port:${SERVER_PORT}" >/dev/null 3>&- &
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ipv4:${VETH_ADDR},allow_port:${SERVER_PORT}" >/dev/null 3>&- &
     sleep 1
     run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
     [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
@@ -332,12 +332,12 @@ sys.exit(0)
     echo "# can still reach ${VETH_ADDR}:${SERVER_PORT} (chain allows it)" >&3
 }
 
-@test "chain allow_ip+allow_port blocks non-matching IP" {
+@test "chain allow_ipv4+allow_port blocks non-matching IP" {
     run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
     [ $status -eq 0 ]
     echo "# can ping ${VETH_ADDR} from the namespace" >&3
     # Allow only PEER_ADDR (not VETH_ADDR) on any port
-    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ip:${PEER_ADDR},allow_port:8787" >/dev/null 3>&- &
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ipv4:${PEER_ADDR},allow_port:8787" >/dev/null 3>&- &
     sleep 1
     run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
     [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
@@ -346,13 +346,13 @@ sys.exit(0)
     echo "# cannot ping ${VETH_ADDR} (chain blocks wrong IP)" >&3
 }
 
-@test "chain allow_ip+allow_port blocks non-matching port" {
+@test "chain allow_ipv4+allow_port blocks non-matching port" {
     new_server
     run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
     [ $status -eq 0 ]
     echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
     # Allow VETH_ADDR but only port 9999 (not SERVER_PORT)
-    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ip:${VETH_ADDR},allow_port:9999" >/dev/null 3>&- &
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ipv4:${VETH_ADDR},allow_port:9999" >/dev/null 3>&- &
     sleep 1
     run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
     [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -19,6 +19,7 @@ teardown() {
     echo "# teardown:" >&3
 
     killall traffico &>/dev/null || true
+    killall -9 python3 &>/dev/null || true
     del_server
     del_netdev
     del_netns "${NETNS}"

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -142,3 +142,39 @@ bats_require_minimum_version 1.7.0
     [ $status -eq 1 ]
     [ "${lines[0]}" == "traffico: too many arguments" ]
 }
+
+@test "--chain with unknown program" {
+    run traffico -i lo --chain "xxx:1.2.3.4"
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: unknown program in chain: 'xxx'" ]
+}
+
+@test "--chain with missing input for program that requires it" {
+    run traffico -i lo --chain "allow_ipv4"
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: program 'allow_ipv4' in chain requires an input value (use name:value)" ]
+}
+
+@test "--chain with invalid input" {
+    run traffico -i lo --chain "allow_ipv4:not.an.ip"
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: invalid IP address: 'not.an.ip'" ]
+}
+
+@test "--chain with too many entries" {
+    run traffico -i lo --chain "nop,nop,nop,nop,nop,nop,nop,nop,nop"
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: chain exceeds maximum of 8 programs" ]
+}
+
+@test "--chain mutually exclusive with positional args" {
+    run traffico -i lo --chain "nop" nop
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: --chain and positional PROGRAM arguments are mutually exclusive" ]
+}
+
+@test "--chain with empty string" {
+    run traffico -i lo --chain ""
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: --chain requires at least one program" ]
+}

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -162,9 +162,15 @@ bats_require_minimum_version 1.7.0
 }
 
 @test "--chain with too many entries" {
-    run traffico -i lo --chain "nop,nop,nop,nop,nop,nop,nop,nop,nop"
+    run traffico -i lo --chain "allow_ipv4:1.2.3.4,allow_ipv4:1.2.3.4,allow_ipv4:1.2.3.4,allow_ipv4:1.2.3.4,allow_ipv4:1.2.3.4,allow_ipv4:1.2.3.4,allow_ipv4:1.2.3.4,allow_ipv4:1.2.3.4,allow_ipv4:1.2.3.4"
     [ $status -eq 1 ]
     [ "${lines[0]}" == "traffico: chain exceeds maximum of 8 programs" ]
+}
+
+@test "--chain with unsupported program" {
+    run traffico -i lo --chain "nop"
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: program 'nop' does not support chaining" ]
 }
 
 @test "--chain mutually exclusive with positional args" {

--- a/traffico.c
+++ b/traffico.c
@@ -215,13 +215,18 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
 
         if (g_chain_arg)
         {
-            // Parse chain: comma-separated "name:input" or "name" entries
-            char chain_buf[1024];
-            snprintf(chain_buf, sizeof(chain_buf), "%s", g_chain_arg);
+            // Parse chain: comma-separated "name:input" or "name" entries.
+            // Tokenize g_chain_arg directly — argp guarantees the pointer
+            // remains valid through ARGP_KEY_FINI.
             char *saveptr = NULL;
-            char *token = strtok_r(chain_buf, ",", &saveptr);
-            while (token && g_chain_len < MAX_CHAIN_LEN)
+            char *token = strtok_r(g_chain_arg, ",", &saveptr);
+            while (token)
             {
+                if (g_chain_len >= MAX_CHAIN_LEN)
+                {
+                    argp_error(state, "chain exceeds maximum of %d programs", MAX_CHAIN_LEN);
+                }
+
                 char *colon = strchr(token, ':');
                 char *prog_name = token;
                 char *input_str = NULL;

--- a/traffico.c
+++ b/traffico.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <signal.h>
 #include <stdio.h>
 #include <string.h>
@@ -11,6 +12,7 @@
 
 #include "api.h"
 #include "api/input_parse.h"
+#include "api/chain.h"
 
 const char *argp_program_version = TOOL_NAME " 0.0";
 const char *argp_program_bug_address = "https://github.com/leodido/traffico/issues";
@@ -34,6 +36,9 @@ const char OPT_ATTACH_LONG[] = "at";
 const char OPT_ATTACH_ARG[] = "INGRESS|EGRESS";
 #define OPT_NO_CLEANUP_KEY 0x81
 const char OPT_NO_CLEANUP_LONG[] = "no-cleanup";
+#define OPT_CHAIN_KEY 0x82
+const char OPT_CHAIN_LONG[] = "chain";
+const char OPT_CHAIN_ARG[] = "PROG:INPUT,...";
 
 const struct argp_option argp_opts[] = {
 
@@ -42,12 +47,16 @@ const struct argp_option argp_opts[] = {
     {OPT_IFNAME_LONG, OPT_IFNAME_KEY, OPT_IFNAME_ARG, 0, "Interface to which to attach the filter\n(defaults to the default gateway interface)", 1},
     {OPT_ATTACH_LONG, OPT_ATTACH_KEY, OPT_ATTACH_ARG, 0, "Where to attach the filter (defaults to egress)", 1},
     {OPT_NO_CLEANUP_LONG, OPT_NO_CLEANUP_KEY, NULL, 0, "Do not detach the TC hook and filter at the exit", 1},
+    {OPT_CHAIN_LONG, OPT_CHAIN_KEY, OPT_CHAIN_ARG, 0, "Attach a chain of programs (e.g., allow_ipv4:10.0.0.1,allow_port:8080)", 1},
     {"", 0, 0, OPTION_DOC, 0, 0},
     {0} // .
 
 };
 
 static struct config g_config;
+static struct chain_entry g_chain[MAX_CHAIN_LEN];
+static int g_chain_len = 0;
+static char *g_chain_arg = NULL;
 
 #define log_erro(fmt, ...) \
     log_err(&g_config, fmt, ##__VA_ARGS__);
@@ -141,6 +150,9 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
     case OPT_NO_CLEANUP_KEY:
         g_config.cleanup_on_exit = false;
         break;
+    case OPT_CHAIN_KEY:
+        g_chain_arg = arg;
+        break;
 
     // Arguments
     case ARGP_KEY_ARG:
@@ -170,13 +182,21 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
         break;
 
     case ARGP_KEY_END:
-        if (state->arg_num == 0)
+        // In chain mode, positional args are not required
+        if (!g_chain_arg)
         {
-            argp_error(state, "program name is mandatory");
+            if (state->arg_num == 0)
+            {
+                argp_error(state, "program name is mandatory");
+            }
+            if (g_config.program == program_0)
+            {
+                argp_error(state, "argument '%s' is not a " TOOL_NAME " program", g_config.program_arg);
+            }
         }
-        if (g_config.program == program_0)
+        else if (state->arg_num > 0)
         {
-            argp_error(state, "argument '%s' is not a " TOOL_NAME " program", g_config.program_arg);
+            argp_error(state, "--chain and positional PROGRAM arguments are mutually exclusive");
         }
         break;
 
@@ -193,18 +213,81 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
             assert(g_config.ifindex != 0);
         }
 
-        // Parse input value based on the selected program
-        if (g_config.input_arg)
+        if (g_chain_arg)
         {
-            const char *err_msg = NULL;
-            if (parse_input(&g_config, g_config.input_arg, &err_msg) != 0)
+            // Parse chain: comma-separated "name:input" or "name" entries
+            char chain_buf[1024];
+            snprintf(chain_buf, sizeof(chain_buf), "%s", g_chain_arg);
+            char *saveptr = NULL;
+            char *token = strtok_r(chain_buf, ",", &saveptr);
+            while (token && g_chain_len < MAX_CHAIN_LEN)
             {
-                argp_error(state, "%s: '%s'", err_msg, g_config.input_arg);
+                char *colon = strchr(token, ':');
+                char *prog_name = token;
+                char *input_str = NULL;
+                if (colon)
+                {
+                    *colon = '\0';
+                    input_str = colon + 1;
+                }
+
+                // Look up program name
+                int found = 0;
+                for (int pi = 1; pi < NUM_PROGRAMS; pi++)
+                {
+                    if (strcasecmp(prog_name, g_programs_name[pi]) == 0)
+                    {
+                        g_chain[g_chain_len].program = (program_t)pi;
+                        found = 1;
+                        break;
+                    }
+                }
+                if (!found)
+                {
+                    argp_error(state, "unknown program in chain: '%s'", prog_name);
+                }
+
+                // Parse input for this program
+                if (input_str)
+                {
+                    struct config tmp = {0};
+                    tmp.program = g_chain[g_chain_len].program;
+                    const char *err_msg = NULL;
+                    if (parse_input(&tmp, input_str, &err_msg) != 0)
+                    {
+                        argp_error(state, "%s: '%s'", err_msg, input_str);
+                    }
+                    g_chain[g_chain_len].has_input = tmp.has_input;
+                    memcpy(&g_chain[g_chain_len].input, &tmp.input, sizeof(tmp.input));
+                }
+                else if (program_requires_input(g_chain[g_chain_len].program))
+                {
+                    argp_error(state, "program '%s' in chain requires an input value (use name:value)", prog_name);
+                }
+
+                g_chain_len++;
+                token = strtok_r(NULL, ",", &saveptr);
+            }
+            if (g_chain_len == 0)
+            {
+                argp_error(state, "--chain requires at least one program");
             }
         }
-        else if (program_requires_input(g_config.program))
+        else
         {
-            argp_error(state, "program '%s' requires an input argument", g_programs_name[g_config.program]);
+            // Single program mode: parse input value
+            if (g_config.input_arg)
+            {
+                const char *err_msg = NULL;
+                if (parse_input(&g_config, g_config.input_arg, &err_msg) != 0)
+                {
+                    argp_error(state, "%s: '%s'", err_msg, g_config.input_arg);
+                }
+            }
+            else if (program_requires_input(g_config.program))
+            {
+                argp_error(state, "program '%s' requires an input argument", g_programs_name[g_config.program]);
+            }
         }
         break;
 
@@ -277,6 +360,12 @@ int main(int argc, char **argv)
     libbpf_set_print(libbpf_print_fn);
 
     // Execute
+    if (g_chain_len > 0)
+    {
+        log_info("chain: %d programs\n", g_chain_len);
+        return attach_chain(&g_config, g_chain, g_chain_len, &await);
+    }
+
     log_info("prog: %s\n", g_programs_name[g_config.program]);
     return attach(&g_config, &await);
 }

--- a/traffico.c
+++ b/traffico.c
@@ -251,6 +251,10 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
                 {
                     argp_error(state, "unknown program in chain: '%s'", prog_name);
                 }
+                if (!program_supports_chaining(g_chain[g_chain_len].program))
+                {
+                    argp_error(state, "program '%s' does not support chaining", prog_name);
+                }
 
                 // Parse input for this program
                 if (input_str)


### PR DESCRIPTION
## Description

Userspace chain attachment logic and `--chain` CLI flag, building on the BPF tail-call infrastructure from #44.

**Chain attachment** (`api/chain.h`):
- `attach_chain()` loads the dispatcher, attaches it to TC, then loads each chain program with its rodata (input value + slot index) and inserts it into the shared `prog_array` via `bpf_map__reuse_fd()` + `bpf_map_update_elem()`
- `set_chain_rodata()` writes input at offset 0 and slot at the aligned offset, matching the BPF rodata layout
- Pinning to bpffs is **best-effort** — if `/sys/fs/bpf` is not mounted, the chain still works (the process holds FDs). This fixes the failure mode from the previous attempt where missing bpffs aborted the entire chain attachment
- Cleanup on exit: detaches TC hook, destroys qdisc, unpins if pinned

**CLI** (`traffico.c`):
- `--chain "allow_ip:10.0.0.1,allow_port:8080"` — comma-separated `name:input` pairs
- Mutually exclusive with positional `PROGRAM [INPUT]` arguments
- Reuses existing `parse_input()` for per-program input validation

**Tests** (`test/cli.bats`): 3 new chain functional tests (53 total, all passing):
- Chain allows traffic matching both IP and port
- Chain blocks traffic with non-matching IP
- Chain blocks traffic with non-matching port

Depends on #44 (dispatcher BPF infrastructure).

## How to test

```bash
xmake -y
sudo XMAKE_ROOT=y xmake run test
```

All 53 tests pass. Requires bpffs mounted for pinning (`sudo mount -t bpf bpf /sys/fs/bpf`), but chain works without it.

## Design notes

- `spec.md` included for reference — full design spec with architecture diagrams and acceptance criteria
- Only `allow_ip`, `allow_port`, `allow_dns` support chaining; `block_*` programs can be added later
- No CNI chain support yet (future PR per spec)