### PR TITLE
feat(bpf): implement `allow_ethertype` L2 gatekeeper

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -123,6 +123,15 @@ BUILT-IN PROGRAMS
         ipv6, arp) and hex values (0x0800) are both supported.
         Example: allow_ethertype ipv4+arp
 
+        In a chain, allow_ethertype must be the first program. L3+
+        programs (allow_ipv4, allow_port, etc.) pass through traffic
+        outside their domain (e.g., non-IPv4 frames), which bypasses
+        any downstream allow_ethertype filter.
+
+        On VLAN-tagged networks (802.1Q), the outer EtherType is the
+        VLAN tag protocol (0x8100), not the payload type. Include
+        0x8100 in the allowed set to avoid dropping tagged frames.
+
     allow_ipv4
         allow_ipv4 allows IPv4 traffic to the input address, drops the
         rest. Non-IPv4 traffic passes through and should be constrained

--- a/README.txt
+++ b/README.txt
@@ -128,9 +128,9 @@ BUILT-IN PROGRAMS
         outside their domain (e.g., non-IPv4 frames), which bypasses
         any downstream allow_ethertype filter.
 
-        On VLAN-tagged networks (802.1Q), the outer EtherType is the
-        VLAN tag protocol (0x8100), not the payload type. Include
-        0x8100 in the allowed set to avoid dropping tagged frames.
+        VLAN TPIDs (0x8100, 0x88A8) are only supported in standalone
+        mode. In chains, they are rejected because downstream L3/L4
+        programs cannot yet parse VLAN-encapsulated payloads.
 
     allow_ipv4
         allow_ipv4 allows IPv4 traffic to the input address, drops the

--- a/README.txt
+++ b/README.txt
@@ -116,6 +116,13 @@ BUILT-IN PROGRAMS
         Non-IPv4 traffic passes through and should be constrained by L2
         or chain policy when needed.
 
+    allow_ethertype
+        allow_ethertype is an L2 gatekeeper that drops Ethernet frames
+        whose EtherType is not in the allowed set. Multiple EtherTypes
+        can be specified by joining them with +. Symbolic names (ipv4,
+        ipv6, arp) and hex values (0x0800) are both supported.
+        Example: allow_ethertype ipv4+arp
+
     allow_ipv4
         allow_ipv4 allows IPv4 traffic to the input address, drops the
         rest. Non-IPv4 traffic passes through and should be constrained

--- a/api/api.$progname.h.in
+++ b/api/api.$progname.h.in
@@ -16,9 +16,11 @@ int ${OPERATION}${PROGNAME}(struct config *conf, after_attach_fn_t cb)
     }
 
     // Set read-only data (between open and load).
