### PR TITLE
fix: handle empty chain entries and continue chained allow paths

### DIFF
--- a/bpf/allow_dns.bpf.c
+++ b/bpf/allow_dns.bpf.c
@@ -32,6 +32,7 @@ int allow_dns(struct __sk_buff *skb)
     if (eth->h_proto != bpf_htons(ETH_P_IP))
     {
         bpf_printk("allow_dns: [eth] protocol is %d: continue", eth->h_proto);
+        tail_call_next(skb, slot);
         return TC_ACT_OK;
     }
 
@@ -67,6 +68,7 @@ int allow_dns(struct __sk_buff *skb)
     if (ip_header->protocol != IPPROTO_TCP && ip_header->protocol != IPPROTO_UDP)
     {
         bpf_printk("allow_dns: [iph] protocol %d is not TCP/UDP: allow", ip_header->protocol);
+        tail_call_next(skb, slot);
         return TC_ACT_OK;
     }
 
@@ -85,6 +87,7 @@ int allow_dns(struct __sk_buff *skb)
     if (dst_port != DNS_PORT)
     {
         bpf_printk("allow_dns: [l4] port %d is not DNS: allow", dst_port);
+        tail_call_next(skb, slot);
         return TC_ACT_OK;
     }
 

--- a/bpf/allow_ipv4.bpf.c
+++ b/bpf/allow_ipv4.bpf.c
@@ -28,6 +28,7 @@ int allow_ipv4(struct __sk_buff *skb)
     if (eth->h_proto != bpf_htons(ETH_P_IP))
     {
         bpf_printk("allow_ipv4: [eth] protocol is %d: continue", eth->h_proto);
+        tail_call_next(skb, slot);
         return TC_ACT_OK;
     }
 
@@ -64,6 +65,7 @@ int allow_ipv4(struct __sk_buff *skb)
     if ((dest & 0xFF000000) == 0x7F000000)
     {
         bpf_printk("allow_ipv4: [iph] destination is localhost: allow");
+        tail_call_next(skb, slot);
         return TC_ACT_OK;
     }
 

--- a/bpf/allow_port.bpf.c
+++ b/bpf/allow_port.bpf.c
@@ -59,6 +59,7 @@ int allow_port(struct __sk_buff *skb)
     if (ip_header->protocol != IPPROTO_TCP && ip_header->protocol != IPPROTO_UDP)
     {
         bpf_printk("allow_port: [iph] protocol %d is not TCP/UDP: allow", ip_header->protocol);
+        tail_call_next(skb, slot);
         return TC_ACT_OK;
     }
 

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -517,7 +517,6 @@ sys.exit(0)
 }
 
 @test "chain allow_port+allow_ipv4 continues through non-matching traffic" {
-    skip "requires allow_port tail-call fix (PR #57)"
     run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
     [ $status -eq 0 ]
     # allow_port returns TC_ACT_OK for ICMP; allow_ipv4 must still be reached in chain mode

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -346,21 +346,18 @@ bats_require_minimum_version 1.7.0
 }
 
 @test "--chain rejects leading separator" {
-    skip "requires chain parser fix (PR #57)"
     run timeout 2 traffico -i lo --chain ",allow_ipv4:127.0.0.1"
     [ $status -eq 1 ]
     [[ "${output}" == *"empty chain entry"* ]]
 }
 
 @test "--chain rejects trailing separator" {
-    skip "requires chain parser fix (PR #57)"
     run timeout 2 traffico -i lo --chain "allow_ipv4:127.0.0.1,"
     [ $status -eq 1 ]
     [[ "${output}" == *"empty chain entry"* ]]
 }
 
 @test "--chain rejects consecutive separators" {
-    skip "requires chain parser fix (PR #57)"
     run timeout 2 traffico -i lo --chain "allow_ipv4:127.0.0.1,,allow_port:80"
     [ $status -eq 1 ]
     [[ "${output}" == *"empty chain entry"* ]]

--- a/traffico.c
+++ b/traffico.c
@@ -216,12 +216,32 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
         if (g_chain_arg)
         {
             // Parse chain: comma-separated "name:input" or "name" entries.
-            // Tokenize g_chain_arg directly — argp guarantees the pointer
-            // remains valid through ARGP_KEY_FINI.
-            char *saveptr = NULL;
-            char *token = strtok_r(g_chain_arg, ",", &saveptr);
-            while (token)
+            // Walk g_chain_arg directly so empty entries are not skipped.
+            if (g_chain_arg[0] == '\0')
             {
+                argp_error(state, "--chain requires at least one program");
+            }
+
+            char *cursor = g_chain_arg;
+            while (cursor)
+            {
+                char *token = cursor;
+                char *comma = strchr(token, ',');
+                if (comma)
+                {
+                    *comma = '\0';
+                    cursor = comma + 1;
+                }
+                else
+                {
+                    cursor = NULL;
+                }
+
+                if (token[0] == '\0')
+                {
+                    argp_error(state, "empty chain entry");
+                }
+
                 if (g_chain_len >= MAX_CHAIN_LEN)
                 {
                     argp_error(state, "chain exceeds maximum of %d programs", MAX_CHAIN_LEN);
@@ -279,7 +299,6 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
                 }
 
                 g_chain_len++;
-                token = strtok_r(NULL, ",", &saveptr);
             }
             if (g_chain_len == 0)
             {


### PR DESCRIPTION
Rebased cherry-pick of @fntlnz's work from #55, which became unmergeable after PRs #41–#53 landed on `main`.

## What changed

- Replaces `strtok_r()` chain parsing with explicit comma walking so empty entries are detected instead of skipped.
- Rejects leading, trailing, and consecutive `--chain` separators with `empty chain entry`.
- Makes chain-capable allow programs tail-call the next program before returning `TC_ACT_OK` on pass-through allow paths:
  - `allow_ipv4`
  - `allow_port`
  - `allow_dns`

## Why

`strtok_r()` skips empty tokens, so malformed chains like `,allow_ipv4:127.0.0.1`, `allow_ipv4:127.0.0.1,`, and `allow_ipv4:127.0.0.1,,allow_port:80` were accepted.

Separately, some allow programs returned `TC_ACT_OK` for traffic they intentionally pass through, such as ICMP in `allow_port`. In a chain, that stopped evaluation early and prevented later programs from enforcing their policy.

---

Replaces #55 (rebased onto current `test/pr-45-tests`).
Original author: @fntlnz.
Stacked on #56.