### PR TITLE
test: add chain parser and attachment regression tests for #45

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           pacman -S --noconfirm \
             clang llvm gcc linux-headers bpf \
             make cmake xmake sudo diffutils \
-            curl iproute2 iputils
+            curl iproute2 iputils python
 
       - name: Configure
         run: xmake f -y --generate-vmlinux=y

--- a/README.txt
+++ b/README.txt
@@ -115,6 +115,11 @@ BUILT-IN PROGRAMS
         destination equal to the input IPv4 address. Localhost (127.0.0.0/8)
         traffic is always allowed.
 
+    allow_port
+        allow_port is a program that drops all TCP/UDP packets except those
+        with destination port equal to the input port number. Non-TCP/UDP
+        protocols (ICMP, etc.) are not affected.
+
     block_private_ipv4
         block_private_ipv4 is a program that can be used to block
         private IPv4 addresses subnets allowing only SSH access on port 22.

--- a/README.txt
+++ b/README.txt
@@ -110,6 +110,11 @@ USAGE
 
 BUILT-IN PROGRAMS
 
+    allow_ip
+        allow_ip is a program that drops all packets except those with
+        destination equal to the input IPv4 address. Localhost (127.0.0.0/8)
+        traffic is always allowed.
+
     block_private_ipv4
         block_private_ipv4 is a program that can be used to block
         private IPv4 addresses subnets allowing only SSH access on port 22.

--- a/README.txt
+++ b/README.txt
@@ -110,8 +110,8 @@ USAGE
 
 BUILT-IN PROGRAMS
 
-    allow_ip
-        allow_ip is a program that drops all packets except those with
+    allow_ipv4
+        allow_ipv4 is a program that drops all packets except those with
         destination equal to the input IPv4 address. Localhost (127.0.0.0/8)
         traffic is always allowed.
 

--- a/README.txt
+++ b/README.txt
@@ -110,6 +110,11 @@ USAGE
 
 BUILT-IN PROGRAMS
 
+    allow_dns
+        allow_dns is a program that drops DNS packets (UDP/TCP port 53)
+        not destined for the input IPv4 resolver address. Non-DNS traffic
+        is not affected.
+
     allow_ipv4
         allow_ipv4 is a program that drops all packets except those with
         destination equal to the input IPv4 address. Localhost (127.0.0.0/8)