-    // Assumes each BPF program has exactly one const volatile global
-    // at offset 0 in .rodata. If a program adds more globals, this
-    // memcpy must account for their offsets.
+    // Copies the input field struct at offset 0 in .rodata. This covers
+    // both single-value inputs (e.g., a __u32 IP) and multi-value inputs
+    // (e.g., ethertypes: __u16[8] + __u8 count). Additional globals like
+    // `slot` (used for chain support) are not set here — they default to
+    // zero from calloc, which is correct for standalone mode.
 #if ${PROGNAME_WITH_RODATA}
     if (conf->has_input)
     {

--- a/api/chain.h
+++ b/api/chain.h
@@ -13,6 +13,7 @@
 #include "api.h"
 #include "dispatcher.skel.h"
 #include "allow_dns.skel.h"
+#include "allow_ethertype.skel.h"
 #include "allow_ipv4.skel.h"
 #include "allow_port.skel.h"
 
@@ -264,6 +265,57 @@ static int load_chain_program(struct config *conf,
         log_out(conf, "done: loaded allow_dns at slot %d\n", slot);
         break;
     }
+    case program_allow_ethertype:
+    {
+        struct allow_ethertype_bpf *obj = allow_ethertype_bpf__open();
+        if (!obj)
+        {
+            log_err(conf, "fail: opening allow_ethertype skeleton\n");
+            return 1;
+        }
+
+        err = bpf_map__reuse_fd(obj->maps.prog_array, prog_array_fd);
+        if (err)
+        {
+            log_err(conf, "fail: reusing prog_array for allow_ethertype\n");
+            allow_ethertype_bpf__destroy(obj);
+            return 1;
+        }
+
+        if (entry->has_input)
+        {
+            err = set_chain_rodata(obj->maps.rodata,
+                                   &entry->input.ethertypes, sizeof(entry->input.ethertypes),
+                                   slot);
+            if (err)
+            {
+                log_err(conf, "fail: setting rodata for allow_ethertype\n");
+                allow_ethertype_bpf__destroy(obj);
+                return 1;
+            }
+        }
+
+        err = allow_ethertype_bpf__load(obj);
+        if (err)
+        {
+            libbpf_strerror(err, buf, sizeof(buf));
+            log_err(conf, "fail: loading allow_ethertype: %s\n", buf);
+            allow_ethertype_bpf__destroy(obj);
+            return 1;
+        }
+
+        int prog_fd = bpf_program__fd(obj->progs.allow_ethertype);
+        err = bpf_map_update_elem(prog_array_fd, &slot, &prog_fd, BPF_ANY);
+        if (err)
+        {
+            log_err(conf, "fail: inserting allow_ethertype into prog_array slot %d\n", slot);
+            allow_ethertype_bpf__destroy(obj);
+            return 1;
+        }
+
+        log_out(conf, "done: loaded allow_ethertype at slot %d\n", slot);
+        break;
+    }
     default:
         log_err(conf, "fail: program '%s' does not support chaining\n",
                 g_programs_name[entry->program]);
@@ -276,9 +328,10 @@ static int load_chain_program(struct config *conf,
 /// Returns true if the given program supports chaining.
 static inline bool program_supports_chaining(program_t program)
 {
-    return program == program_allow_ipv4 ||
-           program == program_allow_port ||
-           program == program_allow_dns;
+    return program == program_allow_dns ||
+           program == program_allow_ethertype ||
+           program == program_allow_ipv4 ||
+           program == program_allow_port;
 }
 
 /// Attach a chain of programs using the dispatcher + tail calls.

--- a/api/chain.h
+++ b/api/chain.h
@@ -19,6 +19,8 @@
 
 #define MAX_CHAIN_LEN 8
 #define BPFFS_BASE "/sys/fs/bpf/traffico"
+#define TRAFFICO_ETH_P_8021Q 0x8100
+#define TRAFFICO_ETH_P_8021AD 0x88A8
 
 /// Maximum number of values in a multi-value input (ethertypes, protos).
 #define MAX_MULTI_VALUES 8
@@ -41,6 +43,20 @@ struct chain_entry
         } protos;          // allow_proto (future)
     } input;
 };
+
+static inline bool chain_entry_has_vlan_tpid(const struct chain_entry *entry)
+{
+    if (entry->program != program_allow_ethertype || !entry->has_input)
+        return false;
+
+    for (__u8 i = 0; i < entry->input.ethertypes.count; i++)
+    {
+        __u16 value = entry->input.ethertypes.values[i];
+        if (value == TRAFFICO_ETH_P_8021Q || value == TRAFFICO_ETH_P_8021AD)
+            return true;
+    }
+    return false;
+}
 
 /// Ensure a directory exists, creating parents as needed.
 static int ensure_dir(const char *dir)
@@ -367,6 +383,19 @@ int attach_chain(struct config *conf,
             log_err(conf, "fail: program '%s' does not support chaining\n",
                     g_programs_name[entries[i].program]);
             return 1;
+        }
+        if (entries[i].program == program_allow_ethertype)
+        {
+            if (i != 0)
+            {
+                log_err(conf, "fail: program 'allow_ethertype' must be first in a chain\n");
+                return 1;
+            }
+            if (chain_len > 1 && chain_entry_has_vlan_tpid(&entries[i]))
+            {
+                log_err(conf, "fail: VLAN EtherTypes in allow_ethertype chains require VLAN-aware L3/L4 parsing\n");
+                return 1;
+            }
         }
     }
 

--- a/api/input_parse.h
+++ b/api/input_parse.h
@@ -279,6 +279,8 @@ static int parse_input(struct config *conf, const char *input_str, const char **
         conf->has_input = true;
         return 0;
     }
+    case program_allow_ethertype:
+        return parse_ethertypes(conf, input_str, err_msg);
     default:
         *err_msg = "program does not accept input";
         return -1;
