### PR TITLE
refactor: rename `block_ip` to `block_ipv4`

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -46,7 +46,7 @@ USAGE
 
         Programs that accept runtime input (marked [input] in --help) take it
         as a second positional argument:
-            traffico --ifname=eth0 block_ip 10.0.0.1
+            traffico --ifname=eth0 block_ipv4 10.0.0.1
             traffico --ifname=eth0 block_port 443
 
     traffico-cni
@@ -68,7 +68,7 @@ USAGE
 
         {
             "type": "traffico-cni",
-            "program": "block_ip",
+            "program": "block_ipv4",
             "input": "10.0.0.1",
             "attachPoint": "egress"
         }
@@ -114,8 +114,8 @@ BUILT-IN PROGRAMS
         block_private_ipv4 is a program that can be used to block
         private IPv4 addresses subnets allowing only SSH access on port 22.
 
-    block_ip
-        block_ip is a program that drops packets with destination equal to the
+    block_ipv4
+        block_ipv4 is a program that drops packets with destination equal to the
         input IPv4 address.
 
     block_port

--- a/api/input_parse.h
+++ b/api/input_parse.h
@@ -12,7 +12,7 @@ static int parse_input(struct config *conf, const char *input_str, const char **
 {
     switch (conf->program)
     {
-    case program_block_ip:
+    case program_block_ipv4:
     {
         struct in_addr addr;
         if (inet_pton(AF_INET, input_str, &addr) != 1)
@@ -48,7 +48,7 @@ static int parse_input(struct config *conf, const char *input_str, const char **
 // Returns true if the given program requires an input argument.
 static inline bool program_requires_input(program_t program)
 {
-    return program == program_block_ip || program == program_block_port;
+    return program == program_block_ipv4 || program == program_block_port;
 }
 
 #endif // TRAFFICO_INPUT_PARSE_H

--- a/bpf/block_ipv4.bpf.c
+++ b/bpf/block_ipv4.bpf.c
@@ -8,7 +8,7 @@ char LICENSE[] SEC("license") = "Dual BSD/GPL";
 const volatile __u32 input = 0; // address to block (host byte order)
 
 SEC("tc")
-int block_ip(struct __sk_buff *skb)
+int block_ipv4(struct __sk_buff *skb)
 {
     void *data_end = (void *)(unsigned long long)skb->data_end;
     void *data = (void *)(unsigned long long)skb->data;
@@ -18,13 +18,13 @@ int block_ip(struct __sk_buff *skb)
 
     if (data + l3_offset > data_end)
     {
-        bpf_printk("block_ip: [eth] size length check hit: continue");
+        bpf_printk("block_ipv4: [eth] size length check hit: continue");
         return TC_ACT_OK;
     }
 
     if (eth->h_proto != bpf_htons(ETH_P_IP))
     {
-        bpf_printk("block_ip: [eth] protocol is %d: continue", eth->h_proto);
+        bpf_printk("block_ipv4: [eth] protocol is %d: continue", eth->h_proto);
         return TC_ACT_OK;
     }
 
@@ -32,20 +32,20 @@ int block_ip(struct __sk_buff *skb)
     const int l4_offset = l3_offset + sizeof(*ip_header);
     if (data + l4_offset > data_end)
     {
-        bpf_printk("block_ip: [iph] size length check hit: continue");
+        bpf_printk("block_ipv4: [iph] size length check hit: continue");
         return TC_ACT_OK;
     }
 
     if (ip_is_fragment(skb, l3_offset))
     {
-        bpf_printk("block_ip: [iph] is fragment: continue");
+        bpf_printk("block_ipv4: [iph] is fragment: continue");
         return TC_ACT_OK;
     }
 
     u32 dest = bpf_ntohl(ip_header->daddr);
     if (dest == input)
     {
-        bpf_printk("block_ip: [iph] destination address is %pI4: block", ip_header->daddr);
+        bpf_printk("block_ipv4: [iph] destination address is %pI4: block", ip_header->daddr);
         return TC_ACT_SHOT;
     }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,7 +45,7 @@ traffico --ifname=eth0 --at=INGRESS block_private_ipv4
 Programs that accept runtime input (marked `[input]` in `--help`) take it as a second positional argument:
 
 ```bash
-traffico --ifname=eth0 block_ip 10.0.0.1
+traffico --ifname=eth0 block_ipv4 10.0.0.1
 traffico --ifname=eth0 block_port 443
 ```
 
@@ -72,7 +72,7 @@ Programs that accept runtime input use the `"input"` field:
 ```json
 {
     "type": "traffico-cni",
-    "program": "block_ip",
+    "program": "block_ipv4",
     "input": "10.0.0.1",
     "attachPoint": "egress"
 }
@@ -120,7 +120,7 @@ Here's an example CNI config file featuring `traffico-cni`.
 | Program | Description |
 |---|---|
 | `block_private_ipv4` | Blocks private IPv4 addresses subnets allowing only SSH access on port 22 |
-| `block_ip` | Drops packets with destination equal to the input IPv4 address |
+| `block_ipv4` | Drops packets with destination equal to the input IPv4 address |
 | `block_port` | Drops packets with the destination port equal to the input port number |
 | `nop` | A simple program that does nothing |
 

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -56,10 +56,10 @@ teardown() {
     run ip netns exec "${NETNS}" tc qdisc del dev "${PEER}" clsact
 }
 
-@test "block_ip blocks specific IP" {
+@test "block_ipv4 blocks specific IP" {
     run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
     [ $status -eq 0 ]
-    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress block_ip "${VETH_ADDR}" >/dev/null 3>&- &
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress block_ipv4 "${VETH_ADDR}" >/dev/null 3>&- &
     sleep 1
     run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
     [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -65,14 +65,14 @@ bats_require_minimum_version 1.7.0
     [ "${lines[0]}" == "traffico: option '--at' requires one of the following values: INGRESS|EGRESS" ]
 }
 
-@test "missing input for block_ip" {
-    run traffico -i lo block_ip
+@test "missing input for block_ipv4" {
+    run traffico -i lo block_ipv4
     [ $status -eq 1 ]
-    [ "${lines[0]}" == "traffico: program 'block_ip' requires an input argument" ]
+    [ "${lines[0]}" == "traffico: program 'block_ipv4' requires an input argument" ]
 }
 
-@test "invalid IP for block_ip" {
-    run traffico -i lo block_ip not.an.ip
+@test "invalid IP for block_ipv4" {
+    run traffico -i lo block_ipv4 not.an.ip
     [ $status -eq 1 ]
     [ "${lines[0]}" == "traffico: invalid IP address: 'not.an.ip'" ]
 }
@@ -102,7 +102,7 @@ bats_require_minimum_version 1.7.0
 }
 
 @test "too many arguments" {
-    run traffico -i lo block_ip 1.2.3.4 extra
+    run traffico -i lo block_ipv4 1.2.3.4 extra
     [ $status -eq 1 ]
     [ "${lines[0]}" == "traffico: too many arguments" ]
 }

--- a/test/cni.bats
+++ b/test/cni.bats
@@ -25,15 +25,15 @@ teardown() {
     del_server
 }
 
-@test "block_ip via CNI" {
+@test "block_ipv4 via CNI" {
     run curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
     [ $status -eq 0 ]
     echo "# can reach ${VETH_ADDR}:${SERVER_PORT}" >&3
     run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
     [ $status -eq 0 ]
     echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
-    echo "# installing block_ip in the namespace" >&3
-    run ip netns exec "${NETNS}" bash -c "cat '$FIXTURE_ROOT/attach_block_ip_in.json' | CNI_COMMAND=ADD traffico-cni"
+    echo "# installing block_ipv4 in the namespace" >&3
+    run ip netns exec "${NETNS}" bash -c "cat '$FIXTURE_ROOT/attach_block_ipv4_in.json' | CNI_COMMAND=ADD traffico-cni"
     [ $status -eq 0 ]
     echo "# attach ok" >&3
     run ip netns exec "${NETNS}" tc qdisc show dev peer0 clsact

--- a/test/cni.flags.bats
+++ b/test/cni.flags.bats
@@ -22,8 +22,8 @@ cni_add() {
     [[ "$output" == *'"msg":	"program does not accept input"'* ]]
 }
 
-@test "rejects missing input for block_ip" {
-    cni_add "block_ip"
+@test "rejects missing input for block_ipv4" {
+    cni_add "block_ipv4"
     [ ! $status -eq 0 ]
     [[ "$output" == *"program requires an"*"input"*"field"* ]]
 }

--- a/test/fixtures/cni/attach_block_ipv4_in.json
+++ b/test/fixtures/cni/attach_block_ipv4_in.json
@@ -16,7 +16,7 @@
         }
     },
     "type": "traffico-cni",
-    "program": "block_ip",
+    "program": "block_ipv4",
     "input": "10.22.1.1",
     "attachPoint": "egress"
 }

--- a/xmake/modules/api.lua
+++ b/xmake/modules/api.lua
@@ -4,7 +4,7 @@ import("core.project.project")
 -- Programs in this table have const volatile rodata that can be
 -- configured at runtime via the input union in struct config.
 local input_fields = {
-    block_ip = "ip",
+    block_ipv4 = "ip",
     block_port = "port",
 }
 


### PR DESCRIPTION
## Description

`block_ip` only inspects IPv4 (`ETH_P_IP`) and filters by IPv4 destination address. The name implies generic IP handling but it doesn't touch IPv6. Renaming to `block_ipv4` makes the scope unambiguous.

This establishes the naming convention for the `allow_ipv4` rename in PR #41.

## Changes

- Rename `bpf/block_ip.bpf.c` → `bpf/block_ipv4.bpf.c` (file, function, `bpf_printk` strings)
- Update `api.lua` input_fields key
- Update `input_parse.h` enum references
- Update `README.txt` and `docs/README.md`
- Rename test fixture and update all test files

Pure rename — no behavioral changes.