### PR TITLE
feat(bpf): implement `allow_proto` L3 protocol gatekeeper

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -134,6 +134,18 @@ BUILT-IN PROGRAMS
         they are rejected because downstream L3/L4 programs cannot
         yet parse VLAN-encapsulated payloads.
 
+    allow_proto
+        allow_proto is an L3 gatekeeper that drops IPv4 packets whose IP
+        protocol is not in the allowed set. Non-IPv4 traffic passes
+        through (L2 filtering is allow_ethertype's job). Multiple
+        protocols can be specified by joining them with +. Symbolic
+        names (tcp, udp, icmp, sctp) and decimal numbers (6, 17) are
+        both supported.
+        Example: allow_proto tcp+udp
+
+        In a chain, allow_proto should be placed after allow_ethertype
+        and before allow_port (L2 -> L3 -> L4 ordering).
+
     allow_ipv4
         allow_ipv4 allows IPv4 traffic to the input address, drops the
         rest. Non-IPv4 traffic passes through and should be constrained

--- a/README.txt
+++ b/README.txt
@@ -145,6 +145,9 @@ BUILT-IN PROGRAMS
 
         In a chain, allow_proto should be placed after allow_ethertype
         and before allow_port (L2 -> L3 -> L4 ordering).
+        VLAN/QinQ-tagged IPv4 is unwrapped before checking the IP
+        protocol; truncated VLAN headers and unsupported additional
+        VLAN nesting fail closed.
 
     allow_ipv4
         allow_ipv4 allows IPv4 traffic to the input address, drops the

--- a/api/api.h.in
+++ b/api/api.h.in
@@ -39,11 +39,11 @@ struct config
         struct {
             __u16 values[MAX_MULTI_VALUES];
             __u8 count;
-        } ethertypes;      // allow_ethertype (future)
+        } ethertypes;      // allow_ethertype
         struct {
             __u8 values[MAX_MULTI_VALUES];
             __u8 count;
-        } protos;          // allow_proto (future)
+        } protos;          // allow_proto
     } input;
 };
 

--- a/api/chain.h
+++ b/api/chain.h
@@ -16,6 +16,7 @@
 #include "allow_ethertype.skel.h"
 #include "allow_ipv4.skel.h"
 #include "allow_port.skel.h"
+#include "allow_proto.skel.h"
 
 #define MAX_CHAIN_LEN 8
 #define BPFFS_BASE "/sys/fs/bpf/traffico"

--- a/api/chain.h
+++ b/api/chain.h
@@ -37,11 +37,11 @@ struct chain_entry
         struct {
             __u16 values[MAX_MULTI_VALUES];
             __u8 count;
-        } ethertypes;      // allow_ethertype (future)
+        } ethertypes;      // allow_ethertype
         struct {
             __u8 values[MAX_MULTI_VALUES];
             __u8 count;
-        } protos;          // allow_proto (future)
+        } protos;          // allow_proto
     } input;
 };
 

--- a/api/chain.h
+++ b/api/chain.h
@@ -332,6 +332,57 @@ static int load_chain_program(struct config *conf,
         log_out(conf, "done: loaded allow_ethertype at slot %d\n", slot);
         break;
     }
+    case program_allow_proto:
+    {
+        struct allow_proto_bpf *obj = allow_proto_bpf__open();
+        if (!obj)
+        {
+            log_err(conf, "fail: opening allow_proto skeleton\n");
+            return 1;
+        }
+
+        err = bpf_map__reuse_fd(obj->maps.prog_array, prog_array_fd);
+        if (err)
+        {
+            log_err(conf, "fail: reusing prog_array for allow_proto\n");
+            allow_proto_bpf__destroy(obj);
+            return 1;
+        }
+
+        if (entry->has_input)
+        {
+            err = set_chain_rodata(obj->maps.rodata,
+                                   &entry->input.protos, sizeof(entry->input.protos),
+                                   slot);
+            if (err)
+            {
+                log_err(conf, "fail: setting rodata for allow_proto\n");
+                allow_proto_bpf__destroy(obj);
+                return 1;
+            }
+        }
+
+        err = allow_proto_bpf__load(obj);
+        if (err)
+        {
+            libbpf_strerror(err, buf, sizeof(buf));
+            log_err(conf, "fail: loading allow_proto: %s\n", buf);
+            allow_proto_bpf__destroy(obj);
+            return 1;
+        }
+
+        int prog_fd = bpf_program__fd(obj->progs.allow_proto);
+        err = bpf_map_update_elem(prog_array_fd, &slot, &prog_fd, BPF_ANY);
+        if (err)
+        {
+            log_err(conf, "fail: inserting allow_proto into prog_array slot %d\n", slot);
+            allow_proto_bpf__destroy(obj);
+            return 1;
+        }
+
+        log_out(conf, "done: loaded allow_proto at slot %d\n", slot);
+        break;
+    }
     default:
         log_err(conf, "fail: program '%s' does not support chaining\n",
                 g_programs_name[entry->program]);
