### PR TITLE
fix(bpf): fix IHL, fragment handling, and `block_private_ipv4` logic 

### DIFF
--- a/bpf/block_ipv4.bpf.c
+++ b/bpf/block_ipv4.bpf.c
@@ -35,8 +35,8 @@ int block_ipv4(struct __sk_buff *skb)
         return TC_ACT_OK;
     }
 
-    // daddr is in the fixed 20-byte IP header — no L4 offset or
-    // fragment handling needed. IHL validation is defense-in-depth.
+    // daddr is in the fixed 20-byte IP header: no L4 offset or fragment handling needed.
+    // IHL validation is defense-in-depth.
     __u8 ihl = ip_header->ihl;
     if (ihl < 5)
     {

--- a/bpf/block_ipv4.bpf.c
+++ b/bpf/block_ipv4.bpf.c
@@ -35,17 +35,12 @@ int block_ipv4(struct __sk_buff *skb)
         return TC_ACT_OK;
     }
 
+    // daddr is in the fixed 20-byte IP header — no L4 offset or
+    // fragment handling needed. IHL validation is defense-in-depth.
     __u8 ihl = ip_header->ihl;
     if (ihl < 5)
     {
         bpf_printk("block_ipv4: [iph] invalid IHL %d: continue", ihl);
-        return TC_ACT_OK;
-    }
-
-    const int l4_offset = l3_offset + (ihl * 4);
-    if (data + l4_offset > data_end)
-    {
-        bpf_printk("block_ipv4: [iph] IHL extends beyond packet: continue");
         return TC_ACT_OK;
     }
 

--- a/bpf/block_ipv4.bpf.c
+++ b/bpf/block_ipv4.bpf.c
@@ -29,16 +29,23 @@ int block_ipv4(struct __sk_buff *skb)
     }
 
     struct iphdr *ip_header = data + l3_offset;
-    const int l4_offset = l3_offset + sizeof(*ip_header);
-    if (data + l4_offset > data_end)
+    if (data + l3_offset + sizeof(*ip_header) > data_end)
     {
         bpf_printk("block_ipv4: [iph] size length check hit: continue");
         return TC_ACT_OK;
     }
 
-    if (ip_is_fragment(skb, l3_offset))
+    __u8 ihl = ip_header->ihl;
+    if (ihl < 5)
     {
-        bpf_printk("block_ipv4: [iph] is fragment: continue");
+        bpf_printk("block_ipv4: [iph] invalid IHL %d: continue", ihl);
+        return TC_ACT_OK;
+    }
+
+    const int l4_offset = l3_offset + (ihl * 4);
+    if (data + l4_offset > data_end)
+    {
+        bpf_printk("block_ipv4: [iph] IHL extends beyond packet: continue");
         return TC_ACT_OK;
     }
 

--- a/bpf/block_port.bpf.c
+++ b/bpf/block_port.bpf.c
@@ -29,17 +29,24 @@ int block_port(struct __sk_buff *skb)
     }
 
     struct iphdr *ip_header = data + l3_offset;
-    const int l4_offset = l3_offset + sizeof(*ip_header);
-
-    if (data + l4_offset > data_end)
+    if (data + l3_offset + sizeof(*ip_header) > data_end)
     {
         bpf_printk("block_port: [iph] size length check hit: continue");
         return TC_ACT_OK;
     }
 
-    if (ip_is_fragment(skb, l3_offset))
+    __u8 ihl = ip_header->ihl;
+    if (ihl < 5)
     {
-        bpf_printk("block_port: [iph] is fragment: continue");
+        bpf_printk("block_port: [iph] invalid IHL %d: continue", ihl);
+        return TC_ACT_OK;
+    }
+
+    const int l4_offset = l3_offset + (ihl * 4);
+
+    if (ip_is_subsequent_fragment(skb, l3_offset))
+    {
+        bpf_printk("block_port: [iph] subsequent fragment: continue");
         return TC_ACT_OK;
     }
 

