### PR TITLE
test: add Scapy-backed advanced packet regression tests

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/archlinux:latest
 
 RUN pacman -Syy --noconfirm
-RUN pacman -S --noconfirm nodejs clang llvm gcc linux-headers bpf unzip docker vi vim cmake gdb tree
+RUN pacman -S --noconfirm nodejs clang llvm gcc linux-headers bpf unzip docker vi vim cmake gdb tree python-scapy
 
 RUN pacman -S --noconfirm --needed git base-devel
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ jobs:
             clang llvm gcc \
             linux-headers-$(uname -r) \
             libelf-dev zlib1g-dev \
-            curl iproute2 iputils-ping
+            curl iproute2 iputils-ping \
+            python3-scapy
 
       - name: Install xmake
         run: |
@@ -51,7 +52,8 @@ jobs:
           pacman -S --noconfirm \
             clang llvm gcc linux-headers bpf \
             make cmake xmake sudo diffutils \
-            curl iproute2 iputils
+            curl iproute2 iputils \
+            python-scapy
 
       - name: Configure
         run: xmake f -y --generate-vmlinux=y

--- a/docs/README.md
+++ b/docs/README.md
@@ -154,3 +154,5 @@ To run the test suite you can do this:
 xmake -b test
 xmake run test
 ```
+
+The full test suite includes Scapy-backed advanced packet tests that exercise IP options, fragmentation, and protocol-specific behavior. These require the `python-scapy` (Arch) or `python3-scapy` (Ubuntu) package. If Scapy is not installed, the advanced tests are skipped automatically.

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+SCAPY_HELPER="$BATS_TEST_DIRNAME/scapy_packets.py"
+SCAPY_SNIFF_TIMEOUT="${SCAPY_SNIFF_TIMEOUT:-2}"
+
 fixtures() {
   FIXTURE_ROOT="$BATS_TEST_DIRNAME/fixtures/$1"
   # shellcheck disable=SC2034
@@ -10,4 +13,77 @@ setsuite() {
   local PREFIX
   PREFIX="$(basename "$BATS_TEST_FILENAME" .bats)"
   echo "${PREFIX%%.*}: "
+}
+
+# Start a background sniffer on IFACE matching packets with IP_ID.
+# Usage: start_sniffer IFACE IP_ID [SRC_IP] [DST_IP]
+start_sniffer() {
+  local iface="$1" ip_id="$2" src_ip="${3:-}" dst_ip="${4:-}"
+  local sniff_args=(--iface "$iface" --ip-id "$ip_id" --timeout "$SCAPY_SNIFF_TIMEOUT")
+  [ -n "$src_ip" ] && sniff_args+=(--src-ip "$src_ip")
+  [ -n "$dst_ip" ] && sniff_args+=(--dst-ip "$dst_ip")
+
+  python3 "$SCAPY_HELPER" sniff "${sniff_args[@]}" &
+  SNIFFER_PID=$!
+  SNIFFER_STATUS_FILE="$BATS_TEST_TMPDIR/sniffer_status"
+  # Brief settle time for the sniffer to attach
+  sleep 0.3
+}
+
+# Wait for the background sniffer and capture its exit code.
+# Returns: 0 if packet was seen, 1 if timeout (not seen).
+wait_sniffer() {
+  local rc=0
+  wait "$SNIFFER_PID" || rc=$?
+  echo "$rc" > "$SNIFFER_STATUS_FILE"
+  return $rc
+}
+
+# Send a crafted packet from inside a namespace.
+# Usage: scapy_send NETNS IFACE [args...]
+# All args after IFACE are passed to scapy_packets.py send.
+scapy_send() {
+  local netns="$1" iface="$2"
+  shift 2
+  ip netns exec "$netns" python3 "$SCAPY_HELPER" send --iface "$iface" "$@"
+}
+
+# Populate ARP caches so Scapy probes don't get lost waiting for ARP.
+arp_prewarm() {
+  local netns="$1"
+  ip netns exec "$netns" ping -W1 -4 -c1 "$VETH_ADDR" &>/dev/null || true
+  sleep 0.1
+}
+
+# Assert a packet is seen on the wire (allowed by BPF).
+# Usage: assert_packet_seen NETNS IP_ID [send_args...]
+# Starts sniffer on VETH, sends from PEER inside NETNS, asserts sniffer sees it.
+assert_packet_seen() {
+  local netns="$1" ip_id="$2"
+  shift 2
+
+  start_sniffer "$VETH" "$ip_id"
+  scapy_send "$netns" "$PEER" --ip-id "$ip_id" "$@"
+  wait_sniffer
+  local rc=$?
+  [ $rc -eq 0 ] || {
+    echo "# FAIL: expected packet (ip_id=$ip_id) to be seen on $VETH but it was not" >&3
+    return 1
+  }
+}
+
+# Assert a packet is NOT seen on the wire (blocked by BPF).
+# Usage: assert_packet_blocked NETNS IP_ID [send_args...]
+assert_packet_blocked() {
+  local netns="$1" ip_id="$2"
+  shift 2
+
+  start_sniffer "$VETH" "$ip_id"
+  scapy_send "$netns" "$PEER" --ip-id "$ip_id" "$@"
+  local rc=0
+  wait "$SNIFFER_PID" || rc=$?
+  if [ $rc -eq 0 ]; then
+    echo "# FAIL: expected packet (ip_id=$ip_id) to be blocked but it appeared on $VETH" >&3
+    return 1
+  fi
 }

--- a/test/scapy.bats
+++ b/test/scapy.bats
@@ -1,0 +1,180 @@
+#!/usr/bin/env bats
+
+load helpers
+export BATS_TEST_NAME_PREFIX=$(setsuite)
+bats_require_minimum_version 1.7.0
+
+# Preflight: skip all tests if scapy is not available
+setup_file() {
+    if ! command -v python3 &>/dev/null; then
+        skip "python3 not found: scapy tests require python3"
+    fi
+    if ! python3 -c "import scapy" &>/dev/null; then
+        skip "scapy not installed: install python-scapy (Arch) or python3-scapy (Ubuntu)"
+    fi
+}
+
+setup() {
+    echo "# setup:" >&3
+
+    load net
+
+    NETNS="ns$((RANDOM % 10))"
+
+    new_netns "${NETNS}"
+    setup_net "${NETNS}"
+
+    # Prewarm ARP so crafted packets aren't lost to ARP resolution
+    arp_prewarm "${NETNS}"
+}
+
+teardown() {
+    echo "# teardown:" >&3
+
+    killall traffico &>/dev/null || true
+    # Clean up any leftover sniffer
+    [ -n "${SNIFFER_PID:-}" ] && kill "$SNIFFER_PID" &>/dev/null || true
+    del_netdev
+    del_netns "${NETNS}"
+}
+
+# --------------------------------------------------------------------------
+# block_ipv4
+# --------------------------------------------------------------------------
+
+@test "block_ipv4: drops packet with IP options (IHL > 5)" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress block_ipv4 "${VETH_ADDR}" >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_blocked "${NETNS}" 1001 \
+        --type tcp --dst-ip "${VETH_ADDR}" --ip-options
+    echo "# blocked IPv4 packet with IP options to ${VETH_ADDR}" >&3
+}
+
+@test "block_ipv4: drops fragmented packet to blocked IP" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress block_ipv4 "${VETH_ADDR}" >/dev/null 3>&- &
+    sleep 1
+
+    # First fragment
+    assert_packet_blocked "${NETNS}" 1002 \
+        --type fragment-first --dst-ip "${VETH_ADDR}"
+    echo "# blocked first fragment to ${VETH_ADDR}" >&3
+
+    # Subsequent fragment
+    assert_packet_blocked "${NETNS}" 1003 \
+        --type fragment-subsequent --dst-ip "${VETH_ADDR}" --frag-offset 10
+    echo "# blocked subsequent fragment to ${VETH_ADDR}" >&3
+}
+
+# --------------------------------------------------------------------------
+# block_port
+# --------------------------------------------------------------------------
+
+@test "block_port: drops TCP with IP options when port matches" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress block_port 8787 >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_blocked "${NETNS}" 2001 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 8787 --ip-options
+    echo "# blocked TCP to port 8787 with IP options" >&3
+}
+
+@test "block_port: allows TCP with IP options when port does not match" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress block_port 8787 >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_seen "${NETNS}" 2002 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 9999 --ip-options
+    echo "# allowed TCP to port 9999 with IP options (blocked port is 8787)" >&3
+}
+
+@test "block_port: drops first fragment with blocked port" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress block_port 8787 >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_blocked "${NETNS}" 2003 \
+        --type fragment-first --dst-ip "${VETH_ADDR}" --dst-port 8787
+    echo "# blocked first fragment to port 8787" >&3
+}
+
+@test "block_port: allows subsequent fragment (fail-open)" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress block_port 8787 >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_seen "${NETNS}" 2004 \
+        --type fragment-subsequent --dst-ip "${VETH_ADDR}" --frag-offset 10
+    echo "# allowed subsequent fragment (fail-open for block_*)" >&3
+}
+
+# --------------------------------------------------------------------------
+# block_private_ipv4
+# --------------------------------------------------------------------------
+
+@test "block_private_ipv4: allows ICMP to non-private destination" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress block_private_ipv4 >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_seen "${NETNS}" 3001 \
+        --type icmp --dst-ip 8.8.8.8
+    echo "# allowed ICMP to 8.8.8.8 (non-private)" >&3
+}
+
+@test "block_private_ipv4: drops ICMP to private destination" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress block_private_ipv4 >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_blocked "${NETNS}" 3002 \
+        --type icmp --dst-ip 10.0.0.1
+    echo "# blocked ICMP to 10.0.0.1 (private)" >&3
+}
+
+@test "block_private_ipv4: allows TCP source port 22 to private (SSH exemption)" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress block_private_ipv4 >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_seen "${NETNS}" 3003 \
+        --type tcp --dst-ip 10.0.0.1 --src-port 22
+    echo "# allowed TCP src port 22 to 10.0.0.1 (SSH exemption)" >&3
+}
+
+@test "block_private_ipv4: allows TCP source port 22 with IP options (SSH + IHL > 5)" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress block_private_ipv4 >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_seen "${NETNS}" 3004 \
+        --type tcp --dst-ip 10.0.0.1 --src-port 22 --ip-options
+    echo "# allowed TCP src port 22 with IP options to 10.0.0.1" >&3
+}
+
+@test "block_private_ipv4: drops UDP source port 22 to private" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress block_private_ipv4 >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_blocked "${NETNS}" 3005 \
+        --type udp --dst-ip 10.0.0.1 --src-port 22
+    echo "# blocked UDP src port 22 to 10.0.0.1 (SSH exemption is TCP-only)" >&3
+}
+
+@test "block_private_ipv4: drops GRE to private destination" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress block_private_ipv4 >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_blocked "${NETNS}" 3006 \
+        --type gre --dst-ip 10.0.0.1
+    echo "# blocked GRE to 10.0.0.1 (non-TCP/UDP to private)" >&3
+}
+
+@test "block_private_ipv4: drops first fragment to private, allows subsequent" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress block_private_ipv4 >/dev/null 3>&- &
+    sleep 1
+
+    # First fragment to private subnet
+    assert_packet_blocked "${NETNS}" 3007 \
+        --type fragment-first --dst-ip 10.0.0.1 --dst-port 80
+    echo "# blocked first fragment to 10.0.0.1" >&3
+
+    # Subsequent fragment: fail-open for block_* programs
+    assert_packet_seen "${NETNS}" 3008 \
+        --type fragment-subsequent --dst-ip 10.0.0.1 --frag-offset 10
+    echo "# allowed subsequent fragment to 10.0.0.1 (fail-open)" >&3
+}

--- a/test/scapy_packets.py
+++ b/test/scapy_packets.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Scapy helper for Bats tests. Provides send and sniff subcommands."""
+
+import argparse
+import sys
+
+from scapy.all import (
+    IP,
+    TCP,
+    UDP,
+    ICMP,
+    GRE,
+    Ether,
+    Raw,
+    IPOption,
+    send as scapy_send,
+    sniff,
+    conf,
+)
+
+# Suppress Scapy warnings
+conf.verb = 0
+
+
+def build_ip_layer(args):
+    """Build an IP layer with optional IP options (NOP padding to force IHL > 5)."""
+    ip = IP(src=args.src_ip, dst=args.dst_ip, id=args.ip_id)
+
+    if args.ip_options:
+        # Add NOP options to push IHL to 8 (32 bytes total header)
+        ip.options = [IPOption(b"\x01")] * 12
+
+    if args.frag_offset is not None:
+        ip.frag = args.frag_offset
+        if args.frag_offset == 0 and args.more_fragments:
+            ip.flags = "MF"
+
+    if args.proto_override:
+        ip.proto = int(args.proto_override)
+
+    return ip
+
+
+def cmd_send(args):
+    """Craft and send a packet."""
+    ip = build_ip_layer(args)
+
+    if args.type == "tcp":
+        pkt = ip / TCP(sport=args.src_port, dport=args.dst_port) / Raw(b"X" * 20)
+    elif args.type == "udp":
+        pkt = ip / UDP(sport=args.src_port, dport=args.dst_port) / Raw(b"X" * 20)
+    elif args.type == "icmp":
+        pkt = ip / ICMP(type=8, id=args.ip_id) / Raw(b"X" * 20)
+    elif args.type == "gre":
+        pkt = ip / GRE() / Raw(b"X" * 20)
+    elif args.type == "fragment-first":
+        # First fragment: MF=1, offset=0, carries L4 header
+        ip.flags = "MF"
+        ip.frag = 0
+        pkt = ip / TCP(sport=args.src_port, dport=args.dst_port) / Raw(b"X" * 20)
+    elif args.type == "fragment-subsequent":
+        # Subsequent fragment: offset > 0, no L4 header
+        ip.frag = args.frag_offset if args.frag_offset else 10
+        pkt = ip / Raw(b"X" * 20)
+    else:
+        print(f"unknown packet type: {args.type}", file=sys.stderr)
+        sys.exit(2)
+
+    # Use L3 send: the kernel adds the Ethernet header and routes
+    # through the default gateway. The packet hits TC egress on its
+    # way out, which is where the BPF program is attached.
+    try:
+        scapy_send(pkt, verbose=False)
+    except OSError:
+        # ENOBUFFS / ENETUNREACH is expected when the BPF program
+        # drops the packet at TC egress. The sniffer judges the result.
+        pass
+
+
+def cmd_sniff(args):
+    """Sniff for a matching packet. Exit 0 if seen, 1 if timeout."""
+    timeout = args.timeout
+    ip_id = args.ip_id
+
+    def match_filter(pkt):
+        if not pkt.haslayer(IP):
+            return False
+        ip = pkt[IP]
+        if ip.id != ip_id:
+            return False
+        if args.src_ip and ip.src != args.src_ip:
+            return False
+        if args.dst_ip and ip.dst != args.dst_ip:
+            return False
+        return True
+
+    result = sniff(
+        iface=args.iface,
+        timeout=timeout,
+        count=1,
+        lfilter=match_filter,
+        store=True,
+    )
+
+    if len(result) > 0:
+        sys.exit(0)  # packet seen
+    else:
+        sys.exit(1)  # timeout, packet not seen
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Scapy packet helper for Bats tests")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # send subcommand
+    p_send = sub.add_parser("send", help="Craft and send a packet")
+    p_send.add_argument("--iface", required=True)
+    p_send.add_argument("--type", required=True,
+                        choices=["tcp", "udp", "icmp", "gre",
+                                 "fragment-first", "fragment-subsequent"])
+    p_send.add_argument("--src-ip", default="10.22.1.2")
+    p_send.add_argument("--dst-ip", default="10.22.1.1")
+    p_send.add_argument("--src-port", type=int, default=12345)
+    p_send.add_argument("--dst-port", type=int, default=80)
+    p_send.add_argument("--ip-id", type=int, default=1)
+    p_send.add_argument("--ip-options", action="store_true",
+                        help="Add NOP IP options to force IHL > 5")
+    p_send.add_argument("--frag-offset", type=int, default=None)
+    p_send.add_argument("--more-fragments", action="store_true")
+    p_send.add_argument("--proto-override", default=None,
+                        help="Override IP protocol number")
+
+    # sniff subcommand
+    p_sniff = sub.add_parser("sniff", help="Sniff for a matching packet")
+    p_sniff.add_argument("--iface", required=True)
+    p_sniff.add_argument("--timeout", type=float, default=2.0)
+    p_sniff.add_argument("--ip-id", type=int, required=True)
+    p_sniff.add_argument("--src-ip", default=None)
+    p_sniff.add_argument("--dst-ip", default=None)
+
+    args = parser.parse_args()
+
+    if args.command == "send":
+        cmd_send(args)
+    elif args.command == "sniff":
+        cmd_sniff(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add 13 test cases covering IP options (IHL > 5), first/subsequent
fragment handling, ICMP subnet filtering, TCP-only SSH exemption,
UDP/GRE blocking, and fail-open behavior for `block_*` programs.

## Architecture

- `test/scapy_packets.py`: Python helper with `send`/`sniff` subcommands
- `test/scapy.bats`: Bats test file using existing veth+namespace topology
- `test/helpers.bash`: sniffer lifecycle wrappers and packet assertions

Tests judge allow/block by wire visibility on the host-side veth,
not application-level behavior. Each packet uses a unique IP ID for
deterministic sniffing. Sniff timeout defaults to 2s, configurable
via `SCAPY_SNIFF_TIMEOUT` env var.

## Test cases

### `block_ipv4`
- Drops packet with IP options (IHL > 5)
- Drops first and subsequent fragments to blocked IP

### `block_port`
- Drops TCP with IP options when port matches
- Allows TCP with IP options when port does not match
- Drops first fragment with blocked port
- Allows subsequent fragment (fail-open)

### `block_private_ipv4`
- Allows ICMP to non-private destination
- Drops ICMP to private destination
- Allows TCP source port 22 to private (SSH exemption)
- Allows TCP source port 22 with IP options (SSH + IHL > 5)
- Drops UDP source port 22 to private (SSH exemption is TCP-only)
- Drops GRE to private destination
- Drops first fragment to private, allows subsequent (fail-open)

## Infrastructure changes

- Scapy added to `.devcontainer/Dockerfile` and both CI jobs (Ubuntu + Arch)
- Tests skip gracefully if scapy is not installed
- README updated to note scapy dependency for full test suite