@@ -347,7 +398,8 @@ static inline bool program_supports_chaining(program_t program)
     return program == program_allow_dns ||
            program == program_allow_ethertype ||
            program == program_allow_ipv4 ||
-           program == program_allow_port;
+           program == program_allow_port ||
+           program == program_allow_proto;
 }
 
 /// Attach a chain of programs using the dispatcher + tail calls.

--- a/api/input_parse.h
+++ b/api/input_parse.h
@@ -65,6 +65,17 @@ static int validate_delimited_input(const char *input_str, const char **err_msg)
     return 0;
 }
 
+// Returns true if the token contains any whitespace character.
+static inline bool token_has_whitespace(const char *token)
+{
+    for (const char *p = token; *p; p++)
+    {
+        if (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r')
+            return true;
+    }
+    return false;
+}
+
 // Parse a '+'-delimited list of EtherTypes into conf->input.ethertypes.
 // Each token is a symbolic name (ipv4, arp, ipv6) or a 0x-prefixed hex value.
 // Returns 0 on success, -1 on error (with err_msg set).
@@ -88,6 +99,11 @@ static int parse_ethertypes(struct config *conf, const char *input_str, const ch
 
     while (token)
     {
+        if (token_has_whitespace(token))
+        {
+            *err_msg = "value must not contain whitespace";
+            return -1;
+        }
         if (count >= MAX_MULTI_VALUES)
         {
             *err_msg = "too many EtherType values";
@@ -179,6 +195,11 @@ static int parse_protos(struct config *conf, const char *input_str, const char *
 
     while (token)
     {
+        if (token_has_whitespace(token))
+        {
+            *err_msg = "value must not contain whitespace";
+            return -1;
+        }
         if (count >= MAX_MULTI_VALUES)
         {
             *err_msg = "too many protocol values";

--- a/api/input_parse.h
+++ b/api/input_parse.h
@@ -2,6 +2,7 @@
 #define TRAFFICO_INPUT_PARSE_H
 
 #include <arpa/inet.h>
+#include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
@@ -70,7 +71,7 @@ static inline bool token_has_whitespace(const char *token)
 {
     for (const char *p = token; *p; p++)
     {
-        if (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r')
+        if (isspace((unsigned char)*p))
             return true;
     }
     return false;

--- a/api/input_parse.h
+++ b/api/input_parse.h
@@ -35,6 +35,7 @@ static const struct proto_name g_proto_names[] = {
     {"tcp", 6},
     {"udp", 17},
     {"icmp", 1},
+    {"sctp", 132},
     {NULL, 0},
 };
 
@@ -283,6 +284,8 @@ static int parse_input(struct config *conf, const char *input_str, const char **
     }
     case program_allow_ethertype:
         return parse_ethertypes(conf, input_str, err_msg);
+    case program_allow_proto:
+        return parse_protos(conf, input_str, err_msg);
     default:
         *err_msg = "program does not accept input";
         return -1;
@@ -292,7 +295,7 @@ static int parse_input(struct config *conf, const char *input_str, const char **
 // Returns true if the given program requires an input argument.
 static inline bool program_requires_input(program_t program)
 {
-    return program == program_allow_dns || program == program_allow_ethertype || program == program_allow_ipv4 || program == program_allow_port || program == program_block_ipv4 || program == program_block_port;
+    return program == program_allow_dns || program == program_allow_ethertype || program == program_allow_ipv4 || program == program_allow_port || program == program_allow_proto || program == program_block_ipv4 || program == program_block_port;
 }
 
 #endif // TRAFFICO_INPUT_PARSE_H

--- a/api/input_parse.h
+++ b/api/input_parse.h
@@ -209,9 +209,14 @@ static int parse_protos(struct config *conf, const char *input_str, const char *
             }
             char *endptr;
             unsigned long v = strtoul(token, &endptr, 10);
-            if (*endptr != '\0' || v > 255)
+            if (*endptr != '\0')
             {
-                *err_msg = "invalid protocol number";
+                *err_msg = "unknown protocol name (use a number 0-255)";
+                return -1;
+            }
+            if (v > 255)
+            {
+                *err_msg = "protocol number out of range (0-255)";
                 return -1;
             }
             // Protocol 0 (HOPOPT) is technically valid but unlikely intended;

--- a/bpf/allow_proto.bpf.c
+++ b/bpf/allow_proto.bpf.c
@@ -1,0 +1,69 @@
+#include "vmlinux.h"
+#include "commons.bpf.h"
+
+#include <bpf/bpf_endian.h>
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";
+
+const volatile __u8 allowed[MAX_MULTI_VALUES] = {};
+const volatile __u8 num_allowed = 0;
+const volatile __u32 slot = 0; // position in the chain (set by userspace)
+
+DEFINE_PROG_ARRAY();
+
+SEC("tc")
+int allow_proto(struct __sk_buff *skb)
+{
+    void *data_end = (void *)(unsigned long long)skb->data_end;
+    void *data = (void *)(unsigned long long)skb->data;
+
+    struct ethhdr *eth = data;
+    const int l3_offset = sizeof(*eth);
+
+    if (data + l3_offset > data_end)
+    {
+        bpf_printk("allow_proto: [eth] size length check hit: block");
+        return TC_ACT_SHOT;
+    }
+
+    // Passthrough: not IPv4 — protocol filtering doesn't apply.
+    // Non-IPv4 filtering is allow_ethertype's job.
+    if (eth->h_proto != bpf_htons(ETH_P_IP))
+    {
+        bpf_printk("allow_proto: [eth] protocol is %d: continue", eth->h_proto);
+        return TC_ACT_OK;
+    }
+
+    struct iphdr *ip_header = data + l3_offset;
+    if (data + l3_offset + sizeof(*ip_header) > data_end)
+    {
+        bpf_printk("allow_proto: [iph] size length check hit: block");
+        return TC_ACT_SHOT;
+    }
+
+    __u8 ihl = ip_header->ihl;
+    if (ihl < 5)
+    {
+        bpf_printk("allow_proto: [iph] invalid IHL %d: block", ihl);
+        return TC_ACT_SHOT;
+    }
+
+    __u8 proto = ip_header->protocol;
+
+    // Linear scan of the allowed IP protocols.
+    // MAX_MULTI_VALUES is small (8), so a loop is fine.
+    for (__u32 i = 0; i < MAX_MULTI_VALUES; i++)
+    {
+        if (i >= num_allowed)
+            break;
+        if (allowed[i] == proto)
+        {
+            bpf_printk("allow_proto: [iph] protocol %d: allow", proto);
+            tail_call_next(skb, slot);
+            return TC_ACT_OK;
+        }
+    }
+
+    bpf_printk("allow_proto: [iph] protocol %d not in allowed set: block", proto);
+    return TC_ACT_SHOT;
+}

--- a/bpf/allow_proto.bpf.c
+++ b/bpf/allow_proto.bpf.c
@@ -5,6 +5,12 @@
 
 char LICENSE[] SEC("license") = "Dual BSD/GPL";
 
+struct traffico_vlan_hdr
+{
+    __u16 h_vlan_tci;
+    __u16 h_vlan_encapsulated_proto;
+};
+
 const volatile __u8 allowed[MAX_MULTI_VALUES] = {};
 const volatile __u8 num_allowed = 0;
 const volatile __u32 slot = 0; // position in the chain (set by userspace)
@@ -18,7 +24,7 @@ int allow_proto(struct __sk_buff *skb)
     void *data = (void *)(unsigned long long)skb->data;
 
     struct ethhdr *eth = data;
-    const int l3_offset = sizeof(*eth);
+    int l3_offset = sizeof(*eth);
 
     if (data + l3_offset > data_end)
     {
@@ -26,11 +32,41 @@ int allow_proto(struct __sk_buff *skb)
         return TC_ACT_SHOT;
     }
 
-    // Passthrough: not IPv4 — protocol filtering doesn't apply.
-    // Non-IPv4 filtering is allow_ethertype's job.
-    if (eth->h_proto != bpf_htons(ETH_P_IP))
+    __u16 h_proto = eth->h_proto;
+
+    // Unwrap up to 2 VLAN tags (802.1Q and/or QinQ)
+#pragma unroll
+    for (int i = 0; i < 2; i++)
     {
-        bpf_printk("allow_proto: [eth] protocol is %d: continue", eth->h_proto);
+        if (h_proto != bpf_htons(ETH_P_8021Q) &&
+            h_proto != bpf_htons(ETH_P_8021AD))
+            break;
+
+        if (data + l3_offset + sizeof(struct traffico_vlan_hdr) > data_end)
+        {
+            bpf_printk("allow_proto: [vlan] size length check hit: block");
+            return TC_ACT_SHOT;
+        }
+
+        struct traffico_vlan_hdr *vlan = data + l3_offset;
+        h_proto = vlan->h_vlan_encapsulated_proto;
+        l3_offset += sizeof(*vlan);
+    }
+
+    // Fail closed on unsupported VLAN nesting (>2 tags)
+    if (h_proto == bpf_htons(ETH_P_8021Q) ||
+        h_proto == bpf_htons(ETH_P_8021AD))
+    {
+        bpf_printk("allow_proto: [vlan] unsupported nesting: block");
+        return TC_ACT_SHOT;
+    }
+
+    // Passthrough: not IPv4 - protocol filtering doesn't apply.
+    // Non-IPv4 filtering is allow_ethertype's job.
+    if (h_proto != bpf_htons(ETH_P_IP))
+    {
+        bpf_printk("allow_proto: [eth] protocol is %d: continue", bpf_ntohs(h_proto));
+        tail_call_next(skb, slot);
         return TC_ACT_OK;
     }
 

--- a/bpf/commons.bpf.h
+++ b/bpf/commons.bpf.h
@@ -23,6 +23,14 @@
 #define ETH_P_ARP 0x0806
 #endif
 
+#ifndef ETH_P_8021Q
+#define ETH_P_8021Q 0x8100
+#endif
+
+#ifndef ETH_P_8021AD
+#define ETH_P_8021AD 0x88A8
+#endif
+
 /// Maximum number of values in a multi-value rodata input.
 /// Must match MAX_MULTI_VALUES in api.h.
 #define MAX_MULTI_VALUES 8

--- a/docs/README.md
+++ b/docs/README.md
@@ -123,6 +123,7 @@ Here's an example CNI config file featuring `traffico-cni`.
 | `allow_ethertype` | L2 gatekeeper: drops frames whose EtherType is not in the allowed set (e.g., `ipv4+arp`). Must be first in a chain (see notes below). |
 | `allow_ipv4` | Allows IPv4 traffic to the input address, drops the rest. Non-IPv4 passes through for L2/chain policy. Localhost (127.0.0.0/8) always allowed. |
 | `allow_port` | Allows IPv4 TCP/UDP traffic to the input port, drops the rest. Other protocols (ICMP, etc.) pass through. Non-IPv4 blocked. |
+| `allow_proto` | L3 gatekeeper: drops IPv4 packets whose IP protocol is not in the allowed set (e.g., `tcp+udp`). Non-IPv4 passes through. |
 | `block_private_ipv4` | Blocks private IPv4 addresses subnets allowing only SSH access on port 22 |
 | `block_ipv4` | Drops packets with destination equal to the input IPv4 address |
 | `block_port` | Drops packets with the destination port equal to the input port number |
@@ -133,6 +134,12 @@ Here's an example CNI config file featuring `traffico-cni`.
 **Chain ordering:** In a chain, `allow_ethertype` must be the first program. L3+ programs (`allow_ipv4`, `allow_port`, etc.) pass through traffic outside their domain (e.g., non-IPv4 frames return `TC_ACT_OK` directly), which bypasses any downstream `allow_ethertype` filter.
 
 **VLAN-tagged networks:** Symbolic names `vlan` (0x8100) and `qinq` (0x88A8) are available. VLAN TPIDs are only supported in standalone mode. In chains, they are rejected because downstream L3/L4 programs cannot yet parse VLAN-encapsulated payloads. Example (standalone): `allow_ethertype ipv4+arp+vlan`.
+
+### Notes on `allow_proto`
+
+**Chain ordering:** In a chain, `allow_proto` should be placed after `allow_ethertype` and before `allow_port`/`allow_dns`. This gives L2 → L3 → L4 ordering with cheapest checks first. Example: `--chain "allow_ethertype:ipv4+arp,allow_proto:tcp+udp,allow_port:8080"`.
+
+**Non-IPv4 passthrough:** Non-IPv4 traffic (ARP, IPv6) passes through unfiltered. L2 filtering is `allow_ethertype`'s responsibility.
 
 ## Build
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -139,6 +139,8 @@ Here's an example CNI config file featuring `traffico-cni`.
 
 **Chain ordering:** In a chain, `allow_proto` should be placed after `allow_ethertype` and before `allow_port`/`allow_dns`. This gives L2 → L3 → L4 ordering with cheapest checks first. Example: `--chain "allow_ethertype:ipv4+arp,allow_proto:tcp+udp,allow_port:8080"`.
 
+**VLAN-tagged IPv4:** `allow_proto` unwraps supported 802.1Q and QinQ tags before reading the IPv4 protocol. Truncated VLAN headers and unsupported additional VLAN nesting fail closed.
+
 **Non-IPv4 passthrough:** Non-IPv4 traffic (ARP, IPv6) passes through unfiltered. L2 filtering is `allow_ethertype`'s responsibility.
 
 ## Build

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -458,6 +458,21 @@ sys.exit(0)
     echo "# cannot ping ${VETH_ADDR} (icmp blocked at L3 by allow_proto)" >&3
 }
 
+@test "chain allow_ethertype+allow_proto allows TCP" {
+    new_server
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
+    # L2: allow IPv4+ARP, L3: allow TCP+UDP — HTTP (TCP) should pass
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ethertype:ipv4+arp,allow_proto:tcp+udp" >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can still reach ${VETH_ADDR}:${SERVER_PORT} (TCP allowed by chain)" >&3
+}
+
 @test "chain allow_ipv4+allow_port allows matching traffic" {
     new_server
     run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -403,6 +403,61 @@ sys.exit(0)
     echo "# can still ping ${VETH_ADDR} (0x0800+0x0806 allowed)" >&3
 }
 
+@test "allow_proto tcp+udp+icmp allows ping" {
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 0 ]
+    echo "# can ping ${VETH_ADDR} from the namespace" >&3
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_proto tcp+udp+icmp >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 0 ]
+    echo "# can still ping ${VETH_ADDR} (icmp in allowed set)" >&3
+}
+
+@test "allow_proto tcp+udp blocks ping" {
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 0 ]
+    echo "# can ping ${VETH_ADDR} from the namespace" >&3
+    # Allow only TCP and UDP — ICMP is not in the allowed set
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_proto tcp+udp >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 1 ]
+    echo "# cannot ping ${VETH_ADDR} (icmp not in allowed set)" >&3
+}
+
+@test "allow_proto with decimal values allows ping" {
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 0 ]
+    echo "# can ping ${VETH_ADDR} from the namespace" >&3
+    # 6=TCP, 17=UDP, 1=ICMP
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_proto 6+17+1 >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 0 ]
+    echo "# can still ping ${VETH_ADDR} (6+17+1 allowed)" >&3
+}
+
+@test "chain allow_ethertype+allow_proto blocks ICMP" {
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 0 ]
+    echo "# can ping ${VETH_ADDR} from the namespace" >&3
+    # L2: allow IPv4+ARP, L3: allow only TCP+UDP — ICMP blocked at L3
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ethertype:ipv4+arp,allow_proto:tcp+udp" >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 1 ]
+    echo "# cannot ping ${VETH_ADDR} (icmp blocked at L3 by allow_proto)" >&3
+}
+
 @test "chain allow_ipv4+allow_port allows matching traffic" {
     new_server
     run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -268,3 +268,69 @@ bats_require_minimum_version 1.7.0
     [ $status -eq 1 ]
     [ "${lines[0]}" == "traffico: duplicate EtherType value: 'qinq+0x88A8'" ]
 }
+
+@test "missing input for allow_proto" {
+    run traffico -i lo allow_proto
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: program 'allow_proto' requires an input argument" ]
+}
+
+@test "unknown protocol name" {
+    run traffico -i lo allow_proto xxx
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: invalid protocol number: 'xxx'" ]
+}
+
+@test "invalid protocol decimal" {
+    run traffico -i lo allow_proto abc
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: invalid protocol number: 'abc'" ]
+}
+
+@test "protocol number out of range" {
+    run traffico -i lo allow_proto 256
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: invalid protocol number: '256'" ]
+}
+
+@test "duplicate protocol values" {
+    run traffico -i lo allow_proto tcp+tcp
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: duplicate protocol value: 'tcp+tcp'" ]
+}
+
+@test "duplicate protocol values across representations" {
+    run traffico -i lo allow_proto tcp+6
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: duplicate protocol value: 'tcp+6'" ]
+}
+
+@test "trailing + in proto input" {
+    run traffico -i lo allow_proto "tcp+"
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: input must not end with '+': 'tcp+'" ]
+}
+
+@test "leading + in proto input" {
+    run traffico -i lo allow_proto "+tcp"
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: input must not start with '+': '+tcp'" ]
+}
+
+@test "consecutive ++ in proto input" {
+    run traffico -i lo allow_proto "tcp++udp"
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: input contains empty value between '+' delimiters: 'tcp++udp'" ]
+}
+
+@test "too many protocol values" {
+    run traffico -i lo allow_proto "1+2+3+4+5+6+7+8+9"
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: too many protocol values: '1+2+3+4+5+6+7+8+9'" ]
+}
+
+@test "sctp symbolic name resolves to 132" {
+    run traffico -i lo allow_proto "sctp+132"
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: duplicate protocol value: 'sctp+132'" ]
+}

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -336,10 +336,11 @@ bats_require_minimum_version 1.7.0
 }
 
 @test "protocol 0 is accepted" {
-    run traffico -i lo allow_proto 0
-    # Exit 1 from BPF load (no root), not from parsing.
-    # If parsing rejected 0, the error message would mention "invalid" or "out of range".
-    [[ "${lines[0]}" != *"invalid"* ]]
-    [[ "${lines[0]}" != *"out of range"* ]]
-    [[ "${lines[0]}" != *"unknown"* ]]
+    run timeout 2 traffico -i lo allow_proto 0
+    [ $status -ne 0 ]
+    # Accept either an unprivileged BPF-load failure or a privileged timeout
+    # after successful attach; both cases mean parsing accepted protocol 0.
+    [[ "$output" != *"invalid"* ]]
+    [[ "$output" != *"out of range"* ]]
+    [[ "$output" != *"unknown"* ]]
 }

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -278,19 +278,19 @@ bats_require_minimum_version 1.7.0
 @test "unknown protocol name" {
     run traffico -i lo allow_proto xxx
     [ $status -eq 1 ]
-    [ "${lines[0]}" == "traffico: invalid protocol number: 'xxx'" ]
+    [ "${lines[0]}" == "traffico: unknown protocol name (use a number 0-255): 'xxx'" ]
 }
 
 @test "invalid protocol decimal" {
     run traffico -i lo allow_proto abc
     [ $status -eq 1 ]
-    [ "${lines[0]}" == "traffico: invalid protocol number: 'abc'" ]
+    [ "${lines[0]}" == "traffico: unknown protocol name (use a number 0-255): 'abc'" ]
 }
 
 @test "protocol number out of range" {
     run traffico -i lo allow_proto 256
     [ $status -eq 1 ]
-    [ "${lines[0]}" == "traffico: invalid protocol number: '256'" ]
+    [ "${lines[0]}" == "traffico: protocol number out of range (0-255): '256'" ]
 }
 
 @test "duplicate protocol values" {
@@ -333,4 +333,13 @@ bats_require_minimum_version 1.7.0
     run traffico -i lo allow_proto "sctp+132"
     [ $status -eq 1 ]
     [ "${lines[0]}" == "traffico: duplicate protocol value: 'sctp+132'" ]
+}
+
+@test "protocol 0 is accepted" {
+    run traffico -i lo allow_proto 0
+    # Exit 1 from BPF load (no root), not from parsing.
+    # If parsing rejected 0, the error message would mention "invalid" or "out of range".
+    [[ "${lines[0]}" != *"invalid"* ]]
+    [[ "${lines[0]}" != *"out of range"* ]]
+    [[ "${lines[0]}" != *"unknown"* ]]
 }

--- a/test/cni.bats
+++ b/test/cni.bats
@@ -129,6 +129,22 @@ s.close()
     echo "# can still ping ${VETH_ADDR} (ipv4+arp allowed)" >&3
 }
 