--- a/bpf/block_private_ipv4.bpf.c
+++ b/bpf/block_private_ipv4.bpf.c
@@ -99,28 +99,24 @@ int block_private_ipv4(struct __sk_buff *skb)
         return TC_ACT_SHOT;
     }
 
-    // Only inspect TCP and UDP for port-22 exemption
-    if (ip_header->protocol != IPPROTO_TCP && ip_header->protocol != IPPROTO_UDP)
+    // SSH exemption: allow TCP responses from port 22 on private subnets.
+    // SSH is TCP-only — no UDP exemption.
+    if (ip_header->protocol == IPPROTO_TCP)
     {
-        bpf_printk("block_private_ipv4: [iph] protocol %d to private subnet: block", ip_header->protocol);
-        return TC_ACT_SHOT;
-    }
+        if (data + l4_offset + 4 > data_end)
+        {
+            bpf_printk("block_private_ipv4: [tcp] size length check hit: continue");
+            return TC_ACT_OK;
+        }
 
-    // Both TCP and UDP headers start with src_port (u16) then dst_port (u16)
-    if (data + l4_offset + 4 > data_end)
-    {
-        bpf_printk("block_private_ipv4: [l4] size length check hit: continue");
-        return TC_ACT_OK;
-    }
+        __u16 *src_port_ptr = (__u16 *)(data + l4_offset);
+        __u16 src_port = bpf_ntohs(*src_port_ptr);
 
-    __u16 *src_port_ptr = (__u16 *)(data + l4_offset);
-    __u16 src_port = bpf_ntohs(*src_port_ptr);
-
-    // Exempt SSH responses (source port 22) from private subnets
-    if (src_port == 22)
-    {
-        bpf_printk("block_private_ipv4: [l4] source port 22 from private subnet: allow");
-        return TC_ACT_OK;
+        if (src_port == 22)
+        {
+            bpf_printk("block_private_ipv4: [tcp] source port 22 from private subnet: allow");
+            return TC_ACT_OK;
+        }
     }
 
     bpf_printk("block_private_ipv4: [iph] destination is on a private subnet: block");

--- a/bpf/block_private_ipv4.bpf.c
+++ b/bpf/block_private_ipv4.bpf.c
@@ -41,34 +41,41 @@ int block_private_ipv4(struct __sk_buff *skb)
 
     if (data + l3_offset > data_end)
     {
-        bpf_printk("classifier: [eth] size length check hit: continue");
+        bpf_printk("block_private_ipv4: [eth] size length check hit: continue");
         return TC_ACT_OK;
     }
 
     if (eth->h_proto != bpf_htons(ETH_P_IP))
     {
-        bpf_printk("classifier: [eth] protocol is %d: continue", eth->h_proto);
+        bpf_printk("block_private_ipv4: [eth] protocol is %d: continue", eth->h_proto);
         return TC_ACT_OK;
     }
 
     struct iphdr *ip_header = data + l3_offset;
-    const int l4_offset = l3_offset + sizeof(*ip_header);
-
-    if (data + l4_offset > data_end)
+    if (data + l3_offset + sizeof(*ip_header) > data_end)
     {
-        bpf_printk("classifier: [iph] size length check hit: continue");
+        bpf_printk("block_private_ipv4: [iph] size length check hit: continue");
         return TC_ACT_OK;
     }
 
+    __u8 ihl = ip_header->ihl;
+    if (ihl < 5)
+    {
+        bpf_printk("block_private_ipv4: [iph] invalid IHL %d: continue", ihl);
+        return TC_ACT_OK;
+    }
+
+    const int l4_offset = l3_offset + (ihl * 4);
+
     if (ip_header->protocol == IPPROTO_ICMP)
     {
-        bpf_printk("classifier: [iph] is icmp, shot");
+        bpf_printk("block_private_ipv4: [iph] is icmp, shot");
         return TC_ACT_SHOT;
     }
 