--- a/api/chain.h
+++ b/api/chain.h
@@ -55,19 +55,26 @@ static int set_chain_rodata(struct bpf_map *rodata_map,
                             const void *input_val, size_t input_sz,
                             __u32 slot)
 {
+    if (!rodata_map)
+        return -EINVAL;
+
     size_t rodata_sz = bpf_map__value_size(rodata_map);
+
+    // Validate that the input fits in the rodata map
+    if (input_sz > rodata_sz)
+        return -ENOSPC;
+
+    size_t slot_offset = (input_sz + 3) & ~3;
+    if (slot_offset + sizeof(__u32) > rodata_sz)
+        return -ENOSPC;
+
     void *buf = calloc(1, rodata_sz);
     if (!buf)
         return -ENOMEM;
 
     // Layout: input at offset 0, slot at offset aligned to 4 bytes after input
     memcpy(buf, input_val, input_sz);
-    // slot is always a __u32 placed after the input field, aligned to 4 bytes
-    size_t slot_offset = (input_sz + 3) & ~3;
-    if (slot_offset + sizeof(__u32) <= rodata_sz)
-    {
-        memcpy((char *)buf + slot_offset, &slot, sizeof(slot));
-    }
+    memcpy((char *)buf + slot_offset, &slot, sizeof(slot));
 
     int err = bpf_map__set_initial_value(rodata_map, buf, rodata_sz);
     free(buf);

--- a/api/chain.h
+++ b/api/chain.h
@@ -1,0 +1,410 @@
+#ifndef TRAFFICO_CHAIN_H
+#define TRAFFICO_CHAIN_H
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <bpf/bpf.h>
+#include <bpf/libbpf.h>
+
+#include "api.h"
+#include "dispatcher.skel.h"
+#include "allow_dns.skel.h"
+#include "allow_ipv4.skel.h"
+#include "allow_port.skel.h"
+
+#define MAX_CHAIN_LEN 8
+#define BPFFS_BASE "/sys/fs/bpf/traffico"
+
+/// A single entry in a chain: program type + input value.
+struct chain_entry
+{
+    program_t program;
+    bool has_input;
+    union {
+        __u32 ip;
+        __u16 port;
+    } input;
+};
+
+/// Ensure a directory exists, creating parents as needed.
+static int ensure_dir(const char *dir)
+{
+    char tmp[256];
+    char *p = NULL;
+    snprintf(tmp, sizeof(tmp), "%s", dir);
+    for (p = tmp + 1; *p; p++)
+    {
+        if (*p == '/')
+        {
+            *p = '\0';
+            mkdir(tmp, 0755);
+            *p = '/';
+        }
+    }
+    return mkdir(tmp, 0755) == 0 || errno == EEXIST ? 0 : -errno;
+}
+
+/// Set rodata for a program's skeleton map.
+/// Writes the input value at offset 0 and the slot index at the
+/// appropriate offset in the rodata buffer.
+static int set_chain_rodata(struct bpf_map *rodata_map,
+                            const void *input_val, size_t input_sz,
+                            __u32 slot)
+{
+    size_t rodata_sz = bpf_map__value_size(rodata_map);
+    void *buf = calloc(1, rodata_sz);
+    if (!buf)
+        return -ENOMEM;
+
+    // Layout: input at offset 0, slot at offset aligned to 4 bytes after input
+    memcpy(buf, input_val, input_sz);
+    // slot is always a __u32 placed after the input field, aligned to 4 bytes
+    size_t slot_offset = (input_sz + 3) & ~3;
+    if (slot_offset + sizeof(__u32) <= rodata_sz)
+    {
+        memcpy((char *)buf + slot_offset, &slot, sizeof(slot));
+    }
+
+    int err = bpf_map__set_initial_value(rodata_map, buf, rodata_sz);
+    free(buf);
+    return err;
+}
+
+/// Load a chain program, set its rodata, reuse the dispatcher's prog_array,
+/// and insert it into the prog_array at the given slot.
+static int load_chain_program(struct config *conf,
+                              struct chain_entry *entry,
+                              int prog_array_fd,
+                              __u32 slot)
+{
+    int err;
+    char buf[100];
+    buf[sizeof(buf) - 1] = '\0';
+
+    switch (entry->program)
+    {
+    case program_allow_ipv4:
+    {
+        struct allow_ipv4_bpf *obj = allow_ipv4_bpf__open();
+        if (!obj)
+        {
+            log_err(conf, "fail: opening allow_ipv4 skeleton\n");
+            return 1;
+        }
+
+        // Reuse dispatcher's prog_array
+        err = bpf_map__reuse_fd(obj->maps.prog_array, prog_array_fd);
+        if (err)
+        {
+            log_err(conf, "fail: reusing prog_array for allow_ipv4v4v4\n");
+            allow_ipv4_bpf__destroy(obj);
+            return 1;
+        }
+
+        // Set rodata
+        if (entry->has_input)
+        {
+            err = set_chain_rodata(obj->maps.rodata,
+                                   &entry->input.ip, sizeof(entry->input.ip),
+                                   slot);
+            if (err)
+            {
+                log_err(conf, "fail: setting rodata for allow_ipv4v4\n");
+                allow_ipv4_bpf__destroy(obj);
+                return 1;
+            }
+        }
+
+        err = allow_ipv4_bpf__load(obj);
+        if (err)
+        {
+            libbpf_strerror(err, buf, sizeof(buf));
+            log_err(conf, "fail: loading allow_ipv4: %s\n", buf);
+            allow_ipv4_bpf__destroy(obj);
+            return 1;
+        }
+
+        int prog_fd = bpf_program__fd(obj->progs.allow_ipv4);
+        err = bpf_map_update_elem(prog_array_fd, &slot, &prog_fd, BPF_ANY);
+        if (err)
+        {
+            log_err(conf, "fail: inserting allow_ipv4 into prog_array slot %d\n", slot);
+            allow_ipv4_bpf__destroy(obj);
+            return 1;
+        }
+
+        log_out(conf, "done: loaded allow_ipv4 at slot %d\n", slot);
+        // Note: we intentionally do NOT destroy obj here — the kernel
+        // holds a reference to the program via prog_array, but the
+        // skeleton's maps/progs FDs must stay open until pinned.
+        // For now, we leak the skeleton. Pinning is handled separately.
+        break;
+    }
+    case program_allow_port:
+    {
+        struct allow_port_bpf *obj = allow_port_bpf__open();
+        if (!obj)
+        {
+            log_err(conf, "fail: opening allow_port skeleton\n");
+            return 1;
+        }
+
+        err = bpf_map__reuse_fd(obj->maps.prog_array, prog_array_fd);
+        if (err)
+        {
+            log_err(conf, "fail: reusing prog_array for allow_port\n");
+            allow_port_bpf__destroy(obj);
+            return 1;
+        }
+
+        if (entry->has_input)
+        {
+            err = set_chain_rodata(obj->maps.rodata,
+                                   &entry->input.port, sizeof(entry->input.port),
+                                   slot);
+            if (err)
+            {
+                log_err(conf, "fail: setting rodata for allow_port\n");
+                allow_port_bpf__destroy(obj);
+                return 1;
+            }
+        }
+
+        err = allow_port_bpf__load(obj);
+        if (err)
+        {
+            libbpf_strerror(err, buf, sizeof(buf));
+            log_err(conf, "fail: loading allow_port: %s\n", buf);
+            allow_port_bpf__destroy(obj);
+            return 1;
+        }
+
+        int prog_fd = bpf_program__fd(obj->progs.allow_port);
+        err = bpf_map_update_elem(prog_array_fd, &slot, &prog_fd, BPF_ANY);
+        if (err)
+        {
+            log_err(conf, "fail: inserting allow_port into prog_array slot %d\n", slot);
+            allow_port_bpf__destroy(obj);
+            return 1;
+        }
+
+        log_out(conf, "done: loaded allow_port at slot %d\n", slot);
+        break;
+    }
+    case program_allow_dns:
+    {
+        struct allow_dns_bpf *obj = allow_dns_bpf__open();
+        if (!obj)
+        {
+            log_err(conf, "fail: opening allow_dns skeleton\n");
+            return 1;
+        }
+
+        err = bpf_map__reuse_fd(obj->maps.prog_array, prog_array_fd);
+        if (err)
+        {
+            log_err(conf, "fail: reusing prog_array for allow_dns\n");
+            allow_dns_bpf__destroy(obj);
+            return 1;
+        }
+
+        if (entry->has_input)
+        {
+            err = set_chain_rodata(obj->maps.rodata,
+                                   &entry->input.ip, sizeof(entry->input.ip),
+                                   slot);
+            if (err)
+            {
+                log_err(conf, "fail: setting rodata for allow_dns\n");
+                allow_dns_bpf__destroy(obj);
+                return 1;
+            }
+        }
+
+        err = allow_dns_bpf__load(obj);
+        if (err)
+        {
+            libbpf_strerror(err, buf, sizeof(buf));
+            log_err(conf, "fail: loading allow_dns: %s\n", buf);
+            allow_dns_bpf__destroy(obj);
+            return 1;
+        }
+
+        int prog_fd = bpf_program__fd(obj->progs.allow_dns);
+        err = bpf_map_update_elem(prog_array_fd, &slot, &prog_fd, BPF_ANY);
+        if (err)
+        {
+            log_err(conf, "fail: inserting allow_dns into prog_array slot %d\n", slot);
+            allow_dns_bpf__destroy(obj);
+            return 1;
+        }
+
+        log_out(conf, "done: loaded allow_dns at slot %d\n", slot);
+        break;
+    }
+    default:
+        log_err(conf, "fail: program '%s' does not support chaining\n",
+                g_programs_name[entry->program]);
+        return 1;
+    }
+
+    return 0;
+}
+
+/// Attach a chain of programs using the dispatcher + tail calls.
+///
+/// 1. Load and attach the dispatcher to TC
+/// 2. For each entry: load the program, set rodata, insert into prog_array
+/// 3. Pin prog_array to bpffs for persistence
+int attach_chain(struct config *conf,
+                 struct chain_entry *entries, int chain_len,
+                 after_attach_fn_t cb)
+{
+    int err;
+    char buf[100];
+    buf[sizeof(buf) - 1] = '\0';
+
+    if (chain_len < 1 || chain_len > MAX_CHAIN_LEN)
+    {
+        log_err(conf, "fail: chain length %d out of range [1, %d]\n",
+                chain_len, MAX_CHAIN_LEN);
+        return 1;
+    }
+
+    // 1. Load and attach the dispatcher
+    struct dispatcher_bpf *dispatcher = dispatcher_bpf__open();
+    if (!dispatcher)
+    {
+        log_err(conf, "fail: opening dispatcher skeleton\n");
+        return 1;
+    }
+
+    err = dispatcher_bpf__load(dispatcher);
+    if (err)
+    {
+        libbpf_strerror(err, buf, sizeof(buf));
+        log_err(conf, "fail: loading dispatcher: %s\n", buf);
+        goto destroy;
+    }
+
+    DECLARE_LIBBPF_OPTS(bpf_tc_hook, hook,
+                        .ifindex = conf->ifindex,
+                        .attach_point = conf->attach_point);
+    err = bpf_tc_hook_create(&hook);
+    if (err && err != -EEXIST)
+    {
+        libbpf_strerror(err, buf, sizeof(buf));
+        log_err(conf, "fail: creating the qdisc: %s\n", buf);
+        goto destroy;
+    }
+
+    int dispatcher_fd = bpf_program__fd(dispatcher->progs.dispatcher);
+    DECLARE_LIBBPF_OPTS(bpf_tc_opts, opts,
+                        .prog_fd = dispatcher_fd,
+                        .flags = BPF_TC_F_REPLACE);
+    err = bpf_tc_attach(&hook, &opts);
+    if (err)
+    {
+        libbpf_strerror(err, buf, sizeof(buf));
+        log_err(conf, "fail: attaching dispatcher: %s\n", buf);
+        goto cleanup_hook;
+    }
+    log_out(conf, "done: attached dispatcher\n");
+
+    // 2. Get the prog_array map FD from the dispatcher
+    int prog_array_fd = bpf_map__fd(dispatcher->maps.prog_array);
+    if (prog_array_fd < 0)
+    {
+        log_err(conf, "fail: getting prog_array fd\n");
+        goto cleanup_hook;
+    }
+
+    // 3. Pin prog_array to bpffs for persistence (best-effort).
+    //    In CLI mode the process stays alive holding FDs, so pinning
+    //    is not required. It only matters for CNI where the process
+    //    exits after attach. If bpffs is not mounted we continue.
+    char pin_dir[256];
+    char pin_path[256];
+    bool pinned = false;
+    snprintf(pin_dir, sizeof(pin_dir), "%s/%s", BPFFS_BASE, conf->ifname);
+    snprintf(pin_path, sizeof(pin_path), "%s/prog_array", pin_dir);
+    err = ensure_dir(pin_dir);
+    if (err)
+    {
+        log_out(conf, "warn: cannot create pin directory %s: %s (continuing without pinning)\n",
+                pin_dir, strerror(-err));
+    }
+    else
+    {
+        // Remove stale pin if it exists
+        unlink(pin_path);
+        err = bpf_map__pin(dispatcher->maps.prog_array, pin_path);
+        if (err)
+        {
+            libbpf_strerror(err, buf, sizeof(buf));
+            log_out(conf, "warn: pinning prog_array failed: %s (continuing without pinning)\n", buf);
+        }
+        else
+        {
+            pinned = true;
+            log_out(conf, "done: pinned prog_array to %s\n", pin_path);
+        }
+    }
+
+    // 4. Load each chain program
+    for (int i = 0; i < chain_len; i++)
+    {
+        err = load_chain_program(conf, &entries[i], prog_array_fd, (__u32)i);
+        if (err)
+        {
+            log_err(conf, "fail: loading chain program at slot %d\n", i);
+            goto cleanup_pins;
+        }
+    }
+
+    log_out(conf, "done: chain of %d programs attached\n", chain_len);
+
+    // 5. Callback (e.g., wait for signal in CLI mode)
+    err = cb(hook, opts);
+
+    // 6. Cleanup
+    if (conf->cleanup_on_exit)
+    {
+        goto cleanup_pins;
+    }
+
+    // If not cleaning up, just destroy the skeleton (FDs are pinned)
+    dispatcher_bpf__destroy(dispatcher);
+    return 0;
+
+cleanup_pins:
+    if (conf->cleanup_on_exit && pinned)
+    {
+        unlink(pin_path);
+        // Remove pin directory (ignore errors — may not be empty)
+        rmdir(pin_dir);
+    }
+
+cleanup_hook:
+    if (conf->cleanup_on_exit)
+    {
+        opts.prog_fd = opts.prog_id = 0;
+        opts.flags = 0;
+        bpf_tc_detach(&hook, &opts);
+        log_out(conf, "done: detached dispatcher\n");
+
+        hook.attach_point |= BPF_TC_INGRESS;
+        bpf_tc_hook_destroy(&hook);
+        log_out(conf, "done: destroyed qdisc\n");
+    }
+
+destroy:
+    dispatcher_bpf__destroy(dispatcher);
+    return err < 0 ? -err : err;
+}
+
+#endif // TRAFFICO_CHAIN_H

--- a/api/chain.h
+++ b/api/chain.h
@@ -100,7 +100,7 @@ static int load_chain_program(struct config *conf,
         err = bpf_map__reuse_fd(obj->maps.prog_array, prog_array_fd);
         if (err)
         {
-            log_err(conf, "fail: reusing prog_array for allow_ipv4v4v4\n");
+            log_err(conf, "fail: reusing prog_array for allow_ipv4\n");
             allow_ipv4_bpf__destroy(obj);
             return 1;
         }
@@ -113,7 +113,7 @@ static int load_chain_program(struct config *conf,
                                    slot);
             if (err)
             {
-                log_err(conf, "fail: setting rodata for allow_ipv4v4\n");
+                log_err(conf, "fail: setting rodata for allow_ipv4\n");
                 allow_ipv4_bpf__destroy(obj);
                 return 1;
             }

--- a/api/chain.h
+++ b/api/chain.h
@@ -255,11 +255,24 @@ static int load_chain_program(struct config *conf,
     return 0;
 }
 
+/// Returns true if the given program supports chaining.
+static inline bool program_supports_chaining(program_t program)
+{
+    return program == program_allow_ipv4 ||
+           program == program_allow_port ||
+           program == program_allow_dns;
+}
+
 /// Attach a chain of programs using the dispatcher + tail calls.
 ///
-/// 1. Load and attach the dispatcher to TC
-/// 2. For each entry: load the program, set rodata, insert into prog_array
-/// 3. Pin prog_array to bpffs for persistence
+/// 1. Validate all chain entries before touching TC
+/// 2. Load and attach the dispatcher to TC
+/// 3. For each entry: load the program, set rodata, insert into prog_array
+/// 4. Pin prog_array to bpffs for persistence
+///
+/// On failure, always cleans up resources created by this call,
+/// regardless of cleanup_on_exit. The --no-cleanup flag only preserves
+/// state after a successful attach.
 int attach_chain(struct config *conf,
                  struct chain_entry *entries, int chain_len,
                  after_attach_fn_t cb)
@@ -275,7 +288,18 @@ int attach_chain(struct config *conf,
         return 1;
     }
 
-    // 1. Load and attach the dispatcher
+    // 1. Validate all chain entries before attaching anything
+    for (int i = 0; i < chain_len; i++)
+    {
+        if (!program_supports_chaining(entries[i].program))
+        {
+            log_err(conf, "fail: program '%s' does not support chaining\n",
+                    g_programs_name[entries[i].program]);
+            return 1;
+        }
+    }
+
+    // 2. Load and attach the dispatcher
     struct dispatcher_bpf *dispatcher = dispatcher_bpf__open();
     if (!dispatcher)
     {
@@ -355,52 +379,68 @@ int attach_chain(struct config *conf,
         }
     }
 
-    // 4. Load each chain program
+    // 5. Load each chain program
     for (int i = 0; i < chain_len; i++)
     {
         err = load_chain_program(conf, &entries[i], prog_array_fd, (__u32)i);
         if (err)
         {
             log_err(conf, "fail: loading chain program at slot %d\n", i);
-            goto cleanup_pins;
+            // Always clean up on failure — a partial chain with an
+            // attached dispatcher is worse than no chain at all.
+            goto cleanup_failure;
         }
     }
 
     log_out(conf, "done: chain of %d programs attached\n", chain_len);
 
-    // 5. Callback (e.g., wait for signal in CLI mode)
+    // 6. Callback (e.g., wait for signal in CLI mode)
     err = cb(hook, opts);
 
-    // 6. Cleanup
+    // 7. Cleanup after callback returns (normal exit path)
     if (conf->cleanup_on_exit)
     {
-        goto cleanup_pins;
+        goto cleanup_success;
     }
 
     // If not cleaning up, just destroy the skeleton (FDs are pinned)
     dispatcher_bpf__destroy(dispatcher);
     return 0;
 
-cleanup_pins:
-    if (conf->cleanup_on_exit && pinned)
+cleanup_failure:
+    // On failure, always clean up regardless of --no-cleanup.
+    // A partially attached chain is a security risk.
+    if (pinned)
     {
         unlink(pin_path);
-        // Remove pin directory (ignore errors — may not be empty)
+        rmdir(pin_dir);
+    }
+    opts.prog_fd = opts.prog_id = 0;
+    opts.flags = 0;
+    bpf_tc_detach(&hook, &opts);
+    log_out(conf, "done: detached dispatcher (failure cleanup)\n");
+    hook.attach_point |= BPF_TC_INGRESS;
+    bpf_tc_hook_destroy(&hook);
+    log_out(conf, "done: destroyed qdisc (failure cleanup)\n");
+    dispatcher_bpf__destroy(dispatcher);
+    return err < 0 ? -err : err;
+
+cleanup_success:
+    if (pinned)
+    {
+        unlink(pin_path);
         rmdir(pin_dir);
     }
 
 cleanup_hook:
-    if (conf->cleanup_on_exit)
-    {
-        opts.prog_fd = opts.prog_id = 0;
-        opts.flags = 0;
-        bpf_tc_detach(&hook, &opts);
-        log_out(conf, "done: detached dispatcher\n");
+    opts.prog_fd = opts.prog_id = 0;
+    opts.flags = 0;
+    bpf_tc_detach(&hook, &opts);
+    log_out(conf, "done: detached dispatcher\n");
 
-        hook.attach_point |= BPF_TC_INGRESS;
-        bpf_tc_hook_destroy(&hook);
-        log_out(conf, "done: destroyed qdisc\n");
-    }
+    hook.attach_point |= BPF_TC_INGRESS;
+    bpf_tc_hook_destroy(&hook);
+    log_out(conf, "done: destroyed qdisc\n");
 
 destroy:
     dispatcher_bpf__destroy(dispatcher);

--- a/api/input_parse.h
+++ b/api/input_parse.h
@@ -12,7 +12,7 @@ static int parse_input(struct config *conf, const char *input_str, const char **
 {
     switch (conf->program)
     {
-    case program_allow_ip:
+    case program_allow_ipv4:
     case program_block_ipv4:
     {
         struct in_addr addr;
@@ -49,7 +49,7 @@ static int parse_input(struct config *conf, const char *input_str, const char **
 // Returns true if the given program requires an input argument.
 static inline bool program_requires_input(program_t program)
 {
-    return program == program_allow_ip || program == program_block_ipv4 || program == program_block_port;
+    return program == program_allow_ipv4 || program == program_block_ipv4 || program == program_block_port;
 }
 
 #endif // TRAFFICO_INPUT_PARSE_H

--- a/api/input_parse.h
+++ b/api/input_parse.h
@@ -12,6 +12,7 @@ static int parse_input(struct config *conf, const char *input_str, const char **
 {
     switch (conf->program)
     {
+    case program_allow_ip:
     case program_block_ipv4:
     {
         struct in_addr addr;
@@ -48,7 +49,7 @@ static int parse_input(struct config *conf, const char *input_str, const char **
 // Returns true if the given program requires an input argument.
 static inline bool program_requires_input(program_t program)
 {
-    return program == program_block_ipv4 || program == program_block_port;
+    return program == program_allow_ip || program == program_block_ipv4 || program == program_block_port;
 }
 
 #endif // TRAFFICO_INPUT_PARSE_H

--- a/api/input_parse.h
+++ b/api/input_parse.h
@@ -12,6 +12,7 @@ static int parse_input(struct config *conf, const char *input_str, const char **
 {
     switch (conf->program)
     {
+    case program_allow_dns:
     case program_allow_ipv4:
     case program_block_ipv4:
     {
@@ -50,7 +51,7 @@ static int parse_input(struct config *conf, const char *input_str, const char **
 // Returns true if the given program requires an input argument.
 static inline bool program_requires_input(program_t program)
 {
-    return program == program_allow_ipv4 || program == program_allow_port || program == program_block_ipv4 || program == program_block_port;
+    return program == program_allow_dns || program == program_allow_ipv4 || program == program_allow_port || program == program_block_ipv4 || program == program_block_port;
 }
 
 #endif // TRAFFICO_INPUT_PARSE_H

--- a/api/input_parse.h
+++ b/api/input_parse.h
@@ -25,6 +25,7 @@ static int parse_input(struct config *conf, const char *input_str, const char **
         conf->has_input = true;
         return 0;
     }
+    case program_allow_port:
     case program_block_port:
     {
         char *endptr;
@@ -49,7 +50,7 @@ static int parse_input(struct config *conf, const char *input_str, const char **
 // Returns true if the given program requires an input argument.
 static inline bool program_requires_input(program_t program)
 {
-    return program == program_allow_ipv4 || program == program_block_ipv4 || program == program_block_port;
+    return program == program_allow_ipv4 || program == program_allow_port || program == program_block_ipv4 || program == program_block_port;
 }
 
 #endif // TRAFFICO_INPUT_PARSE_H

--- a/bpf/allow_dns.bpf.c
+++ b/bpf/allow_dns.bpf.c
@@ -20,10 +20,12 @@ int allow_dns(struct __sk_buff *skb)
 
     if (data + l3_offset > data_end)
     {
-        bpf_printk("allow_dns: [eth] size length check hit: continue");
-        return TC_ACT_OK;
+        bpf_printk("allow_dns: [eth] size length check hit: block");
+        return TC_ACT_SHOT;
     }
 
+    // Passthrough: not IPv4 — DNS filtering doesn't apply.
+    // Non-IPv4 filtering is allow_ethertype's job.
     if (eth->h_proto != bpf_htons(ETH_P_IP))
     {
         bpf_printk("allow_dns: [eth] protocol is %d: continue", eth->h_proto);
@@ -31,21 +33,34 @@ int allow_dns(struct __sk_buff *skb)
     }
 
     struct iphdr *ip_header = data + l3_offset;
-    const int l4_offset = l3_offset + sizeof(*ip_header);
+    if (data + l3_offset + sizeof(*ip_header) > data_end)
+    {
+        bpf_printk("allow_dns: [iph] size length check hit: block");
+        return TC_ACT_SHOT;
+    }
 
+    __u8 ihl = ip_header->ihl;
+    if (ihl < 5)
+    {
+        bpf_printk("allow_dns: [iph] invalid IHL %d: block", ihl);
+        return TC_ACT_SHOT;
+    }
+
+    const int l4_offset = l3_offset + (ihl * 4);
     if (data + l4_offset > data_end)
     {
-        bpf_printk("allow_dns: [iph] size length check hit: continue");
-        return TC_ACT_OK;
+        bpf_printk("allow_dns: [iph] IHL extends beyond packet: block");
+        return TC_ACT_SHOT;
     }
 
-    if (ip_is_fragment(skb, l3_offset))
+    if (ip_is_subsequent_fragment(skb, l3_offset))
     {
-        bpf_printk("allow_dns: [iph] is fragment: continue");
-        return TC_ACT_OK;
+        bpf_printk("allow_dns: [iph] subsequent fragment: block");
+        return TC_ACT_SHOT;
     }
 
-    // Only inspect TCP and UDP
+    // Passthrough: not TCP/UDP — DNS filtering doesn't apply.
+    // Protocol filtering is allow_proto's job.
     if (ip_header->protocol != IPPROTO_TCP && ip_header->protocol != IPPROTO_UDP)
     {
         bpf_printk("allow_dns: [iph] protocol %d is not TCP/UDP: allow", ip_header->protocol);
@@ -55,14 +70,15 @@ int allow_dns(struct __sk_buff *skb)
     // Both TCP and UDP headers start with src_port (u16) then dst_port (u16)
     if (data + l4_offset + 4 > data_end)
     {
-        bpf_printk("allow_dns: [l4] size length check hit: continue");
-        return TC_ACT_OK;
+        bpf_printk("allow_dns: [l4] size length check hit: block");
+        return TC_ACT_SHOT;
     }
 
     __u16 *dst_port_ptr = (__u16 *)(data + l4_offset + 2); // skip 2-byte src_port
     __u16 dst_port = bpf_ntohs(*dst_port_ptr);
 
-    // Not DNS traffic — let it through
+    // Passthrough: not DNS traffic — allow_dns only restricts which
+    // resolver handles DNS. Port filtering is allow_port's job.
     if (dst_port != DNS_PORT)
     {
         bpf_printk("allow_dns: [l4] port %d is not DNS: allow", dst_port);

--- a/bpf/allow_dns.bpf.c
+++ b/bpf/allow_dns.bpf.c
@@ -1,0 +1,82 @@
+#include "vmlinux.h"
+#include "commons.bpf.h"
+
+#include <bpf/bpf_endian.h>
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";
+
+const volatile __u32 input = 0; // approved DNS resolver IP (host byte order)
+
+#define DNS_PORT 53
+
+SEC("tc")
+int allow_dns(struct __sk_buff *skb)
+{
+    void *data_end = (void *)(unsigned long long)skb->data_end;
+    void *data = (void *)(unsigned long long)skb->data;
+
+    struct ethhdr *eth = data;
+    const int l3_offset = sizeof(*eth);
+
+    if (data + l3_offset > data_end)
+    {
+        bpf_printk("allow_dns: [eth] size length check hit: continue");
+        return TC_ACT_OK;
+    }
+
+    if (eth->h_proto != bpf_htons(ETH_P_IP))
+    {
+        bpf_printk("allow_dns: [eth] protocol is %d: continue", eth->h_proto);
+        return TC_ACT_OK;
+    }
+
+    struct iphdr *ip_header = data + l3_offset;
+    const int l4_offset = l3_offset + sizeof(*ip_header);
+
+    if (data + l4_offset > data_end)
+    {
+        bpf_printk("allow_dns: [iph] size length check hit: continue");
+        return TC_ACT_OK;
+    }
+
+    if (ip_is_fragment(skb, l3_offset))
+    {
+        bpf_printk("allow_dns: [iph] is fragment: continue");
+        return TC_ACT_OK;
+    }
+
+    // Only inspect TCP and UDP
+    if (ip_header->protocol != IPPROTO_TCP && ip_header->protocol != IPPROTO_UDP)
+    {
+        bpf_printk("allow_dns: [iph] protocol %d is not TCP/UDP: allow", ip_header->protocol);
+        return TC_ACT_OK;
+    }
+
+    // Both TCP and UDP headers start with src_port (u16) then dst_port (u16)
+    if (data + l4_offset + 4 > data_end)
+    {
+        bpf_printk("allow_dns: [l4] size length check hit: continue");
+        return TC_ACT_OK;
+    }
+
+    __u16 *dst_port_ptr = (__u16 *)(data + l4_offset + 2); // skip 2-byte src_port
+    __u16 dst_port = bpf_ntohs(*dst_port_ptr);
+
+    // Not DNS traffic — let it through
+    if (dst_port != DNS_PORT)
+    {
+        bpf_printk("allow_dns: [l4] port %d is not DNS: allow", dst_port);
+        return TC_ACT_OK;
+    }
+
+    // DNS traffic — check dest IP against approved resolver
+    u32 dest = bpf_ntohl(ip_header->daddr);
+
+    if (dest != input)
+    {
+        bpf_printk("allow_dns: [dns] resolver %pI4 not allowed: block", &ip_header->daddr);
+        return TC_ACT_SHOT;
+    }
+
+    return TC_ACT_OK;
+}

--- a/bpf/allow_dns.bpf.c
+++ b/bpf/allow_dns.bpf.c
@@ -98,4 +98,5 @@ int allow_dns(struct __sk_buff *skb)
     }
 
     tail_call_next(skb, slot);
+    return TC_ACT_OK;
 }

--- a/bpf/allow_dns.bpf.c
+++ b/bpf/allow_dns.bpf.c
@@ -6,6 +6,9 @@
 char LICENSE[] SEC("license") = "Dual BSD/GPL";
 
 const volatile __u32 input = 0; // approved DNS resolver IP (host byte order)
+const volatile __u32 slot = 0;  // position in the chain (set by userspace)
+
+DEFINE_PROG_ARRAY();
 
 #define DNS_PORT 53
 
@@ -94,5 +97,5 @@ int allow_dns(struct __sk_buff *skb)
         return TC_ACT_SHOT;
     }
 
-    return TC_ACT_OK;
+    tail_call_next(skb, slot);
 }

--- a/bpf/allow_ip.bpf.c
+++ b/bpf/allow_ip.bpf.c
@@ -1,0 +1,61 @@
+#include "vmlinux.h"
+#include "commons.bpf.h"
+
+#include <bpf/bpf_endian.h>
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";
+
+const volatile __u32 input = 0; // address to allow (host byte order)
+
+SEC("tc")
+int allow_ip(struct __sk_buff *skb)
+{
+    void *data_end = (void *)(unsigned long long)skb->data_end;
+    void *data = (void *)(unsigned long long)skb->data;
+
+    struct ethhdr *eth = data;
+    const int l3_offset = sizeof(*eth);
+
+    if (data + l3_offset > data_end)
+    {
+        bpf_printk("allow_ip: [eth] size length check hit: continue");
+        return TC_ACT_OK;
+    }
+
+    if (eth->h_proto != bpf_htons(ETH_P_IP))
+    {
+        bpf_printk("allow_ip: [eth] protocol is %d: continue", eth->h_proto);
+        return TC_ACT_OK;
+    }
+
+    struct iphdr *ip_header = data + l3_offset;
+    const int l4_offset = l3_offset + sizeof(*ip_header);
+    if (data + l4_offset > data_end)
+    {
+        bpf_printk("allow_ip: [iph] size length check hit: continue");
+        return TC_ACT_OK;
+    }
+
+    if (ip_is_fragment(skb, l3_offset))
+    {
+        bpf_printk("allow_ip: [iph] is fragment: continue");
+        return TC_ACT_OK;
+    }
+
+    u32 dest = bpf_ntohl(ip_header->daddr);
+
+    // Exempt localhost (127.0.0.0/8)
+    if ((dest & 0xFF000000) == 0x7F000000)
+    {
+        bpf_printk("allow_ip: [iph] destination is localhost: allow");
+        return TC_ACT_OK;
+    }
+
+    if (dest != input)
+    {
+        bpf_printk("allow_ip: [iph] destination address is not allowed: block");
+        return TC_ACT_SHOT;
+    }
+
+    return TC_ACT_OK;
+}

--- a/bpf/allow_ipv4.bpf.c
+++ b/bpf/allow_ipv4.bpf.c
@@ -18,8 +18,8 @@ int allow_ipv4(struct __sk_buff *skb)
 
     if (data + l3_offset > data_end)
     {
-        bpf_printk("allow_ipv4: [eth] size length check hit: continue");
-        return TC_ACT_OK;
+        bpf_printk("allow_ipv4: [eth] size length check hit: block");
+        return TC_ACT_SHOT;
     }
 
     if (eth->h_proto != bpf_htons(ETH_P_IP))
@@ -29,17 +29,24 @@ int allow_ipv4(struct __sk_buff *skb)
     }
 
     struct iphdr *ip_header = data + l3_offset;
-    const int l4_offset = l3_offset + sizeof(*ip_header);
-    if (data + l4_offset > data_end)
+    if (data + l3_offset + sizeof(*ip_header) > data_end)
     {
-        bpf_printk("allow_ipv4: [iph] size length check hit: continue");
-        return TC_ACT_OK;
+        bpf_printk("allow_ipv4: [iph] size length check hit: block");
+        return TC_ACT_SHOT;
     }
 
-    if (ip_is_fragment(skb, l3_offset))
+    __u8 ihl = ip_header->ihl;
+    if (ihl < 5)
     {
-        bpf_printk("allow_ipv4: [iph] is fragment: continue");
-        return TC_ACT_OK;
+        bpf_printk("allow_ipv4: [iph] invalid IHL %d: block", ihl);
+        return TC_ACT_SHOT;
+    }
+
+    const int l4_offset = l3_offset + (ihl * 4);
+    if (data + l4_offset > data_end)
+    {
+        bpf_printk("allow_ipv4: [iph] IHL extends beyond packet: block");
+        return TC_ACT_SHOT;
     }
 
     u32 dest = bpf_ntohl(ip_header->daddr);

--- a/bpf/allow_ipv4.bpf.c
+++ b/bpf/allow_ipv4.bpf.c
@@ -6,6 +6,9 @@
 char LICENSE[] SEC("license") = "Dual BSD/GPL";
 
 const volatile __u32 input = 0; // address to allow (host byte order)
+const volatile __u32 slot = 0;  // position in the chain (set by userspace)
+
+DEFINE_PROG_ARRAY();
 
 SEC("tc")
 int allow_ipv4(struct __sk_buff *skb)
@@ -64,5 +67,5 @@ int allow_ipv4(struct __sk_buff *skb)
         return TC_ACT_SHOT;
     }
 
-    return TC_ACT_OK;
+    tail_call_next(skb, slot);
 }

--- a/bpf/allow_ipv4.bpf.c
+++ b/bpf/allow_ipv4.bpf.c
@@ -68,4 +68,5 @@ int allow_ipv4(struct __sk_buff *skb)
     }
 
     tail_call_next(skb, slot);
+    return TC_ACT_OK;
 }

--- a/bpf/allow_ipv4.bpf.c
+++ b/bpf/allow_ipv4.bpf.c
@@ -8,7 +8,7 @@ char LICENSE[] SEC("license") = "Dual BSD/GPL";
 const volatile __u32 input = 0; // address to allow (host byte order)
 
 SEC("tc")
-int allow_ip(struct __sk_buff *skb)
+int allow_ipv4(struct __sk_buff *skb)
 {
     void *data_end = (void *)(unsigned long long)skb->data_end;
     void *data = (void *)(unsigned long long)skb->data;
@@ -18,13 +18,13 @@ int allow_ip(struct __sk_buff *skb)
 
     if (data + l3_offset > data_end)
     {
-        bpf_printk("allow_ip: [eth] size length check hit: continue");
+        bpf_printk("allow_ipv4: [eth] size length check hit: continue");
         return TC_ACT_OK;
     }
 
     if (eth->h_proto != bpf_htons(ETH_P_IP))
     {
-        bpf_printk("allow_ip: [eth] protocol is %d: continue", eth->h_proto);
+        bpf_printk("allow_ipv4: [eth] protocol is %d: continue", eth->h_proto);
         return TC_ACT_OK;
     }
 
@@ -32,13 +32,13 @@ int allow_ip(struct __sk_buff *skb)
     const int l4_offset = l3_offset + sizeof(*ip_header);
     if (data + l4_offset > data_end)
     {
-        bpf_printk("allow_ip: [iph] size length check hit: continue");
+        bpf_printk("allow_ipv4: [iph] size length check hit: continue");
         return TC_ACT_OK;
     }
 
     if (ip_is_fragment(skb, l3_offset))
     {
-        bpf_printk("allow_ip: [iph] is fragment: continue");
+        bpf_printk("allow_ipv4: [iph] is fragment: continue");
         return TC_ACT_OK;
     }
 
@@ -47,13 +47,13 @@ int allow_ip(struct __sk_buff *skb)
     // Exempt localhost (127.0.0.0/8)
     if ((dest & 0xFF000000) == 0x7F000000)
     {
-        bpf_printk("allow_ip: [iph] destination is localhost: allow");
+        bpf_printk("allow_ipv4: [iph] destination is localhost: allow");
         return TC_ACT_OK;
     }
 
     if (dest != input)
     {
-        bpf_printk("allow_ip: [iph] destination address is not allowed: block");
+        bpf_printk("allow_ipv4: [iph] destination address is not allowed: block");
         return TC_ACT_SHOT;
     }
 

--- a/bpf/allow_port.bpf.c
+++ b/bpf/allow_port.bpf.c
@@ -1,0 +1,70 @@
+#include "vmlinux.h"
+#include "commons.bpf.h"
+
+#include <bpf/bpf_endian.h>
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";
+
+const volatile __u16 input = 0; // destination port to allow (host byte order)
+
+SEC("tc")
+int allow_port(struct __sk_buff *skb)
+{
+    void *data_end = (void *)(unsigned long long)skb->data_end;
+    void *data = (void *)(unsigned long long)skb->data;
+
+    struct ethhdr *eth = data;
+    const int l3_offset = sizeof(*eth);
+
+    if (data + l3_offset > data_end)
+    {
+        bpf_printk("allow_port: [eth] size length check hit: continue");
+        return TC_ACT_OK;
+    }
+
+    if (eth->h_proto != bpf_htons(ETH_P_IP))
+    {
+        bpf_printk("allow_port: [eth] protocol is %d: continue", eth->h_proto);
+        return TC_ACT_OK;
+    }
+
+    struct iphdr *ip_header = data + l3_offset;
+    const int l4_offset = l3_offset + sizeof(*ip_header);
+
+    if (data + l4_offset > data_end)
+    {
+        bpf_printk("allow_port: [iph] size length check hit: continue");
+        return TC_ACT_OK;
+    }
+
+    if (ip_is_fragment(skb, l3_offset))
+    {
+        bpf_printk("allow_port: [iph] is fragment: continue");
+        return TC_ACT_OK;
+    }
+
+    // Only inspect TCP and UDP; let other protocols (ICMP, etc.) pass through
+    if (ip_header->protocol != IPPROTO_TCP && ip_header->protocol != IPPROTO_UDP)
+    {
+        bpf_printk("allow_port: [iph] protocol %d is not TCP/UDP: allow", ip_header->protocol);
+        return TC_ACT_OK;
+    }
+
+    // Both TCP and UDP headers start with src_port (u16) then dst_port (u16)
+    if (data + l4_offset + 4 > data_end)
+    {
+        bpf_printk("allow_port: [l4] size length check hit: continue");
+        return TC_ACT_OK;
+    }
+
+    __u16 *dst_port_ptr = (__u16 *)(data + l4_offset + 2); // skip 2-byte src_port
+    __u16 dst_port = bpf_ntohs(*dst_port_ptr);
+
+    if (dst_port != input)
+    {
+        bpf_printk("allow_port: [l4] destination port %d not allowed: block", dst_port);
+        return TC_ACT_SHOT;
+    }
+
+    return TC_ACT_OK;
+}

--- a/bpf/allow_port.bpf.c
+++ b/bpf/allow_port.bpf.c
@@ -6,6 +6,9 @@
 char LICENSE[] SEC("license") = "Dual BSD/GPL";
 
 const volatile __u16 input = 0; // destination port to allow (host byte order)
+const volatile __u32 slot = 0;  // position in the chain (set by userspace)
+
+DEFINE_PROG_ARRAY();
 
 SEC("tc")
 int allow_port(struct __sk_buff *skb)
@@ -81,5 +84,5 @@ int allow_port(struct __sk_buff *skb)
         return TC_ACT_SHOT;
     }
 
-    return TC_ACT_OK;
+    tail_call_next(skb, slot);
 }

--- a/bpf/allow_port.bpf.c
+++ b/bpf/allow_port.bpf.c
@@ -85,4 +85,5 @@ int allow_port(struct __sk_buff *skb)
     }
 
     tail_call_next(skb, slot);
+    return TC_ACT_OK;
 }

--- a/bpf/allow_port.bpf.c
+++ b/bpf/allow_port.bpf.c
@@ -18,10 +18,12 @@ int allow_port(struct __sk_buff *skb)
 
     if (data + l3_offset > data_end)
     {
-        bpf_printk("allow_port: [eth] size length check hit: continue");
-        return TC_ACT_OK;
+        bpf_printk("allow_port: [eth] size length check hit: block");
+        return TC_ACT_SHOT;
     }
 
+    // Passthrough: not IPv4 — port filtering doesn't apply.
+    // Non-IPv4 filtering is allow_ethertype's job.
     if (eth->h_proto != bpf_htons(ETH_P_IP))
     {
         bpf_printk("allow_port: [eth] protocol is %d: continue", eth->h_proto);
@@ -29,21 +31,34 @@ int allow_port(struct __sk_buff *skb)
     }
 
     struct iphdr *ip_header = data + l3_offset;
-    const int l4_offset = l3_offset + sizeof(*ip_header);
+    if (data + l3_offset + sizeof(*ip_header) > data_end)
+    {
+        bpf_printk("allow_port: [iph] size length check hit: block");
+        return TC_ACT_SHOT;
+    }
 
+    __u8 ihl = ip_header->ihl;
+    if (ihl < 5)
+    {
+        bpf_printk("allow_port: [iph] invalid IHL %d: block", ihl);
+        return TC_ACT_SHOT;
+    }
+
+    const int l4_offset = l3_offset + (ihl * 4);
     if (data + l4_offset > data_end)
     {
-        bpf_printk("allow_port: [iph] size length check hit: continue");
-        return TC_ACT_OK;
+        bpf_printk("allow_port: [iph] IHL extends beyond packet: block");
+        return TC_ACT_SHOT;
     }
 
-    if (ip_is_fragment(skb, l3_offset))
+    if (ip_is_subsequent_fragment(skb, l3_offset))
     {
-        bpf_printk("allow_port: [iph] is fragment: continue");
-        return TC_ACT_OK;
+        bpf_printk("allow_port: [iph] subsequent fragment: block");
+        return TC_ACT_SHOT;
     }
 
-    // Only inspect TCP and UDP; let other protocols (ICMP, etc.) pass through
+    // Passthrough: not TCP/UDP — port filtering doesn't apply.
+    // Protocol filtering is allow_proto's job.
     if (ip_header->protocol != IPPROTO_TCP && ip_header->protocol != IPPROTO_UDP)
     {
         bpf_printk("allow_port: [iph] protocol %d is not TCP/UDP: allow", ip_header->protocol);
@@ -53,8 +68,8 @@ int allow_port(struct __sk_buff *skb)
     // Both TCP and UDP headers start with src_port (u16) then dst_port (u16)
     if (data + l4_offset + 4 > data_end)
     {
-        bpf_printk("allow_port: [l4] size length check hit: continue");
-        return TC_ACT_OK;
+        bpf_printk("allow_port: [l4] size length check hit: block");
+        return TC_ACT_SHOT;
     }
 
     __u16 *dst_port_ptr = (__u16 *)(data + l4_offset + 2); // skip 2-byte src_port

--- a/bpf/commons.bpf.h
+++ b/bpf/commons.bpf.h
@@ -70,4 +70,28 @@ struct trace_event_raw_bpf_trace_printk___x
     while (0)
 #endif
 
+/// Tail call support for program chaining.
+///
+/// Programs that participate in a chain define a prog_array map and use
+/// tail_call_next() instead of returning TC_ACT_OK at the end of their
+/// allow path. When used standalone (no chain), the map is empty and
+/// bpf_tail_call silently fails, falling through to TC_ACT_OK.
+/// When used in a chain, userspace reuses the dispatcher's prog_array
+/// map FD via bpf_map__reuse_fd() before loading the program.
+
+#define DEFINE_PROG_ARRAY()                              \
+    struct {                                             \
+        __uint(type, BPF_MAP_TYPE_PROG_ARRAY);           \
+        __uint(key_size, sizeof(__u32));                  \
+        __uint(value_size, sizeof(__u32));                \
+        __uint(max_entries, 8);                           \
+    } prog_array SEC(".maps")
+
+/// Tail-call the next program in the chain.
+/// If the tail call fails (empty slot = end of chain), falls through
+/// to TC_ACT_OK — the packet passed all filters and is allowed.
+#define tail_call_next(skb, slot)                        \
+    bpf_tail_call(skb, &prog_array, (slot) + 1);        \
+    return TC_ACT_OK
+
 #endif // TRAFFICO_BPF_COMMONS_H

--- a/bpf/commons.bpf.h
+++ b/bpf/commons.bpf.h
@@ -88,10 +88,9 @@ struct trace_event_raw_bpf_trace_printk___x
     } prog_array SEC(".maps")
 
 /// Tail-call the next program in the chain.
-/// If the tail call fails (empty slot = end of chain), falls through
-/// to TC_ACT_OK — the packet passed all filters and is allowed.
+/// If the tail call fails (empty slot = end of chain), execution
+/// continues to the next statement. Callers must return explicitly.
 #define tail_call_next(skb, slot)                        \
-    bpf_tail_call(skb, &prog_array, (slot) + 1);        \
-    return TC_ACT_OK
+    bpf_tail_call(skb, &prog_array, (slot) + 1)
 
 #endif // TRAFFICO_BPF_COMMONS_H

--- a/bpf/dispatcher.bpf.c
+++ b/bpf/dispatcher.bpf.c
@@ -1,0 +1,20 @@
+#include "vmlinux.h"
+#include "commons.bpf.h"
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+    __uint(key_size, sizeof(__u32));
+    __uint(value_size, sizeof(__u32));
+    __uint(max_entries, 8);
+} prog_array SEC(".maps");
+
+SEC("tc")
+int dispatcher(struct __sk_buff *skb)
+{
+    bpf_tail_call(skb, &prog_array, 0);
+
+    // Fallback: no programs in chain, allow packet
+    return TC_ACT_OK;
+}

--- a/bpf/xmake.lua
+++ b/bpf/xmake.lua
@@ -66,6 +66,7 @@ add_requires("libbpf v1.5.0", { system = false })
 -- probe
 target("bpf")
     set_kind("object")
+    set_symbols("none") -- BPF objects must not use -fvisibility=hidden (breaks libbpf map linkage)
     set_policy("build.fence", true)
     includes("../tools")
     add_deps("bpftool")

--- a/docs/README.md
+++ b/docs/README.md
@@ -120,6 +120,7 @@ Here's an example CNI config file featuring `traffico-cni`.
 | Program | Description |
 |---|---|
 | `allow_ipv4` | Drops all packets except those destined for the input IPv4 address (localhost exempt) |
+| `allow_port` | Drops all TCP/UDP packets except those destined for the input port (non-TCP/UDP unaffected) |
 | `block_private_ipv4` | Blocks private IPv4 addresses subnets allowing only SSH access on port 22 |
 | `block_ipv4` | Drops packets with destination equal to the input IPv4 address |
 | `block_port` | Drops packets with the destination port equal to the input port number |

--- a/docs/README.md
+++ b/docs/README.md
@@ -119,7 +119,7 @@ Here's an example CNI config file featuring `traffico-cni`.
 
 | Program | Description |
 |---|---|
-| `allow_ip` | Drops all packets except those destined for the input IPv4 address (localhost exempt) |
+| `allow_ipv4` | Drops all packets except those destined for the input IPv4 address (localhost exempt) |
 | `block_private_ipv4` | Blocks private IPv4 addresses subnets allowing only SSH access on port 22 |
 | `block_ipv4` | Drops packets with destination equal to the input IPv4 address |
 | `block_port` | Drops packets with the destination port equal to the input port number |

--- a/docs/README.md
+++ b/docs/README.md
@@ -119,6 +119,7 @@ Here's an example CNI config file featuring `traffico-cni`.
 
 | Program | Description |
 |---|---|
+| `allow_ip` | Drops all packets except those destined for the input IPv4 address (localhost exempt) |
 | `block_private_ipv4` | Blocks private IPv4 addresses subnets allowing only SSH access on port 22 |
 | `block_ipv4` | Drops packets with destination equal to the input IPv4 address |
 | `block_port` | Drops packets with the destination port equal to the input port number |

--- a/docs/README.md
+++ b/docs/README.md
@@ -119,6 +119,7 @@ Here's an example CNI config file featuring `traffico-cni`.
 
 | Program | Description |
 |---|---|
+| `allow_dns` | Drops DNS (port 53) packets not destined for the input resolver IP (non-DNS unaffected) |
 | `allow_ipv4` | Drops all packets except those destined for the input IPv4 address (localhost exempt) |
 | `allow_port` | Drops all TCP/UDP packets except those destined for the input port (non-TCP/UDP unaffected) |
 | `block_private_ipv4` | Blocks private IPv4 addresses subnets allowing only SSH access on port 22 |

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -132,6 +132,78 @@ teardown() {
     echo "# localhost still reachable (exempt from allow_ipv4)" >&3
 }
 
+@test "allow_dns permits DNS to approved resolver" {
+    # Start a TCP listener on port 53 (simulating a DNS resolver)
+    python3 -c "
+import socket, threading
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(('${VETH_ADDR}', 53))
+s.listen(1)
+s.settimeout(5)
+try:
+    c, _ = s.accept()
+    c.send(b'ok')
+    c.close()
+except: pass
+s.close()
+" &
+    DNS_PID=$!
+    sleep 0.5
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_dns "${VETH_ADDR}" >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" curl --max-time 2 --silent "telnet://${VETH_ADDR}:53"
+    [ $status -eq 0 ]
+    echo "# DNS to approved resolver ${VETH_ADDR}:53 allowed" >&3
+    kill $DNS_PID 2>/dev/null || true
+}
+
+@test "allow_dns blocks DNS to other resolvers" {
+    # Start a TCP listener on port 53 (simulating an unauthorized resolver)
+    python3 -c "
+import socket
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(('${VETH_ADDR}', 53))
+s.listen(1)
+s.settimeout(5)
+try:
+    c, _ = s.accept()
+    c.send(b'ok')
+    c.close()
+except: pass
+s.close()
+" &
+    DNS_PID=$!
+    sleep 0.5
+    # Allow DNS only to PEER_ADDR (not VETH_ADDR where the server is)
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_dns "${PEER_ADDR}" >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" curl --max-time 2 --silent "telnet://${VETH_ADDR}:53"
+    [ ! $status -eq 0 ]
+    echo "# DNS to ${VETH_ADDR}:53 blocked (only ${PEER_ADDR} allowed)" >&3
+    kill $DNS_PID 2>/dev/null || true
+}
+
+@test "allow_dns does not block non-DNS traffic" {
+    new_server
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
+    # Allow DNS only to PEER_ADDR — but non-DNS traffic should still pass
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_dns "${PEER_ADDR}" >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# non-DNS traffic to ${VETH_ADDR}:${SERVER_PORT} still works" >&3
+}
+
 @test "allow_port allows specific port" {
     new_server
     run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -132,6 +132,47 @@ teardown() {
     echo "# localhost still reachable (exempt from allow_ipv4)" >&3
 }
 
+@test "allow_port allows specific port" {
+    new_server
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_port "${SERVER_PORT}" >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can still reach ${VETH_ADDR}:${SERVER_PORT} (allowed port)" >&3
+}
+
+@test "allow_port blocks other ports" {
+    new_server
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_port 9999 >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ ! $status -eq 0 ]
+    echo "# cannot reach ${VETH_ADDR}:${SERVER_PORT} (only port 9999 allowed)" >&3
+}
+
+@test "allow_port does not block ICMP" {
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 0 ]
+    echo "# can ping ${VETH_ADDR} from the namespace" >&3
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_port 9999 >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 0 ]
+    echo "# can still ping ${VETH_ADDR} (ICMP not blocked by allow_port)" >&3
+}
+
 @test "block_private_ipv4 blocks ICMP packets" {
     run ip netns exec "${NETNS}" ping -W1 -4 -c1 10.22.1.2
     [ $status -eq 0 ]

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -288,6 +288,29 @@ s.close()
     echo "# cannot reach ${VETH_ADDR}:${SERVER_PORT} (chain blocks wrong port)" >&3
 }
 
+@test "chain allow_port+allow_ipv4 continues through non-matching traffic" {
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 0 ]
+    # allow_port returns TC_ACT_OK for ICMP; allow_ipv4 must still be reached in chain mode
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_port:9999,allow_ipv4:${PEER_ADDR}" >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 1 ]
+}
+
+@test "chain attach failure does not leave dispatcher attached with --no-cleanup" {
+    # block_ipv4 is unsupported in chain mode, so attach should fail and clean up qdisc state
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo "$output" | xargs)" == "" ]
+    run ip netns exec "${NETNS}" traffico --verbose --no-cleanup -i "${PEER}" --at egress --chain "allow_ipv4:${PEER_ADDR},block_ipv4:${VETH_ADDR}" >/dev/null 3>&-
+    [ $status -eq 1 ]
+    [[ "${output}" == *"does not support chaining"* ]]
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo "$output" | xargs)" == "" ]
+}
+
 @test "block_private_ipv4 blocks ICMP packets" {
     run ip netns exec "${NETNS}" ping -W1 -4 -c1 10.22.1.2
     [ $status -eq 0 ]

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -245,6 +245,49 @@ s.close()
     echo "# can still ping ${VETH_ADDR} (ICMP not blocked by allow_port)" >&3
 }
 
+@test "chain allow_ip+allow_port allows matching traffic" {
+    new_server
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ip:${VETH_ADDR},allow_port:${SERVER_PORT}" >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can still reach ${VETH_ADDR}:${SERVER_PORT} (chain allows it)" >&3
+}
+
+@test "chain allow_ip+allow_port blocks non-matching IP" {
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 0 ]
+    echo "# can ping ${VETH_ADDR} from the namespace" >&3
+    # Allow only PEER_ADDR (not VETH_ADDR) on any port
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ip:${PEER_ADDR},allow_port:8787" >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 1 ]
+    echo "# cannot ping ${VETH_ADDR} (chain blocks wrong IP)" >&3
+}
+
+@test "chain allow_ip+allow_port blocks non-matching port" {
+    new_server
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
+    # Allow VETH_ADDR but only port 9999 (not SERVER_PORT)
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ip:${VETH_ADDR},allow_port:9999" >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ ! $status -eq 0 ]
+    echo "# cannot reach ${VETH_ADDR}:${SERVER_PORT} (chain blocks wrong port)" >&3
+}
+
 @test "block_private_ipv4 blocks ICMP packets" {
     run ip netns exec "${NETNS}" ping -W1 -4 -c1 10.22.1.2
     [ $status -eq 0 ]

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -95,6 +95,43 @@ teardown() {
     echo "# can still reach ${VETH_ADDR}:${SERVER_PORT} (blocked port 9999, not ${SERVER_PORT})" >&3
 }
 
+@test "allow_ip allows specific IP" {
+    new_server
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_ip "${VETH_ADDR}" >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can still reach ${VETH_ADDR}:${SERVER_PORT} (allowed IP)" >&3
+}
+
+@test "allow_ip blocks other IPs" {
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 0 ]
+    echo "# can reach ${VETH_ADDR} from the namespace" >&3
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_ip "${PEER_ADDR}" >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
+    [ $status -eq 1 ]
+    echo "# cannot reach ${VETH_ADDR} (only ${PEER_ADDR} allowed)" >&3
+}
+
+@test "allow_ip does not block localhost" {
+    run ip netns exec "${NETNS}" traffico -i lo --at egress allow_ip "${VETH_ADDR}" >/dev/null 3>&- &
+    sleep 1
+    run ip netns exec "${NETNS}" tc qdisc show dev lo clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    run ip netns exec "${NETNS}" ping -W1 -4 -c1 127.0.0.1
+    [ $status -eq 0 ]
+    echo "# localhost still reachable (exempt from allow_ip)" >&3
+}
+
 @test "block_private_ipv4 blocks ICMP packets" {
     run ip netns exec "${NETNS}" ping -W1 -4 -c1 10.22.1.2
     [ $status -eq 0 ]

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -245,12 +245,12 @@ s.close()
     echo "# can still ping ${VETH_ADDR} (ICMP not blocked by allow_port)" >&3
 }
 
-@test "chain allow_ip+allow_port allows matching traffic" {
+@test "chain allow_ipv4+allow_port allows matching traffic" {
     new_server
     run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
     [ $status -eq 0 ]
     echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
-    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ip:${VETH_ADDR},allow_port:${SERVER_PORT}" >/dev/null 3>&- &
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ipv4:${VETH_ADDR},allow_port:${SERVER_PORT}" >/dev/null 3>&- &
     sleep 1
     run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
     [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
@@ -259,12 +259,12 @@ s.close()
     echo "# can still reach ${VETH_ADDR}:${SERVER_PORT} (chain allows it)" >&3
 }
 
-@test "chain allow_ip+allow_port blocks non-matching IP" {
+@test "chain allow_ipv4+allow_port blocks non-matching IP" {
     run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
     [ $status -eq 0 ]
     echo "# can ping ${VETH_ADDR} from the namespace" >&3
     # Allow only PEER_ADDR (not VETH_ADDR) on any port
-    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ip:${PEER_ADDR},allow_port:8787" >/dev/null 3>&- &
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ipv4:${PEER_ADDR},allow_port:8787" >/dev/null 3>&- &
     sleep 1
     run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
     [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
@@ -273,13 +273,13 @@ s.close()
     echo "# cannot ping ${VETH_ADDR} (chain blocks wrong IP)" >&3
 }
 
-@test "chain allow_ip+allow_port blocks non-matching port" {
+@test "chain allow_ipv4+allow_port blocks non-matching port" {
     new_server
     run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
     [ $status -eq 0 ]
     echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
     # Allow VETH_ADDR but only port 9999 (not SERVER_PORT)
-    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ip:${VETH_ADDR},allow_port:9999" >/dev/null 3>&- &
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ipv4:${VETH_ADDR},allow_port:9999" >/dev/null 3>&- &
     sleep 1
     run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
     [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -95,12 +95,12 @@ teardown() {
     echo "# can still reach ${VETH_ADDR}:${SERVER_PORT} (blocked port 9999, not ${SERVER_PORT})" >&3
 }
 
-@test "allow_ip allows specific IP" {
+@test "allow_ipv4 allows specific IP" {
     new_server
     run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
     [ $status -eq 0 ]
     echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
-    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_ip "${VETH_ADDR}" >/dev/null 3>&- &
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_ipv4 "${VETH_ADDR}" >/dev/null 3>&- &
     sleep 1
     run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
     [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
@@ -109,11 +109,11 @@ teardown() {
     echo "# can still reach ${VETH_ADDR}:${SERVER_PORT} (allowed IP)" >&3
 }
 
-@test "allow_ip blocks other IPs" {
+@test "allow_ipv4 blocks other IPs" {
     run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
     [ $status -eq 0 ]
     echo "# can reach ${VETH_ADDR} from the namespace" >&3
-    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_ip "${PEER_ADDR}" >/dev/null 3>&- &
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_ipv4 "${PEER_ADDR}" >/dev/null 3>&- &
     sleep 1
     run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
     [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
@@ -122,14 +122,14 @@ teardown() {
     echo "# cannot reach ${VETH_ADDR} (only ${PEER_ADDR} allowed)" >&3
 }
 
-@test "allow_ip does not block localhost" {
-    run ip netns exec "${NETNS}" traffico -i lo --at egress allow_ip "${VETH_ADDR}" >/dev/null 3>&- &
+@test "allow_ipv4 does not block localhost" {
+    run ip netns exec "${NETNS}" traffico -i lo --at egress allow_ipv4 "${VETH_ADDR}" >/dev/null 3>&- &
     sleep 1
     run ip netns exec "${NETNS}" tc qdisc show dev lo clsact
     [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
     run ip netns exec "${NETNS}" ping -W1 -4 -c1 127.0.0.1
     [ $status -eq 0 ]
-    echo "# localhost still reachable (exempt from allow_ip)" >&3
+    echo "# localhost still reachable (exempt from allow_ipv4)" >&3
 }
 
 @test "block_private_ipv4 blocks ICMP packets" {

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -65,6 +65,18 @@ bats_require_minimum_version 1.7.0
     [ "${lines[0]}" == "traffico: option '--at' requires one of the following values: INGRESS|EGRESS" ]
 }
 
+@test "missing input for allow_dns" {
+    run traffico -i lo allow_dns
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: program 'allow_dns' requires an input argument" ]
+}
+
+@test "invalid IP for allow_dns" {
+    run traffico -i lo allow_dns not.an.ip
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: invalid IP address: 'not.an.ip'" ]
+}
+
 @test "missing input for allow_ipv4" {
     run traffico -i lo allow_ipv4
     [ $status -eq 1 ]

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -142,3 +142,39 @@ bats_require_minimum_version 1.7.0
     [ $status -eq 1 ]
     [ "${lines[0]}" == "traffico: too many arguments" ]
 }
+
+@test "--chain with unknown program" {
+    run traffico -i lo --chain "xxx:1.2.3.4"
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: unknown program in chain: 'xxx'" ]
+}
+
+@test "--chain with missing input for program that requires it" {
+    run traffico -i lo --chain "allow_ipv4"
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: program 'allow_ipv4' in chain requires an input value (use name:value)" ]
+}
+
+@test "--chain with invalid input" {
+    run traffico -i lo --chain "allow_ipv4:not.an.ip"
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: invalid IP address: 'not.an.ip'" ]
+}
+
+@test "--chain with too many entries" {
+    run traffico -i lo --chain "nop,nop,nop,nop,nop,nop,nop,nop,nop"
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: chain exceeds maximum of 8 programs" ]
+}
+
+@test "--chain mutually exclusive with positional args" {
+    run traffico -i lo --chain "nop" nop
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: --chain and positional PROGRAM arguments are mutually exclusive" ]
+}
+
+@test "--chain with empty string" {
+    run traffico -i lo --chain ""
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: --chain requires at least one program" ]
+}

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -65,6 +65,18 @@ bats_require_minimum_version 1.7.0
     [ "${lines[0]}" == "traffico: option '--at' requires one of the following values: INGRESS|EGRESS" ]
 }
 
+@test "missing input for allow_ip" {
+    run traffico -i lo allow_ip
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: program 'allow_ip' requires an input argument" ]
+}
+
+@test "invalid IP for allow_ip" {
+    run traffico -i lo allow_ip not.an.ip
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: invalid IP address: 'not.an.ip'" ]
+}
+
 @test "missing input for block_ipv4" {
     run traffico -i lo block_ipv4
     [ $status -eq 1 ]

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -178,3 +178,21 @@ bats_require_minimum_version 1.7.0
     [ $status -eq 1 ]
     [ "${lines[0]}" == "traffico: --chain requires at least one program" ]
 }
+
+@test "--chain rejects leading separator" {
+    run timeout 2 traffico -i lo --chain ",allow_ipv4:127.0.0.1"
+    [ $status -eq 1 ]
+    [[ "${output}" == *"empty chain entry"* ]]
+}
+
+@test "--chain rejects trailing separator" {
+    run timeout 2 traffico -i lo --chain "allow_ipv4:127.0.0.1,"
+    [ $status -eq 1 ]
+    [[ "${output}" == *"empty chain entry"* ]]
+}
+
+@test "--chain rejects consecutive separators" {
+    run timeout 2 traffico -i lo --chain "allow_ipv4:127.0.0.1,,allow_port:80"
+    [ $status -eq 1 ]
+    [[ "${output}" == *"empty chain entry"* ]]
+}

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -65,14 +65,14 @@ bats_require_minimum_version 1.7.0
     [ "${lines[0]}" == "traffico: option '--at' requires one of the following values: INGRESS|EGRESS" ]
 }
 
-@test "missing input for allow_ip" {
-    run traffico -i lo allow_ip
+@test "missing input for allow_ipv4" {
+    run traffico -i lo allow_ipv4
     [ $status -eq 1 ]
-    [ "${lines[0]}" == "traffico: program 'allow_ip' requires an input argument" ]
+    [ "${lines[0]}" == "traffico: program 'allow_ipv4' requires an input argument" ]
 }
 
-@test "invalid IP for allow_ip" {
-    run traffico -i lo allow_ip not.an.ip
+@test "invalid IP for allow_ipv4" {
+    run traffico -i lo allow_ipv4 not.an.ip
     [ $status -eq 1 ]
     [ "${lines[0]}" == "traffico: invalid IP address: 'not.an.ip'" ]
 }

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -89,6 +89,18 @@ bats_require_minimum_version 1.7.0
     [ "${lines[0]}" == "traffico: invalid IP address: 'not.an.ip'" ]
 }
 
+@test "missing input for allow_port" {
+    run traffico -i lo allow_port
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: program 'allow_port' requires an input argument" ]
+}
+
+@test "invalid port for allow_port" {
+    run traffico -i lo allow_port abc
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: invalid port number: 'abc'" ]
+}
+
 @test "missing input for block_port" {
     run traffico -i lo block_port
     [ $status -eq 1 ]

--- a/test/cni.bats
+++ b/test/cni.bats
@@ -63,6 +63,25 @@ teardown() {
     echo "# cannot reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
 }
 
+@test "allow_port via CNI" {
+    run curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can reach ${VETH_ADDR}:${SERVER_PORT}" >&3
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
+    echo "# installing allow_port in the namespace" >&3
+    run ip netns exec "${NETNS}" bash -c "cat '$FIXTURE_ROOT/attach_allow_port_in.json' | CNI_COMMAND=ADD traffico-cni"
+    [ $status -eq 0 ]
+    echo "# attach ok" >&3
+    run ip netns exec "${NETNS}" tc qdisc show dev peer0 clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    echo "# qdisc ok" >&3
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can still reach ${VETH_ADDR}:${SERVER_PORT} (allowed port)" >&3
+}
+
 @test "block_port via CNI" {
     run curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
     [ $status -eq 0 ]

--- a/test/cni.bats
+++ b/test/cni.bats
@@ -25,15 +25,15 @@ teardown() {
     del_server
 }
 
-@test "allow_ip via CNI" {
+@test "allow_ipv4 via CNI" {
     run curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
     [ $status -eq 0 ]
     echo "# can reach ${VETH_ADDR}:${SERVER_PORT}" >&3
     run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
     [ $status -eq 0 ]
     echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
-    echo "# installing allow_ip in the namespace" >&3
-    run ip netns exec "${NETNS}" bash -c "cat '$FIXTURE_ROOT/attach_allow_ip_in.json' | CNI_COMMAND=ADD traffico-cni"
+    echo "# installing allow_ipv4 in the namespace" >&3
+    run ip netns exec "${NETNS}" bash -c "cat '$FIXTURE_ROOT/attach_allow_ipv4_in.json' | CNI_COMMAND=ADD traffico-cni"
     [ $status -eq 0 ]
     echo "# attach ok" >&3
     run ip netns exec "${NETNS}" tc qdisc show dev peer0 clsact

--- a/test/cni.bats
+++ b/test/cni.bats
@@ -25,6 +25,25 @@ teardown() {
     del_server
 }
 
+@test "allow_ip via CNI" {
+    run curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can reach ${VETH_ADDR}:${SERVER_PORT}" >&3
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
+    echo "# installing allow_ip in the namespace" >&3
+    run ip netns exec "${NETNS}" bash -c "cat '$FIXTURE_ROOT/attach_allow_ip_in.json' | CNI_COMMAND=ADD traffico-cni"
+    [ $status -eq 0 ]
+    echo "# attach ok" >&3
+    run ip netns exec "${NETNS}" tc qdisc show dev peer0 clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    echo "# qdisc ok" >&3
+    run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
+    [ $status -eq 0 ]
+    echo "# can still reach ${VETH_ADDR}:${SERVER_PORT} (allowed IP)" >&3
+}
+
 @test "block_ipv4 via CNI" {
     run curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
     [ $status -eq 0 ]

--- a/test/cni.bats
+++ b/test/cni.bats
@@ -63,6 +63,56 @@ teardown() {
     echo "# cannot reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
 }
 
+@test "allow_dns via CNI" {
+    python3 -c "
+import socket
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(('${VETH_ADDR}', 53))
+s.listen(1)
+s.settimeout(5)
+try:
+    c, _ = s.accept()
+    c.send(b'ok')
+    c.close()
+except: pass
+s.close()
+" &
+    DNS_PID=$!
+    sleep 0.5
+    run ip netns exec "${NETNS}" curl --max-time 2 --silent "telnet://${VETH_ADDR}:53"
+    [ $status -eq 0 ]
+    echo "# can reach ${VETH_ADDR}:53 from the namespace" >&3
+    # Restart listener for the post-attach test
+    python3 -c "
+import socket
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(('${VETH_ADDR}', 53))
+s.listen(1)
+s.settimeout(5)
+try:
+    c, _ = s.accept()
+    c.send(b'ok')
+    c.close()
+except: pass
+s.close()
+" &
+    DNS_PID=$!
+    sleep 0.5
+    echo "# installing allow_dns in the namespace" >&3
+    run ip netns exec "${NETNS}" bash -c "cat '$FIXTURE_ROOT/attach_allow_dns_in.json' | CNI_COMMAND=ADD traffico-cni"
+    [ $status -eq 0 ]
+    echo "# attach ok" >&3
+    run ip netns exec "${NETNS}" tc qdisc show dev peer0 clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+    echo "# qdisc ok" >&3
+    run ip netns exec "${NETNS}" curl --max-time 2 --silent "telnet://${VETH_ADDR}:53"
+    [ $status -eq 0 ]
+    echo "# can still reach ${VETH_ADDR}:53 (approved resolver)" >&3
+    kill $DNS_PID 2>/dev/null || true
+}
+
 @test "allow_port via CNI" {
     run curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
     [ $status -eq 0 ]

--- a/test/cni.flags.bats
+++ b/test/cni.flags.bats
@@ -28,6 +28,12 @@ cni_add() {
     [[ "$output" == *"program requires an"*"input"*"field"* ]]
 }
 
+@test "rejects missing input for allow_port" {
+    cni_add "allow_port"
+    [ ! $status -eq 0 ]
+    [[ "$output" == *"program requires an"*"input"*"field"* ]]
+}
+
 @test "rejects missing input for block_ipv4" {
     cni_add "block_ipv4"
     [ ! $status -eq 0 ]

--- a/test/cni.flags.bats
+++ b/test/cni.flags.bats
@@ -22,8 +22,8 @@ cni_add() {
     [[ "$output" == *'"msg":	"program does not accept input"'* ]]
 }
 
-@test "rejects missing input for allow_ip" {
-    cni_add "allow_ip"
+@test "rejects missing input for allow_ipv4" {
+    cni_add "allow_ipv4"
     [ ! $status -eq 0 ]
     [[ "$output" == *"program requires an"*"input"*"field"* ]]
 }

--- a/test/cni.flags.bats
+++ b/test/cni.flags.bats
@@ -22,6 +22,12 @@ cni_add() {
     [[ "$output" == *'"msg":	"program does not accept input"'* ]]
 }
 
+@test "rejects missing input for allow_dns" {
+    cni_add "allow_dns"
+    [ ! $status -eq 0 ]
+    [[ "$output" == *"program requires an"*"input"*"field"* ]]
+}
+
 @test "rejects missing input for allow_ipv4" {
     cni_add "allow_ipv4"
     [ ! $status -eq 0 ]

--- a/test/cni.flags.bats
+++ b/test/cni.flags.bats
@@ -22,6 +22,12 @@ cni_add() {
     [[ "$output" == *'"msg":	"program does not accept input"'* ]]
 }
 
+@test "rejects missing input for allow_ip" {
+    cni_add "allow_ip"
+    [ ! $status -eq 0 ]
+    [[ "$output" == *"program requires an"*"input"*"field"* ]]
+}
+
 @test "rejects missing input for block_ipv4" {
     cni_add "block_ipv4"
     [ ! $status -eq 0 ]

--- a/test/fixtures/cni/attach_allow_dns_in.json
+++ b/test/fixtures/cni/attach_allow_dns_in.json
@@ -1,0 +1,22 @@
+{
+    "cniVersion": "0.4.0",
+    "name": "dummy-network",
+    "prevResult": {
+        "cniVersion": "1.0.0",
+        "interfaces": [
+            {
+                "name": "peer0"
+            }
+        ],
+        "ips": [
+        ],
+        "routes": [
+        ],
+        "dns": {
+        }
+    },
+    "type": "traffico-cni",
+    "program": "allow_dns",
+    "input": "10.22.1.1",
+    "attachPoint": "egress"
+}

--- a/test/fixtures/cni/attach_allow_ip_in.json
+++ b/test/fixtures/cni/attach_allow_ip_in.json
@@ -1,0 +1,22 @@
+{
+    "cniVersion": "0.4.0",
+    "name": "dummy-network",
+    "prevResult": {
+        "cniVersion": "1.0.0",
+        "interfaces": [
+            {
+                "name": "peer0"
+            }
+        ],
+        "ips": [
+        ],
+        "routes": [
+        ],
+        "dns": {
+        }
+    },
+    "type": "traffico-cni",
+    "program": "allow_ip",
+    "input": "10.22.1.1",
+    "attachPoint": "egress"
+}

--- a/test/fixtures/cni/attach_allow_ipv4_in.json
+++ b/test/fixtures/cni/attach_allow_ipv4_in.json
@@ -16,7 +16,7 @@
         }
     },
     "type": "traffico-cni",
-    "program": "allow_ip",
+    "program": "allow_ipv4",
     "input": "10.22.1.1",
     "attachPoint": "egress"
 }

--- a/test/fixtures/cni/attach_allow_port_in.json
+++ b/test/fixtures/cni/attach_allow_port_in.json
@@ -1,0 +1,22 @@
+{
+    "cniVersion": "0.4.0",
+    "name": "dummy-network",
+    "prevResult": {
+        "cniVersion": "1.0.0",
+        "interfaces": [
+            {
+                "name": "peer0"
+            }
+        ],
+        "ips": [
+        ],
+        "routes": [
+        ],
+        "dns": {
+        }
+    },
+    "type": "traffico-cni",
+    "program": "allow_port",
+    "input": "8787",
+    "attachPoint": "egress"
+}

--- a/traffico.c
+++ b/traffico.c
@@ -215,13 +215,18 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
 
         if (g_chain_arg)
         {
-            // Parse chain: comma-separated "name:input" or "name" entries
-            char chain_buf[1024];
-            snprintf(chain_buf, sizeof(chain_buf), "%s", g_chain_arg);
+            // Parse chain: comma-separated "name:input" or "name" entries.
+            // Tokenize g_chain_arg directly — argp guarantees the pointer
+            // remains valid through ARGP_KEY_FINI.
             char *saveptr = NULL;
-            char *token = strtok_r(chain_buf, ",", &saveptr);
-            while (token && g_chain_len < MAX_CHAIN_LEN)
+            char *token = strtok_r(g_chain_arg, ",", &saveptr);
+            while (token)
             {
+                if (g_chain_len >= MAX_CHAIN_LEN)
+                {
+                    argp_error(state, "chain exceeds maximum of %d programs", MAX_CHAIN_LEN);
+                }
+
                 char *colon = strchr(token, ':');
                 char *prog_name = token;
                 char *input_str = NULL;

--- a/traffico.c
+++ b/traffico.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <signal.h>
 #include <stdio.h>
 #include <string.h>
@@ -11,6 +12,7 @@
 
 #include "api.h"
 #include "api/input_parse.h"
+#include "api/chain.h"
 
 const char *argp_program_version = TOOL_NAME " 0.0";
 const char *argp_program_bug_address = "https://github.com/leodido/traffico/issues";
@@ -34,6 +36,9 @@ const char OPT_ATTACH_LONG[] = "at";
 const char OPT_ATTACH_ARG[] = "INGRESS|EGRESS";
 #define OPT_NO_CLEANUP_KEY 0x81
 const char OPT_NO_CLEANUP_LONG[] = "no-cleanup";
+#define OPT_CHAIN_KEY 0x82
+const char OPT_CHAIN_LONG[] = "chain";
+const char OPT_CHAIN_ARG[] = "PROG:INPUT,...";
 
 const struct argp_option argp_opts[] = {
 
@@ -42,12 +47,16 @@ const struct argp_option argp_opts[] = {
     {OPT_IFNAME_LONG, OPT_IFNAME_KEY, OPT_IFNAME_ARG, 0, "Interface to which to attach the filter\n(defaults to the default gateway interface)", 1},
     {OPT_ATTACH_LONG, OPT_ATTACH_KEY, OPT_ATTACH_ARG, 0, "Where to attach the filter (defaults to egress)", 1},
     {OPT_NO_CLEANUP_LONG, OPT_NO_CLEANUP_KEY, NULL, 0, "Do not detach the TC hook and filter at the exit", 1},
+    {OPT_CHAIN_LONG, OPT_CHAIN_KEY, OPT_CHAIN_ARG, 0, "Attach a chain of programs (e.g., allow_ipv4:10.0.0.1,allow_port:8080)", 1},
     {"", 0, 0, OPTION_DOC, 0, 0},
     {0} // .
 
 };
 
 static struct config g_config;
+static struct chain_entry g_chain[MAX_CHAIN_LEN];
+static int g_chain_len = 0;
+static char *g_chain_arg = NULL;
 
 #define log_erro(fmt, ...) \
     log_err(&g_config, fmt, ##__VA_ARGS__);
@@ -141,6 +150,9 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
     case OPT_NO_CLEANUP_KEY:
         g_config.cleanup_on_exit = false;
         break;
+    case OPT_CHAIN_KEY:
+        g_chain_arg = arg;
+        break;
 
     // Arguments
     case ARGP_KEY_ARG:
@@ -170,13 +182,21 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
         break;
 
     case ARGP_KEY_END:
-        if (state->arg_num == 0)
+        // In chain mode, positional args are not required
+        if (!g_chain_arg)
         {
-            argp_error(state, "program name is mandatory");
+            if (state->arg_num == 0)
+            {
+                argp_error(state, "program name is mandatory");
+            }
+            if (g_config.program == program_0)
+            {
+                argp_error(state, "argument '%s' is not a " TOOL_NAME " program", g_config.program_arg);
+            }
         }
-        if (g_config.program == program_0)
+        else if (state->arg_num > 0)
         {
-            argp_error(state, "argument '%s' is not a " TOOL_NAME " program", g_config.program_arg);
+            argp_error(state, "--chain and positional PROGRAM arguments are mutually exclusive");
         }
         break;
 
@@ -193,18 +213,81 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
             assert(g_config.ifindex != 0);
         }
 
-        // Parse input value based on the selected program
-        if (g_config.input_arg)
+        if (g_chain_arg)
         {
-            const char *err_msg = NULL;
-            if (parse_input(&g_config, g_config.input_arg, &err_msg) != 0)
+            // Parse chain: comma-separated "name:input" or "name" entries
+            char chain_buf[1024];
+            snprintf(chain_buf, sizeof(chain_buf), "%s", g_chain_arg);
+            char *saveptr = NULL;
+            char *token = strtok_r(chain_buf, ",", &saveptr);
+            while (token && g_chain_len < MAX_CHAIN_LEN)
             {
-                argp_error(state, "%s: '%s'", err_msg, g_config.input_arg);
+                char *colon = strchr(token, ':');
+                char *prog_name = token;
+                char *input_str = NULL;
+                if (colon)
+                {
+                    *colon = '\0';
+                    input_str = colon + 1;
+                }
+
+                // Look up program name
+                int found = 0;
+                for (int pi = 1; pi < NUM_PROGRAMS; pi++)
+                {
+                    if (strcasecmp(prog_name, g_programs_name[pi]) == 0)
+                    {
+                        g_chain[g_chain_len].program = (program_t)pi;
+                        found = 1;
+                        break;
+                    }
+                }
+                if (!found)
+                {
+                    argp_error(state, "unknown program in chain: '%s'", prog_name);
+                }
+
+                // Parse input for this program
+                if (input_str)
+                {
+                    struct config tmp = {0};
+                    tmp.program = g_chain[g_chain_len].program;
+                    const char *err_msg = NULL;
+                    if (parse_input(&tmp, input_str, &err_msg) != 0)
+                    {
+                        argp_error(state, "%s: '%s'", err_msg, input_str);
+                    }
+                    g_chain[g_chain_len].has_input = tmp.has_input;
+                    memcpy(&g_chain[g_chain_len].input, &tmp.input, sizeof(tmp.input));
+                }
+                else if (program_requires_input(g_chain[g_chain_len].program))
+                {
+                    argp_error(state, "program '%s' in chain requires an input value (use name:value)", prog_name);
+                }
+
+                g_chain_len++;
+                token = strtok_r(NULL, ",", &saveptr);
+            }
+            if (g_chain_len == 0)
+            {
+                argp_error(state, "--chain requires at least one program");
             }
         }
-        else if (program_requires_input(g_config.program))
+        else
         {
-            argp_error(state, "program '%s' requires an input argument", g_programs_name[g_config.program]);
+            // Single program mode: parse input value
+            if (g_config.input_arg)
+            {
+                const char *err_msg = NULL;
+                if (parse_input(&g_config, g_config.input_arg, &err_msg) != 0)
+                {
+                    argp_error(state, "%s: '%s'", err_msg, g_config.input_arg);
+                }
+            }
+            else if (program_requires_input(g_config.program))
+            {
+                argp_error(state, "program '%s' requires an input argument", g_programs_name[g_config.program]);
+            }
         }
         break;
 
@@ -277,6 +360,12 @@ int main(int argc, char **argv)
     libbpf_set_print(libbpf_print_fn);
 
     // Execute
+    if (g_chain_len > 0)
+    {
+        log_info("chain: %d programs\n", g_chain_len);
+        return attach_chain(&g_config, g_chain, g_chain_len, &await);
+    }
+
     log_info("prog: %s\n", g_programs_name[g_config.program]);
     return attach(&g_config, &await);
 }

--- a/xmake/modules/api.lua
+++ b/xmake/modules/api.lua
@@ -5,6 +5,7 @@ import("core.project.project")
 -- configured at runtime via the input union in struct config.
 local input_fields = {
     allow_ipv4 = "ip",
+    allow_port = "port",
     block_ipv4 = "ip",
     block_port = "port",
 }

--- a/xmake/modules/api.lua
+++ b/xmake/modules/api.lua
@@ -4,6 +4,7 @@ import("core.project.project")
 -- Programs in this table have const volatile rodata that can be
 -- configured at runtime via the input union in struct config.
 local input_fields = {
+    allow_dns = "ip",
     allow_ipv4 = "ip",
     allow_port = "port",
     block_ipv4 = "ip",

--- a/xmake/modules/api.lua
+++ b/xmake/modules/api.lua
@@ -4,6 +4,7 @@ import("core.project.project")
 -- Programs in this table have const volatile rodata that can be
 -- configured at runtime via the input union in struct config.
 local input_fields = {
+    allow_ip = "ip",
     block_ipv4 = "ip",
     block_port = "port",
 }

--- a/xmake/modules/api.lua
+++ b/xmake/modules/api.lua
@@ -4,7 +4,7 @@ import("core.project.project")
 -- Programs in this table have const volatile rodata that can be
 -- configured at runtime via the input union in struct config.
 local input_fields = {
-    allow_ip = "ip",
+    allow_ipv4 = "ip",
     block_ipv4 = "ip",
     block_port = "port",
 }

--- a/xmake/modules/api.lua
+++ b/xmake/modules/api.lua
@@ -11,13 +11,25 @@ local input_fields = {
     block_port = "port",
 }
 
+-- Internal BPF programs that are not user-facing.
+-- These are compiled and get skeletons but are excluded from the
+-- program list, enum, and dispatch table.
+local internal_programs = {
+    dispatcher = true,
+}
+
 -- get sourcefiles
 function _get_programs(target_name)
     local programs = {}
     for _, target in pairs(project.targets()) do
         if target:is_enabled() and target:name() == target_name then
             for _, src in pairs(target:sourcebatches()) do
-                table.join2(programs, src.sourcefiles)
+                for _, f in ipairs(src.sourcefiles) do
+                    local progname = string.match(path.basename(f), "(.+)%..+$")
+                    if not internal_programs[progname] then
+                        table.insert(programs, f)
+                    end
+                end
             end
         end
     end


### PR DESCRIPTION
Covered cases:

- rejects empty chain entries from leading, trailing, or consecutive separators

- verifies chained allow_port -> allow_ipv4 continues evaluation instead of letting non-matching traffic bypass later programs

- verifies failed chain attach with --no-cleanup does not leave dispatcher/qdisc state behind

Some of these are expected to fail against the current branch and expose remaining behavior gaps; the attach-failure cleanup case is included as regression coverage for the current prevalidation/cleanup path.

This is intentionally test-only and stacked on top of feat/dispatcher-chain.