### PR TITLE
feat: add `vlan` and `qinq` symbolic names for `allow_ethertype`

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -120,7 +120,8 @@ BUILT-IN PROGRAMS
         allow_ethertype is an L2 gatekeeper that drops Ethernet frames
         whose EtherType is not in the allowed set. Multiple EtherTypes
         can be specified by joining them with +. Symbolic names (ipv4,
-        ipv6, arp) and hex values (0x0800) are both supported.
+        ipv6, arp, vlan, qinq) and hex values (0x0800) are both
+        supported.
         Example: allow_ethertype ipv4+arp
 
         In a chain, allow_ethertype must be the first program. L3+
@@ -128,9 +129,10 @@ BUILT-IN PROGRAMS
         outside their domain (e.g., non-IPv4 frames), which bypasses
         any downstream allow_ethertype filter.
 
-        VLAN TPIDs (0x8100, 0x88A8) are only supported in standalone
-        mode. In chains, they are rejected because downstream L3/L4
-        programs cannot yet parse VLAN-encapsulated payloads.
+        Symbolic names vlan (0x8100) and qinq (0x88A8) are available.
+        VLAN TPIDs are only supported in standalone mode. In chains,
+        they are rejected because downstream L3/L4 programs cannot
+        yet parse VLAN-encapsulated payloads.
 
     allow_ipv4
         allow_ipv4 allows IPv4 traffic to the input address, drops the

--- a/api/input_parse.h
+++ b/api/input_parse.h
@@ -19,6 +19,8 @@ static const struct ethertype_name g_ethertype_names[] = {
     {"ipv4", 0x0800},
     {"ipv6", 0x86DD},
     {"arp", 0x0806},
+    {"vlan", 0x8100},
+    {"qinq", 0x88A8},
     {NULL, 0},
 };
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -132,7 +132,7 @@ Here's an example CNI config file featuring `traffico-cni`.
 
 **Chain ordering:** In a chain, `allow_ethertype` must be the first program. L3+ programs (`allow_ipv4`, `allow_port`, etc.) pass through traffic outside their domain (e.g., non-IPv4 frames return `TC_ACT_OK` directly), which bypasses any downstream `allow_ethertype` filter.
 
-**VLAN-tagged networks:** On 802.1Q networks, the outer EtherType is the VLAN tag protocol identifier (`0x8100`), not the payload type. VLAN TPIDs (`0x8100`, `0x88A8`) are only supported in standalone mode. In chains, VLAN TPIDs are rejected because downstream L3/L4 programs cannot yet parse VLAN-encapsulated payloads.
+**VLAN-tagged networks:** Symbolic names `vlan` (0x8100) and `qinq` (0x88A8) are available. VLAN TPIDs are only supported in standalone mode. In chains, they are rejected because downstream L3/L4 programs cannot yet parse VLAN-encapsulated payloads. Example (standalone): `allow_ethertype ipv4+arp+vlan`.
 
 ## Build
 

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -256,3 +256,15 @@ bats_require_minimum_version 1.7.0
     [ $status -eq 1 ]
     [ "${lines[0]}" == "traffico: invalid EtherType hex value: '0x0000'" ]
 }
+
+@test "vlan symbolic name resolves to 0x8100" {
+    run traffico -i lo allow_ethertype "vlan+0x8100"
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: duplicate EtherType value: 'vlan+0x8100'" ]
+}
+
+@test "qinq symbolic name resolves to 0x88A8" {
+    run traffico -i lo allow_ethertype "qinq+0x88A8"
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: duplicate EtherType value: 'qinq+0x88A8'" ]
+}


### PR DESCRIPTION
Add `vlan` (0x8100) and `qinq` (0x88A8) to the EtherType symbolic name table so users on VLAN-tagged networks can write `allow_ethertype ipv4+arp+vlan` instead of raw hex values.

## Changes

- `api/input_parse.h`: add `vlan` → `0x8100` and `qinq` → `0x88A8` to `g_ethertype_names[]`
- `test/cli.flags.bats`: two tests verifying the names resolve to the correct hex values (via duplicate detection)
- `README.txt`, `docs/README.md`: updated symbolic name lists and VLAN documentation to reference the new names

## Stacked on

- PR #51 (`feat/allow-ethertype`)