-    if (ip_is_fragment(skb, l3_offset))
+    if (ip_is_subsequent_fragment(skb, l3_offset))
     {
-        bpf_printk("classifier: [iph] is fragment: continue");
+        bpf_printk("block_private_ipv4: [iph] subsequent fragment: continue");
         return TC_ACT_OK;
     }
 
@@ -77,7 +84,7 @@ int block_private_ipv4(struct __sk_buff *skb)
 
     if (data + l7_offset > data_end)
     {
-        bpf_printk("classifier: [tcph] size length check hit: continue");
+        bpf_printk("block_private_ipv4: [tcph] size length check hit: continue");
         return TC_ACT_OK;
     }
 

--- a/bpf/block_private_ipv4.bpf.c
+++ b/bpf/block_private_ipv4.bpf.c
@@ -32,7 +32,6 @@ static struct subnet blocked_subnets[] = {
 SEC("tc")
 int block_private_ipv4(struct __sk_buff *skb)
 {
-    bpf_printk("=============================================");
     void *data_end = (void *)(unsigned long long)skb->data_end;
     void *data = (void *)(unsigned long long)skb->data;
 
@@ -67,55 +66,63 @@ int block_private_ipv4(struct __sk_buff *skb)
 
     const int l4_offset = l3_offset + (ihl * 4);
 
-    if (ip_header->protocol == IPPROTO_ICMP)
-    {
-        bpf_printk("block_private_ipv4: [iph] is icmp, shot");
-        return TC_ACT_SHOT;
-    }
-
     if (ip_is_subsequent_fragment(skb, l3_offset))
     {
         bpf_printk("block_private_ipv4: [iph] subsequent fragment: continue");
         return TC_ACT_OK;
     }
 
-    struct tcphdr *tcp = (struct tcphdr *)(data + l4_offset);
-    const int l7_offset = l4_offset + sizeof(*tcp);
-
-    if (data + l7_offset > data_end)
-    {
-        bpf_printk("block_private_ipv4: [tcph] size length check hit: continue");
-        return TC_ACT_OK;
-    }
-
-    bpf_printk("daddr: %d", ip_header->daddr);
-    bpf_printk("saddr: %d", ip_header->saddr);
-
-    u16 tcp_dest_nl = bpf_ntohs(tcp->dest);
-    u16 tcp_source_nl = bpf_ntohs(tcp->source);
-
+    // Check destination against private subnets
+    u32 dest = ip_header->daddr;
+    bool is_private = false;
     for (int i = 0; i < sizeof(blocked_subnets) / sizeof(struct subnet); i++)
     {
         u32 netmask = bpf_htonl(blocked_subnets[i].netmask);
         u32 subnetip = bpf_htonl(blocked_subnets[i].subnet);
 
-        bpf_printk("ip_header->daddr & netmask: %d", ip_header->daddr & netmask);
-        bpf_printk("subnetip & netmask: %d", subnetip & netmask);
-        bpf_printk("tcp dest port: %d", tcp_dest_nl);
-        bpf_printk("tcp source port: %d", tcp_source_nl);
-
-        if ((ip_header->daddr & netmask) == (subnetip & netmask))
+        if ((dest & netmask) == (subnetip & netmask))
         {
-            if (tcp_source_nl == 22)
-            {
-                bpf_printk("even though it matched, the source port is 22, so we will allow it");
-                return TC_ACT_OK;
-            }
-
-            bpf_printk("daddr is on a blocked subnet, shot");
-            return TC_ACT_SHOT;
+            is_private = true;
+            break;
         }
     }
 
-    return TC_ACT_OK;
+    if (!is_private)
+    {
+        return TC_ACT_OK;
+    }
+
+    // Destination is a private subnet — block ICMP unconditionally
+    if (ip_header->protocol == IPPROTO_ICMP)
+    {
+        bpf_printk("block_private_ipv4: [iph] ICMP to private subnet: block");
+        return TC_ACT_SHOT;
+    }
+
+    // Only inspect TCP and UDP for port-22 exemption
+    if (ip_header->protocol != IPPROTO_TCP && ip_header->protocol != IPPROTO_UDP)
+    {
+        bpf_printk("block_private_ipv4: [iph] protocol %d to private subnet: block", ip_header->protocol);
+        return TC_ACT_SHOT;
+    }
+
+    // Both TCP and UDP headers start with src_port (u16) then dst_port (u16)
+    if (data + l4_offset + 4 > data_end)
+    {
+        bpf_printk("block_private_ipv4: [l4] size length check hit: continue");
+        return TC_ACT_OK;
+    }
+
+    __u16 *src_port_ptr = (__u16 *)(data + l4_offset);
+    __u16 src_port = bpf_ntohs(*src_port_ptr);
+
+    // Exempt SSH responses (source port 22) from private subnets
+    if (src_port == 22)
+    {
+        bpf_printk("block_private_ipv4: [l4] source port 22 from private subnet: allow");
+        return TC_ACT_OK;
+    }
+
+    bpf_printk("block_private_ipv4: [iph] destination is on a private subnet: block");
+    return TC_ACT_SHOT;
 }

--- a/bpf/block_private_ipv4.bpf.c
+++ b/bpf/block_private_ipv4.bpf.c
@@ -92,7 +92,7 @@ int block_private_ipv4(struct __sk_buff *skb)
         return TC_ACT_OK;
     }
 