+@test "allow_proto via CNI" {
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 0 ]
+    echo "# can ping ${VETH_ADDR} from the namespace" >&3
+    echo "# installing allow_proto in the namespace" >&3
+    run ip netns exec "${NETNS}" bash -c "cat '$FIXTURE_ROOT/attach_allow_proto_in.json' | CNI_COMMAND=ADD traffico-cni"
+    [ $status -eq 0 ]
+    echo "# attach ok" >&3
+    run ip netns exec "${NETNS}" tc qdisc show dev peer0 clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    echo "# qdisc ok" >&3
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 0 ]
+    echo "# can still ping ${VETH_ADDR} (tcp+udp+icmp allowed)" >&3
+}
+
 @test "allow_port via CNI" {
     run curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
     [ $status -eq 0 ]

--- a/test/fixtures/cni/attach_allow_proto_in.json
+++ b/test/fixtures/cni/attach_allow_proto_in.json
@@ -1,0 +1,22 @@
+{
+    "cniVersion": "0.4.0",
+    "name": "dummy-network",
+    "prevResult": {
+        "cniVersion": "1.0.0",
+        "interfaces": [
+            {
+                "name": "peer0"
+            }
+        ],
+        "ips": [
+        ],
+        "routes": [
+        ],
+        "dns": {
+        }
+    },
+    "type": "traffico-cni",
+    "program": "allow_proto",
+    "input": "tcp+udp+icmp",
+    "attachPoint": "egress"
+}

--- a/xmake/modules/api.lua
+++ b/xmake/modules/api.lua
@@ -13,6 +13,7 @@ local input_fields = {
     allow_ethertype = { field = "ethertypes", multi = true },
     allow_ipv4 = "ip",
     allow_port = "port",
+    allow_proto = { field = "protos", multi = true },
     block_ipv4 = "ip",
     block_port = "port",
 }


### PR DESCRIPTION
L3 IP protocol allowlist program. Drops IPv4 packets whose IP protocol
is not in the allowed set. Non-IPv4 traffic passes through (L2 filtering
is `allow_ethertype`'s job). Accepts a `+`-delimited list of symbolic
names (`tcp`, `udp`, `icmp`, `sctp`) or decimal numbers.

Second multi-value input program, following the pattern established by
`allow_ethertype` in PR #51.

## Changes

1. **BPF program** (`bpf/allow_proto.bpf.c`): reads `ip_header->protocol`,
   linear scans `allowed[MAX_MULTI_VALUES]` array. Match: tail-call next.
   No match: `TC_ACT_SHOT`. Non-IPv4 passthrough (`TC_ACT_OK`).
   Fail-closed on truncated headers and invalid IHL.

2. **Parser wiring**: `case program_allow_proto` in `parse_input()`
   calling the existing `parse_protos()` helper. Added to
   `program_requires_input()`. Added `sctp` (132) to `g_proto_names[]`.
   `input_fields` entry in `api.lua`:
   `allow_proto = { field = "protos", multi = true }`.

3. **Chain loader**: `case program_allow_proto` in
   `load_chain_program()`. Passes the protos struct (values + count)
   to `set_chain_rodata()`. Added to `program_supports_chaining()`.

4. **Tests**: 11 flag validation tests (missing input, unknown name,
   invalid decimal, out of range, duplicates, delimiter edge cases,
   too many values, sctp cross-repr). 4 integration tests (standalone
   allow, standalone block, decimal input, chain with allow_ethertype).
   1 CNI test with fixture.

5. **Docs**: `README.txt` and `docs/README.md` with chain ordering notes.

## Design decisions

- **Non-IPv4 passthrough**: consistent with `allow_ipv4`, `allow_port`,
  `allow_dns`. The chain ordering bypass where L3+ passthrough
  short-circuits downstream L2 filters is a chain-model issue, not
  specific to this program.
- **No fragment handling**: the protocol field is at byte 9 in the fixed
  IP header, always readable regardless of fragmentation.
- **Recommended chain position**: after `allow_ethertype`, before
  `allow_port` (L2 → L3 → L4).

## Stacked on

- PR #52 (`feat/ethertype-vlan-names`) — vlan/qinq symbolic names
- PR #51 (`feat/allow-ethertype`) — L2 gatekeeper
- PR #49 (`feat/multi-value-rodata`) — multi-value input infrastructure