@@ -288,7 +290,7 @@ static int parse_input(struct config *conf, const char *input_str, const char **
 // Returns true if the given program requires an input argument.
 static inline bool program_requires_input(program_t program)
 {
-    return program == program_allow_dns || program == program_allow_ipv4 || program == program_allow_port || program == program_block_ipv4 || program == program_block_port;
+    return program == program_allow_dns || program == program_allow_ethertype || program == program_allow_ipv4 || program == program_allow_port || program == program_block_ipv4 || program == program_block_port;
 }
 
 #endif // TRAFFICO_INPUT_PARSE_H

--- a/bpf/allow_ethertype.bpf.c
+++ b/bpf/allow_ethertype.bpf.c
@@ -28,7 +28,7 @@ int allow_ethertype(struct __sk_buff *skb)
 
     // Linear scan of the allowed EtherTypes.
     // MAX_MULTI_VALUES is small (8), so a loop is fine.
-    for (__u8 i = 0; i < MAX_MULTI_VALUES; i++)
+    for (__u32 i = 0; i < MAX_MULTI_VALUES; i++)
     {
         if (i >= num_allowed)
             break;

--- a/bpf/allow_ethertype.bpf.c
+++ b/bpf/allow_ethertype.bpf.c
@@ -1,0 +1,45 @@
+#include "vmlinux.h"
+#include "commons.bpf.h"
+
+#include <bpf/bpf_endian.h>
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";
+
+const volatile __u16 allowed[MAX_MULTI_VALUES] = {};
+const volatile __u8 num_allowed = 0;
+const volatile __u32 slot = 0; // position in the chain (set by userspace)
+
+DEFINE_PROG_ARRAY();
+
+SEC("tc")
+int allow_ethertype(struct __sk_buff *skb)
+{
+    void *data_end = (void *)(unsigned long long)skb->data_end;
+    void *data = (void *)(unsigned long long)skb->data;
+
+    struct ethhdr *eth = data;
+    if (data + sizeof(*eth) > data_end)
+    {
+        bpf_printk("allow_ethertype: [eth] size length check hit: block");
+        return TC_ACT_SHOT;
+    }
+
+    __u16 proto = bpf_ntohs(eth->h_proto);
+
+    // Linear scan of the allowed EtherTypes.
+    // MAX_MULTI_VALUES is small (8), so a loop is fine.
+    for (__u8 i = 0; i < MAX_MULTI_VALUES; i++)
+    {
+        if (i >= num_allowed)
+            break;
+        if (allowed[i] == proto)
+        {
+            bpf_printk("allow_ethertype: [eth] protocol 0x%x: allow", proto);
+            tail_call_next(skb, slot);
+            return TC_ACT_OK;
+        }
+    }
+
+    bpf_printk("allow_ethertype: [eth] protocol 0x%x not in allowed set: block", proto);
+    return TC_ACT_SHOT;
+}

--- a/bpf/commons.bpf.h
+++ b/bpf/commons.bpf.h
@@ -15,6 +15,18 @@
 #define ETH_P_IP 0x0800
 #endif
 
+#ifndef ETH_P_IPV6
+#define ETH_P_IPV6 0x86DD
+#endif
+
+#ifndef ETH_P_ARP
+#define ETH_P_ARP 0x0806
+#endif
+
+/// Maximum number of values in a multi-value rodata input.
+/// Must match MAX_MULTI_VALUES in api.h.
+#define MAX_MULTI_VALUES 8
+
 #ifndef IP_MF
 #define IP_MF 0x2000
 #endif

--- a/bpf/commons.bpf.h
+++ b/bpf/commons.bpf.h
@@ -77,9 +77,9 @@ struct trace_event_raw_bpf_trace_printk___x
     })
 #else
 #define bpf_printk(fmt, ...) \
+    do                       \
     {                        \
-    }                        \
-    while (0)
+    } while (0)
 #endif
 
 /// Tail call support for program chaining.

--- a/docs/README.md
+++ b/docs/README.md
@@ -120,13 +120,19 @@ Here's an example CNI config file featuring `traffico-cni`.
 | Program | Description |
 |---|---|
 | `allow_dns` | Allows IPv4 DNS traffic (port 53) to the input resolver, drops the rest. Other traffic passes through. Non-IPv4 passes through for L2/chain policy. |