-    // Destination is a private subnet — block ICMP unconditionally
+    // Destination is a private subnet: block ICMP unconditionally
     if (ip_header->protocol == IPPROTO_ICMP)
     {
         bpf_printk("block_private_ipv4: [iph] ICMP to private subnet: block");
@@ -100,7 +100,7 @@ int block_private_ipv4(struct __sk_buff *skb)
     }
 
     // SSH exemption: allow TCP responses from port 22 on private subnets.
-    // SSH is TCP-only — no UDP exemption.
+    // SSH is TCP-only, no UDP exemption.
     if (ip_header->protocol == IPPROTO_TCP)
     {
         if (data + l4_offset + 4 > data_end)

--- a/bpf/commons.bpf.h
+++ b/bpf/commons.bpf.h
@@ -31,7 +31,7 @@ static inline int ip_is_fragment(struct __sk_buff *skb, u64 nhoff)
 }
 
 /// Returns true only for subsequent fragments (offset > 0).
-/// First fragments (MF=1, offset=0) return false — they carry L4 headers.
+/// First fragments (MF=1, offset=0) return false (they carry L4 headers).
 static inline int ip_is_subsequent_fragment(struct __sk_buff *skb, u64 nhoff)
 {
     return load_half(skb, nhoff + offsetof(struct iphdr, frag_off)) & IP_OFFSET;

--- a/bpf/commons.bpf.h
+++ b/bpf/commons.bpf.h
@@ -30,6 +30,13 @@ static inline int ip_is_fragment(struct __sk_buff *skb, u64 nhoff)
     return load_half(skb, nhoff + offsetof(struct iphdr, frag_off)) & (IP_MF | IP_OFFSET);
 }
 
+/// Returns true only for subsequent fragments (offset > 0).
+/// First fragments (MF=1, offset=0) return false — they carry L4 headers.
+static inline int ip_is_subsequent_fragment(struct __sk_buff *skb, u64 nhoff)
+{
+    return load_half(skb, nhoff + offsetof(struct iphdr, frag_off)) & IP_OFFSET;
+}
+
 /// \brief Our own definition of the bpf_trace_printk tracepoint struct.
 ///
 /// Defining it we avoid depending on the latest vmlinux.h file.


### PR DESCRIPTION
## Problem

Three bugs affected the main-branch BPF programs, plus several pre-existing logic errors in `block_private_ipv4`:

1. **IHL bug** (closes #35): all programs used `sizeof(struct iphdr)` (fixed 20 bytes) for the L4 header offset. Packets with IP options (IHL > 5) caused `block_port` and `block_private_ipv4` to read L4 data at the wrong offset.

2. **Fragment bypass**: all programs skipped fragments entirely via `ip_is_fragment()`, which catches both first fragments (offset=0, MF=1) and subsequent fragments (offset>0). First fragments carry L4 headers and can be inspected. For `block_ipv4`, `daddr` is always present — the skip was a pure bypass.

3. **Stale printk prefix**: `block_private_ipv4` used `"classifier:"` instead of `"block_private_ipv4:"`.

4. **`block_private_ipv4` ICMP ordering**: ICMP was dropped unconditionally *before* the subnet check — ICMP to non-private IPs (e.g., `8.8.8.8`) was incorrectly blocked.

5. **`block_private_ipv4` TCP-only assumption**: L4 header was unconditionally cast to `struct tcphdr *`. Non-TCP/UDP protocols (GRE, IPIP, etc.) had their bytes misinterpreted as port values, potentially false-matching the port-22 SSH exemption.

6. **`block_private_ipv4` L4 bounds check**: used `sizeof(tcphdr)` (20 bytes) which is wrong for UDP (8 bytes), rejecting valid short UDP packets.

7. **`block_private_ipv4` UDP port-22 exemption**: the SSH exemption allowed both TCP and UDP with source port 22. SSH is TCP-only — UDP source port 22 is not SSH traffic.

## Changes

### `commons.bpf.h`
- New `ip_is_subsequent_fragment()` helper — returns true only for fragments with offset > 0 (no L4 headers). First fragments (MF=1, offset=0) return false.

### `block_ipv4`
- IHL >= 5 validation (defense-in-depth; `daddr` is in the fixed header).
- Removed unused `l4_offset` computation and bounds check.
- Removed fragment skip (`daddr` is always readable).
- Added comment explaining why no L4 offset or fragment handling is needed.

### `block_port`
- IHL-based L4 offset (`ihl * 4` instead of `sizeof(iphdr)`).
- IHL >= 5 validation.
- `ip_is_fragment()` → `ip_is_subsequent_fragment()`: first fragments now inspected, subsequent fragments pass through (fail-open).

### `block_private_ipv4`
- IHL-based L4 offset.
- IHL >= 5 validation.
- `ip_is_fragment()` → `ip_is_subsequent_fragment()`.
- **Restructured logic**: subnet check runs first. ICMP drop now only applies to private destinations.
- **Added protocol guard**: only TCP proceeds to port-22 exemption. All other protocols (UDP, GRE, IPIP, etc.) to private subnets are blocked unconditionally.
- **Restricted SSH exemption to TCP**: only `IPPROTO_TCP` with source port 22 is exempted. UDP port 22 is not SSH.
- **Fixed L4 bounds check**: 4 bytes (src+dst port) instead of `sizeof(tcphdr)`.
- Fixed stale `"classifier:"` printk prefix.
- Removed debug separator `bpf_printk("=====...")` and verbose per-packet logging.

## Boundary check behavior

All programs are `block_*` (fail-open). Boundary check failures return `TC_ACT_OK`. The `allow_*` programs use fail-closed (`TC_ACT_SHOT`) — that's handled in PRs #41–#43.

## Test coverage gap

The existing tests use `curl` in network namespaces and only cover basic attach-and-block with normal packets. There are no tests for IP options (IHL > 5), fragmented packets, or the ICMP/protocol changes. Crafting these packets requires `scapy` or raw sockets. Tracked for follow-up.

## Note on the `block_ip` → `block_ipv4` rename

The rename is **not part of this PR**. It was merged separately in PR #46. This branch forks from `main` after that merge (`a7622b0`). The diff may appear to include rename changes if compared against a stale `main`.