-| `allow_ethertype` | L2 gatekeeper: drops frames whose EtherType is not in the allowed set (e.g., `ipv4+arp`) |
+| `allow_ethertype` | L2 gatekeeper: drops frames whose EtherType is not in the allowed set (e.g., `ipv4+arp`). Must be first in a chain (see notes below). |
 | `allow_ipv4` | Allows IPv4 traffic to the input address, drops the rest. Non-IPv4 passes through for L2/chain policy. Localhost (127.0.0.0/8) always allowed. |
 | `allow_port` | Allows IPv4 TCP/UDP traffic to the input port, drops the rest. Other protocols (ICMP, etc.) pass through. Non-IPv4 blocked. |
 | `block_private_ipv4` | Blocks private IPv4 addresses subnets allowing only SSH access on port 22 |
 | `block_ipv4` | Drops packets with destination equal to the input IPv4 address |
 | `block_port` | Drops packets with the destination port equal to the input port number |
 | `nop` | A simple program that does nothing |
+
+### Notes on `allow_ethertype`
+
+**Chain ordering:** In a chain, `allow_ethertype` must be the first program. L3+ programs (`allow_ipv4`, `allow_port`, etc.) pass through traffic outside their domain (e.g., non-IPv4 frames return `TC_ACT_OK` directly), which bypasses any downstream `allow_ethertype` filter.
+
+**VLAN-tagged networks:** On 802.1Q networks, the outer EtherType is the VLAN tag protocol identifier (`0x8100`), not the payload type. Include `0x8100` (or `0x88A8` for QinQ) in the allowed set to avoid dropping tagged frames.
 
 ## Build
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -120,6 +120,7 @@ Here's an example CNI config file featuring `traffico-cni`.
 | Program | Description |
 |---|---|
 | `allow_dns` | Allows IPv4 DNS traffic (port 53) to the input resolver, drops the rest. Other traffic passes through. Non-IPv4 passes through for L2/chain policy. |
+| `allow_ethertype` | L2 gatekeeper: drops frames whose EtherType is not in the allowed set (e.g., `ipv4+arp`) |
 | `allow_ipv4` | Allows IPv4 traffic to the input address, drops the rest. Non-IPv4 passes through for L2/chain policy. Localhost (127.0.0.0/8) always allowed. |
 | `allow_port` | Allows IPv4 TCP/UDP traffic to the input port, drops the rest. Other protocols (ICMP, etc.) pass through. Non-IPv4 blocked. |
 | `block_private_ipv4` | Blocks private IPv4 addresses subnets allowing only SSH access on port 22 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -132,7 +132,7 @@ Here's an example CNI config file featuring `traffico-cni`.
 
 **Chain ordering:** In a chain, `allow_ethertype` must be the first program. L3+ programs (`allow_ipv4`, `allow_port`, etc.) pass through traffic outside their domain (e.g., non-IPv4 frames return `TC_ACT_OK` directly), which bypasses any downstream `allow_ethertype` filter.
 
-**VLAN-tagged networks:** On 802.1Q networks, the outer EtherType is the VLAN tag protocol identifier (`0x8100`), not the payload type. Include `0x8100` (or `0x88A8` for QinQ) in the allowed set to avoid dropping tagged frames.
+**VLAN-tagged networks:** On 802.1Q networks, the outer EtherType is the VLAN tag protocol identifier (`0x8100`), not the payload type. VLAN TPIDs (`0x8100`, `0x88A8`) are only supported in standalone mode. In chains, VLAN TPIDs are rejected because downstream L3/L4 programs cannot yet parse VLAN-encapsulated payloads.
 
 ## Build
 

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -359,6 +359,33 @@ sys.exit(0)
     echo "# can still ping ${VETH_ADDR} (chain allows ipv4+arp to ${VETH_ADDR})" >&3
 }
 
+@test "chain allow_ethertype blocks non-matching EtherType" {
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 0 ]
+    echo "# can ping ${VETH_ADDR} from the namespace" >&3
+    # Only allow IPv6 in the chain — IPv4 ping should be blocked by allow_ethertype
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ethertype:ipv6,allow_ipv4:${VETH_ADDR}" >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 1 ]
+    echo "# cannot ping ${VETH_ADDR} (chain blocks ipv4 at L2)" >&3
+}
+
+@test "allow_ethertype with hex values allows IPv4 traffic" {
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 0 ]
+    echo "# can ping ${VETH_ADDR} from the namespace" >&3
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_ethertype 0x0800+0x0806 >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 0 ]
+    echo "# can still ping ${VETH_ADDR} (0x0800+0x0806 allowed)" >&3
+}
+
 @test "chain allow_ipv4+allow_port allows matching traffic" {
     new_server
     run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -268,7 +268,7 @@ sys.exit(0)
     run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
     [ $status -eq 0 ]
     echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
-    # Allow DNS only to PEER_ADDR — but non-DNS traffic should still pass
+    # Allow DNS only to PEER_ADDR - but non-DNS traffic should still pass
     run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_dns "${PEER_ADDR}" >/dev/null 3>&- &
     sleep 1
     run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
@@ -336,7 +336,7 @@ sys.exit(0)
     run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
     [ $status -eq 0 ]
     echo "# can ping ${VETH_ADDR} from the namespace" >&3
-    # Only allow IPv6 — IPv4 and ARP are not in the allowed set
+    # Only allow IPv6 - IPv4 and ARP are not in the allowed set
     run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_ethertype ipv6 >/dev/null 3>&- &
     sleep 1
     run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
@@ -350,12 +350,14 @@ sys.exit(0)
     run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
     [ $status -eq 0 ]
     echo "# can ping ${VETH_ADDR} from the namespace" >&3
-    # Allow only IPv4 without ARP — ping needs ARP to resolve the MAC
+    # Allow only IPv4 without ARP - ping needs ARP to resolve the MAC
     # address, so blocking ARP at L2 prevents the ping from completing
     run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_ethertype ipv4 >/dev/null 3>&- &
     sleep 1
     run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
     [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    # Flush neighbor cache so the next ping must ARP-resolve
+    ip netns exec "${NETNS}" ip neigh flush dev "${PEER}"
     run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
     [ $status -eq 1 ]
     echo "# cannot ping ${VETH_ADDR} (ARP blocked, cannot resolve MAC)" >&3
@@ -378,7 +380,7 @@ sys.exit(0)
     run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
     [ $status -eq 0 ]
     echo "# can ping ${VETH_ADDR} from the namespace" >&3
-    # Only allow IPv6 in the chain — IPv4 ping should be blocked by allow_ethertype
+    # Only allow IPv6 in the chain - IPv4 ping should be blocked by allow_ethertype
     run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ethertype:ipv6,allow_ipv4:${VETH_ADDR}" >/dev/null 3>&- &
     sleep 1
     run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -319,6 +319,46 @@ sys.exit(0)
     echo "# can still ping ${VETH_ADDR} (ICMP not blocked by allow_port)" >&3
 }
 
+@test "allow_ethertype ipv4+arp allows IPv4 traffic" {
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 0 ]
+    echo "# can ping ${VETH_ADDR} from the namespace" >&3
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_ethertype ipv4+arp >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 0 ]
+    echo "# can still ping ${VETH_ADDR} (ipv4+arp allowed)" >&3
+}
+
+@test "allow_ethertype ipv6 blocks IPv4 traffic" {
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 0 ]
+    echo "# can ping ${VETH_ADDR} from the namespace" >&3
+    # Only allow IPv6 — IPv4 and ARP are not in the allowed set
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_ethertype ipv6 >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 1 ]
+    echo "# cannot ping ${VETH_ADDR} (ipv4 not in allowed set)" >&3
+}
+
+@test "chain allow_ethertype+allow_ipv4 allows matching traffic" {
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 0 ]
+    echo "# can ping ${VETH_ADDR} from the namespace" >&3
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ethertype:ipv4+arp,allow_ipv4:${VETH_ADDR}" >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 0 ]
+    echo "# can still ping ${VETH_ADDR} (chain allows ipv4+arp to ${VETH_ADDR})" >&3
+}
+
 @test "chain allow_ipv4+allow_port allows matching traffic" {
     new_server
     run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -346,6 +346,21 @@ sys.exit(0)
     echo "# cannot ping ${VETH_ADDR} (ipv4 not in allowed set)" >&3
 }
 
+@test "allow_ethertype ipv4 without arp blocks ping" {
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 0 ]
+    echo "# can ping ${VETH_ADDR} from the namespace" >&3
+    # Allow only IPv4 without ARP — ping needs ARP to resolve the MAC
+    # address, so blocking ARP at L2 prevents the ping from completing
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_ethertype ipv4 >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 1 ]
+    echo "# cannot ping ${VETH_ADDR} (ARP blocked, cannot resolve MAC)" >&3
+}
+
 @test "chain allow_ethertype+allow_ipv4 allows matching traffic" {
     run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
     [ $status -eq 0 ]

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -220,3 +220,21 @@ bats_require_minimum_version 1.7.0
     [ $status -eq 1 ]
     [ "${lines[0]}" == "traffico: input must not start with '+': '+ipv4'" ]
 }
+
+@test "consecutive ++ in ethertype input" {
+    run traffico -i lo allow_ethertype "ipv4++arp"
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: input contains empty value between '+' delimiters: 'ipv4++arp'" ]
+}
+
+@test "too many ethertype values" {
+    run traffico -i lo allow_ethertype "ipv4+ipv6+arp+0x8100+0x88A8+0x8847+0x8848+0x88CC+0x0842"
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: too many EtherType values: 'ipv4+ipv6+arp+0x8100+0x88A8+0x8847+0x8848+0x88CC+0x0842'" ]
+}
+
+@test "zero ethertype hex value" {
+    run traffico -i lo allow_ethertype 0x0000
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: invalid EtherType hex value: '0x0000'" ]
+}

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -209,6 +209,12 @@ bats_require_minimum_version 1.7.0
     [ "${lines[0]}" == "traffico: duplicate EtherType value: 'ipv4+ipv4'" ]
 }
 
+@test "duplicate ethertype values across representations" {
+    run traffico -i lo allow_ethertype ipv4+0x0800
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: duplicate EtherType value: 'ipv4+0x0800'" ]
+}
+
 @test "trailing + in ethertype input" {
     run traffico -i lo allow_ethertype "ipv4+"
     [ $status -eq 1 ]

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -173,6 +173,18 @@ bats_require_minimum_version 1.7.0
     [ "${lines[0]}" == "traffico: program 'nop' does not support chaining" ]
 }
 
+@test "--chain rejects allow_ethertype not in slot 0" {
+    run traffico -i lo --chain "allow_ipv4:127.0.0.1,allow_ethertype:ipv4+arp"
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: program 'allow_ethertype' must be first in a chain" ]
+}
+
+@test "--chain rejects VLAN TPIDs in multi-program chain" {
+    run timeout 2 traffico -i lo --chain "allow_ethertype:ipv4+0x8100,allow_ipv4:127.0.0.1"
+    [ $status -ne 0 ]
+    [[ "$output" == *"VLAN EtherTypes"* ]]
+}
+
 @test "--chain mutually exclusive with positional args" {
     run traffico -i lo --chain "nop" nop
     [ $status -eq 1 ]

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -184,3 +184,39 @@ bats_require_minimum_version 1.7.0
     [ $status -eq 1 ]
     [ "${lines[0]}" == "traffico: --chain requires at least one program" ]
 }
+
+@test "missing input for allow_ethertype" {
+    run traffico -i lo allow_ethertype
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: program 'allow_ethertype' requires an input argument" ]
+}
+
+@test "unknown ethertype name" {
+    run traffico -i lo allow_ethertype xxx
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: unknown EtherType name: 'xxx'" ]
+}
+
+@test "invalid ethertype hex value" {
+    run traffico -i lo allow_ethertype 0xZZZZ
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: invalid EtherType hex value: '0xZZZZ'" ]
+}
+
+@test "duplicate ethertype values" {
+    run traffico -i lo allow_ethertype ipv4+ipv4
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: duplicate EtherType value: 'ipv4+ipv4'" ]
+}
+
+@test "trailing + in ethertype input" {
+    run traffico -i lo allow_ethertype "ipv4+"
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: input must not end with '+': 'ipv4+'" ]
+}
+
+@test "leading + in ethertype input" {
+    run traffico -i lo allow_ethertype "+ipv4"
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: input must not start with '+': '+ipv4'" ]
+}

--- a/test/cni.bats
+++ b/test/cni.bats
@@ -113,6 +113,22 @@ s.close()
     kill $DNS_PID 2>/dev/null || true
 }
 
+@test "allow_ethertype via CNI" {
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 0 ]
+    echo "# can ping ${VETH_ADDR} from the namespace" >&3
+    echo "# installing allow_ethertype in the namespace" >&3
+    run ip netns exec "${NETNS}" bash -c "cat '$FIXTURE_ROOT/attach_allow_ethertype_in.json' | CNI_COMMAND=ADD traffico-cni"
+    [ $status -eq 0 ]
+    echo "# attach ok" >&3
+    run ip netns exec "${NETNS}" tc qdisc show dev peer0 clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    echo "# qdisc ok" >&3
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 0 ]
+    echo "# can still ping ${VETH_ADDR} (ipv4+arp allowed)" >&3
+}
+
 @test "allow_port via CNI" {
     run curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
     [ $status -eq 0 ]

--- a/test/fixtures/cni/attach_allow_ethertype_in.json
+++ b/test/fixtures/cni/attach_allow_ethertype_in.json
@@ -1,0 +1,22 @@
+{
+    "cniVersion": "0.4.0",
+    "name": "dummy-network",
+    "prevResult": {
+        "cniVersion": "1.0.0",
+        "interfaces": [
+            {
+                "name": "peer0"
+            }
+        ],
+        "ips": [
+        ],
+        "routes": [
+        ],
+        "dns": {
+        }
+    },
+    "type": "traffico-cni",
+    "program": "allow_ethertype",
+    "input": "ipv4+arp",
+    "attachPoint": "egress"
+}

--- a/traffico.c
+++ b/traffico.c
@@ -255,6 +255,10 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
                 {
                     argp_error(state, "program '%s' does not support chaining", prog_name);
                 }
+                if (g_chain[g_chain_len].program == program_allow_ethertype && g_chain_len != 0)
+                {
+                    argp_error(state, "program 'allow_ethertype' must be first in a chain");
+                }
 
                 // Parse input for this program
                 if (input_str)
@@ -280,6 +284,17 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
             if (g_chain_len == 0)
             {
                 argp_error(state, "--chain requires at least one program");
+            }
+            if (g_chain_len > 1 && g_chain[0].program == program_allow_ethertype)
+            {
+                for (__u8 j = 0; j < g_chain[0].input.ethertypes.count; j++)
+                {
+                    __u16 v = g_chain[0].input.ethertypes.values[j];
+                    if (v == 0x8100 || v == 0x88A8)
+                    {
+                        argp_error(state, "VLAN EtherTypes in allow_ethertype chains require VLAN-aware L3/L4 parsing");
+                    }
+                }
             }
         }
         else

--- a/xmake/modules/api.lua
+++ b/xmake/modules/api.lua
@@ -10,6 +10,7 @@ import("core.project.project")
 -- PROGNAME_IS_MULTI_VALUE to distinguish array inputs from scalars.
 local input_fields = {
     allow_dns = "ip",
+    allow_ethertype = { field = "ethertypes", multi = true },
     allow_ipv4 = "ip",
     allow_port = "port",
     block_ipv4 = "ip",


### PR DESCRIPTION
L2 EtherType allowlist program. Drops Ethernet frames whose EtherType
is not in the allowed set. Accepts a `+`-delimited list of symbolic
names (`ipv4`, `ipv6`, `arp`) or `0x`-prefixed hex values.

First multi-value input program, using the infrastructure from PR #49.

## Changes

1. **BPF program** (`bpf/allow_ethertype.bpf.c`): reads `eth->h_proto`,
   linear scans `allowed[MAX_MULTI_VALUES]` array. Match: tail-call next.
   No match: `TC_ACT_SHOT`. Fail-closed on truncated Ethernet headers.
   Also adds `ETH_P_IPV6`, `ETH_P_ARP`, `MAX_MULTI_VALUES` to `commons.bpf.h`.

2. **Parser wiring**: `case program_allow_ethertype` in `parse_input()`
   calling the existing `parse_ethertypes()` helper. Added to
   `program_requires_input()`. `input_fields` entry in `api.lua`:
   `{ field = "ethertypes", multi = true }`.

3. **Chain loader**: `case program_allow_ethertype` in
   `load_chain_program()`. Passes the full ethertypes struct (array + count)
   to `set_chain_rodata()`. Added to `program_supports_chaining()`.

4. **Tests**: 6 flag validation tests (missing input, unknown name, invalid
   hex, duplicates, trailing/leading `+`). 3 integration tests (standalone
   allow, standalone block, chain). 1 CNI test with fixture.

5. **Docs**: `README.txt` and `docs/README.md`.

## Stacked on

- PR #49 (`feat/multi-value-rodata`) - multi-value input infrastructure
- PR #45 (`feat/dispatcher-chain`) - chain CLI
- PR #44 (`feat/dispatcher-bpf`) - dispatcher infrastructure
- PR #43 (`feat/allow-dns`)
- PR #42 (`feat/allow-port`)
- PR #41 (`feat/allow-ip`)