### PR TITLE
test: add Scapy coverage for allow-program edge cases

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -15,13 +15,37 @@ setsuite() {
   echo "${PREFIX%%.*}: "
 }
 
+# Return true when a crafted packet needs raw marker matching because it does
+# not expose a reliable IPv4 ID to Scapy's sniffer.
+scapy_needs_marker_match() {
+  local expect_type=0
+  local arg
+
+  for arg in "$@"; do
+    if [ "$expect_type" -eq 1 ]; then
+      case "$arg" in
+        ipv4-invalid-ihl|ethernet-truncated|qinq-inner-ipv4|non-ipv4-tcp|ipv6-tcp)
+          return 0
+          ;;
+      esac
+      expect_type=0
+      continue
+    fi
+
+    [ "$arg" = "--type" ] && expect_type=1
+  done
+
+  return 1
+}
+
 # Start a background sniffer on IFACE matching packets with IP_ID.
-# Usage: start_sniffer IFACE IP_ID [SRC_IP] [DST_IP]
+# Usage: start_sniffer IFACE IP_ID [SRC_IP] [DST_IP] [MATCH_MARKER]
 start_sniffer() {
-  local iface="$1" ip_id="$2" src_ip="${3:-}" dst_ip="${4:-}"
+  local iface="$1" ip_id="$2" src_ip="${3:-}" dst_ip="${4:-}" match_marker="${5:-}"
   local sniff_args=(--iface "$iface" --ip-id "$ip_id" --timeout "$SCAPY_SNIFF_TIMEOUT")
   [ -n "$src_ip" ] && sniff_args+=(--src-ip "$src_ip")
   [ -n "$dst_ip" ] && sniff_args+=(--dst-ip "$dst_ip")
+  [ "$match_marker" = "1" ] && sniff_args+=(--match-marker)
 
   python3 "$SCAPY_HELPER" sniff "${sniff_args[@]}" &
   SNIFFER_PID=$!
@@ -61,8 +85,10 @@ arp_prewarm() {
 assert_packet_seen() {
   local netns="$1" ip_id="$2"
   shift 2
+  local match_marker=0
+  scapy_needs_marker_match "$@" && match_marker=1
 
-  start_sniffer "$VETH" "$ip_id"
+  start_sniffer "$VETH" "$ip_id" "" "" "$match_marker"
   scapy_send "$netns" "$PEER" --ip-id "$ip_id" "$@"
   wait_sniffer
   local rc=$?
@@ -77,8 +103,10 @@ assert_packet_seen() {
 assert_packet_blocked() {
   local netns="$1" ip_id="$2"
   shift 2
+  local match_marker=0
+  scapy_needs_marker_match "$@" && match_marker=1
 
-  start_sniffer "$VETH" "$ip_id"
+  start_sniffer "$VETH" "$ip_id" "" "" "$match_marker"
   scapy_send "$netns" "$PEER" --ip-id "$ip_id" "$@"
   local rc=0
   wait "$SNIFFER_PID" || rc=$?

--- a/test/scapy.bats
+++ b/test/scapy.bats
@@ -39,6 +39,142 @@ teardown() {
 }
 
 # --------------------------------------------------------------------------
+# allow_ipv4
+# --------------------------------------------------------------------------
+
+@test "allow_ipv4: drops packet with invalid IHL" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_ipv4 "${VETH_ADDR}" >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_blocked "${NETNS}" 4001 \
+        --type ipv4-invalid-ihl --dst-ip "${VETH_ADDR}"
+    echo "# blocked IPv4 packet with IHL < 5 to ${VETH_ADDR}" >&3
+}
+
+@test "allow_ipv4: drops packet with truncated IPv4 header" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_ipv4 "${VETH_ADDR}" >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_blocked "${NETNS}" 4002 \
+        --type ipv4-truncated-ihl --dst-ip "${VETH_ADDR}"
+    echo "# blocked IPv4 packet whose IHL extends beyond packet data" >&3
+}
+
+@test "allow_ipv4: allows non-IPv4 EtherType" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_ipv4 "${VETH_ADDR}" >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_seen "${NETNS}" 4003 \
+        --type ipv6-tcp --dst-port 8787
+    echo "# allowed IPv6 TCP packet through IPv4-only allowlist" >&3
+}
+
+# --------------------------------------------------------------------------
+# allow_port
+# --------------------------------------------------------------------------
+
+@test "allow_port: drops non-IPv4 EtherType" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_port 8787 >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_blocked "${NETNS}" 5001 \
+        --type non-ipv4-tcp --dst-ip "${VETH_ADDR}" --dst-port 8787
+    echo "# blocked non-IPv4 EtherType carrying TCP-like payload to allowed port" >&3
+}
+
+@test "allow_port: drops IPv6 TCP to allowed port" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_port 8787 >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_blocked "${NETNS}" 5002 \
+        --type ipv6-tcp --dst-port 8787
+    echo "# blocked IPv6 TCP to allowed IPv4 TCP/UDP port" >&3
+}
+
+@test "allow_port: allows fragmented non-TCP/UDP IPv4" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_port 8787 >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_seen "${NETNS}" 5003 \
+        --type fragment-subsequent --dst-ip "${VETH_ADDR}" --frag-offset 10 --proto-override 1
+    echo "# allowed subsequent non-TCP/UDP IPv4 fragment" >&3
+}
+
+@test "allow_port: drops packet with truncated L4 header" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_port 8787 >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_blocked "${NETNS}" 5004 \
+        --type ipv4-truncated-l4 --dst-ip "${VETH_ADDR}"
+    echo "# blocked IPv4 TCP packet with fewer than four L4 bytes" >&3
+}
+
+# --------------------------------------------------------------------------
+# allow_dns
+# --------------------------------------------------------------------------
+
+@test "allow_dns: allows non-IPv4 EtherType" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_dns "${VETH_ADDR}" >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_seen "${NETNS}" 6001 \
+        --type non-ipv4-tcp --dst-ip "${VETH_ADDR}" --dst-port 53
+    echo "# allowed non-IPv4 EtherType carrying DNS-like payload" >&3
+}
+
+@test "allow_dns: drops packet with truncated L4 header" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_dns "${VETH_ADDR}" >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_blocked "${NETNS}" 6002 \
+        --type ipv4-truncated-l4 --dst-ip "${VETH_ADDR}"
+    echo "# blocked IPv4 DNS candidate with fewer than four L4 bytes" >&3
+}
+
+@test "allow_dns: allows non-TCP/UDP protocol with DNS-shaped payload" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_dns "${VETH_ADDR}" >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_seen "${NETNS}" 6003 \
+        --type ipv4-non-l4-dns-port --dst-ip "${VETH_ADDR}"
+    echo "# allowed non-TCP/UDP IPv4 packet with DNS port-shaped payload" >&3
+}
+
+# --------------------------------------------------------------------------
+# allow_ethertype
+# --------------------------------------------------------------------------
+
+@test "allow_ethertype: drops truncated Ethernet frame" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_ethertype ipv4 >/dev/null 3>&- &
+    sleep 1
+
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
+
+    assert_packet_blocked "${NETNS}" 7001 \
+        --type ethernet-truncated
+    echo "# blocked frame shorter than Ethernet header" >&3
+}
+
+@test "allow_ethertype: drops QinQ when only inner EtherType is allowed" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_ethertype ipv4 >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_blocked "${NETNS}" 7003 \
+        --type qinq-inner-ipv4 --dst-ip "${VETH_ADDR}"
+    echo "# blocked QinQ frame when only the inner IPv4 EtherType matches" >&3
+}
+
+@test "allow_ethertype: drops disallowed EtherType" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_ethertype ipv4 >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_blocked "${NETNS}" 7004 \
+        --type non-ipv4-tcp --dst-ip "${VETH_ADDR}" --dst-port 8787
+    echo "# blocked frame whose EtherType is not in the allowed set" >&3
+}
+
+# --------------------------------------------------------------------------
 # block_ipv4
 # --------------------------------------------------------------------------
 

--- a/test/scapy_packets.py
+++ b/test/scapy_packets.py
@@ -179,20 +179,19 @@ def cmd_sniff(args):
     """Sniff for a matching packet. Exit 0 if seen, 1 if timeout."""
     timeout = args.timeout
     ip_id = args.ip_id
+    marker = marker_for(ip_id)
 
     def match_filter(pkt):
-        if not pkt.haslayer(IP):
-            raw = bytes(pkt)
-            return marker_for(ip_id) in raw
-        ip = pkt[IP]
-        if ip.id == ip_id:
-            if args.src_ip and ip.src != args.src_ip:
-                return False
-            if args.dst_ip and ip.dst != args.dst_ip:
-                return False
-            return True
-        raw = bytes(pkt)
-        return marker_for(ip_id) in raw
+        if pkt.haslayer(IP):
+            ip = pkt[IP]
+            if ip.id == ip_id:
+                if args.src_ip and ip.src != args.src_ip:
+                    return False
+                if args.dst_ip and ip.dst != args.dst_ip:
+                    return False
+                return True
+
+        return args.match_marker and marker in bytes(pkt)
 
     result = sniff(
         iface=args.iface,
@@ -244,6 +243,8 @@ def main():
     p_sniff.add_argument("--ip-id", type=int, required=True)
     p_sniff.add_argument("--src-ip", default=None)
     p_sniff.add_argument("--dst-ip", default=None)
+    p_sniff.add_argument("--match-marker", action="store_true",
+                         help="Also match the raw payload marker for packets without a reliable IPv4 ID")
 
     args = parser.parse_args()
 

--- a/test/scapy_packets.py
+++ b/test/scapy_packets.py
@@ -2,10 +2,13 @@
 """Scapy helper for Bats tests. Provides send and sniff subcommands."""
 
 import argparse
+import socket
+import struct
 import sys
 
 from scapy.all import (
     IP,
+    IPv6,
     TCP,
     UDP,
     ICMP,
@@ -14,12 +17,41 @@ from scapy.all import (
     Raw,
     IPOption,
     send as scapy_send,
+    sendp as scapy_sendp,
     sniff,
     conf,
 )
 
 # Suppress Scapy warnings
 conf.verb = 0
+
+
+def marker_for(ip_id):
+    """Build a payload marker used by L2-only packets that have no IPv4 ID."""
+    return b"TRAFFICO" + struct.pack("!H", ip_id & 0xFFFF)
+
+
+def ether(eth_type):
+    """Build a broadcast Ethernet header for raw L2 test packets."""
+    return Ether(dst="ff:ff:ff:ff:ff:ff", type=eth_type)
+
+
+def ipv4_header(args, ihl=5, total_length=20, proto=6):
+    """Build a raw IPv4 header with caller-controlled IHL/total length."""
+    version_ihl = (4 << 4) | ihl
+    return struct.pack(
+        "!BBHHHBBH4s4s",
+        version_ihl,
+        0,
+        total_length,
+        args.ip_id,
+        0,
+        64,
+        proto,
+        0,
+        socket.inet_aton(args.src_ip),
+        socket.inet_aton(args.dst_ip),
+    )
 
 
 def build_ip_layer(args):
@@ -45,7 +77,59 @@ def cmd_send(args):
     """Craft and send a packet."""
     ip = build_ip_layer(args)
 
-    if args.type == "tcp":
+    if args.type == "ipv4-invalid-ihl":
+        pkt = (
+            ether(0x0800)
+            / Raw(ipv4_header(args, ihl=4, total_length=20) + marker_for(args.ip_id))
+        )
+    elif args.type == "ethernet-truncated":
+        pkt = Raw(marker_for(args.ip_id))
+    elif args.type == "qinq-inner-ipv4":
+        pkt = (
+            ether(0x88A8)
+            / Raw(
+                struct.pack("!HHHH", 0, 0x8100, 0, 0x0800)
+                + ipv4_header(args, ihl=5, total_length=30)
+                + marker_for(args.ip_id)
+            )
+        )
+    elif args.type == "ipv4-truncated-ihl":
+        pkt = ether(0x0800) / Raw(ipv4_header(args, ihl=6, total_length=24))
+    elif args.type == "ipv4-truncated-l4":
+        pkt = (
+            ether(0x0800)
+            / Raw(
+                ipv4_header(args, ihl=5, total_length=22, proto=6)
+                + struct.pack("!H", args.src_port)
+            )
+        )
+    elif args.type == "ipv4-non-l4-dns-port":
+        pkt = (
+            ether(0x0800)
+            / Raw(
+                ipv4_header(args, ihl=5, total_length=34, proto=47)
+                + struct.pack("!HH", args.src_port, 53)
+                + marker_for(args.ip_id)
+            )
+        )
+    elif args.type == "non-ipv4-tcp":
+        pkt = (
+            ether(0x88B5)
+            / Raw(
+                ipv4_header(args, ihl=5, total_length=44, proto=6)
+                + struct.pack("!HH", args.src_port, args.dst_port)
+                + marker_for(args.ip_id)
+            )
+        )
+    elif args.type == "ipv6-tcp":
+        src_ipv6 = f"0:6::{args.dst_port:04x}"
+        pkt = (
+            ether(0x86DD)
+            / IPv6(src=src_ipv6, dst=args.dst_ipv6, tc=0x50)
+            / TCP(sport=args.src_port, dport=args.dst_port)
+            / Raw(marker_for(args.ip_id))
+        )
+    elif args.type == "tcp":
         pkt = ip / TCP(sport=args.src_port, dport=args.dst_port) / Raw(b"X" * 20)
     elif args.type == "udp":
         pkt = ip / UDP(sport=args.src_port, dport=args.dst_port) / Raw(b"X" * 20)
@@ -66,11 +150,25 @@ def cmd_send(args):
         print(f"unknown packet type: {args.type}", file=sys.stderr)
         sys.exit(2)
 
-    # Use L3 send: the kernel adds the Ethernet header and routes
-    # through the default gateway. The packet hits TC egress on its
-    # way out, which is where the BPF program is attached.
+    l2_types = {
+        "ipv4-invalid-ihl",
+        "ethernet-truncated",
+        "qinq-inner-ipv4",
+        "ipv4-truncated-ihl",
+        "ipv4-truncated-l4",
+        "ipv4-non-l4-dns-port",
+        "non-ipv4-tcp",
+        "ipv6-tcp",
+    }
+
     try:
-        scapy_send(pkt, verbose=False)
+        if args.type in l2_types:
+            scapy_sendp(pkt, iface=args.iface, verbose=False)
+        else:
+            # Use L3 send: the kernel adds the Ethernet header and routes
+            # through the default gateway. The packet hits TC egress on its
+            # way out, which is where the BPF program is attached.
+            scapy_send(pkt, verbose=False)
     except OSError:
         # ENOBUFFS / ENETUNREACH is expected when the BPF program
         # drops the packet at TC egress. The sniffer judges the result.
@@ -84,15 +182,17 @@ def cmd_sniff(args):
 
     def match_filter(pkt):
         if not pkt.haslayer(IP):
-            return False
+            raw = bytes(pkt)
+            return marker_for(ip_id) in raw
         ip = pkt[IP]
-        if ip.id != ip_id:
-            return False
-        if args.src_ip and ip.src != args.src_ip:
-            return False
-        if args.dst_ip and ip.dst != args.dst_ip:
-            return False
-        return True
+        if ip.id == ip_id:
+            if args.src_ip and ip.src != args.src_ip:
+                return False
+            if args.dst_ip and ip.dst != args.dst_ip:
+                return False
+            return True
+        raw = bytes(pkt)
+        return marker_for(ip_id) in raw
 
     result = sniff(
         iface=args.iface,
@@ -117,9 +217,16 @@ def main():
     p_send.add_argument("--iface", required=True)
     p_send.add_argument("--type", required=True,
                         choices=["tcp", "udp", "icmp", "gre",
-                                 "fragment-first", "fragment-subsequent"])
+                                 "fragment-first", "fragment-subsequent",
+                                 "ipv4-invalid-ihl", "ethernet-truncated",
+                                 "qinq-inner-ipv4",
+                                 "ipv4-truncated-ihl",
+                                 "ipv4-truncated-l4",
+                                 "ipv4-non-l4-dns-port",
+                                 "non-ipv4-tcp", "ipv6-tcp"])
     p_send.add_argument("--src-ip", default="10.22.1.2")
     p_send.add_argument("--dst-ip", default="10.22.1.1")
+    p_send.add_argument("--dst-ipv6", default="2001:db8::1")
     p_send.add_argument("--src-port", type=int, default=12345)
     p_send.add_argument("--dst-port", type=int, default=80)
     p_send.add_argument("--ip-id", type=int, default=1)

--- a/test/scapy_packets.py
+++ b/test/scapy_packets.py
@@ -5,6 +5,7 @@ import argparse
 import socket
 import struct
 import sys
+import time
 
 from scapy.all import (
     IP,
@@ -141,11 +142,11 @@ def cmd_send(args):
         # First fragment: MF=1, offset=0, carries L4 header
         ip.flags = "MF"
         ip.frag = 0
-        pkt = ip / TCP(sport=args.src_port, dport=args.dst_port) / Raw(b"X" * 20)
+        pkt = Ether(dst="ff:ff:ff:ff:ff:ff") / ip / TCP(sport=args.src_port, dport=args.dst_port) / Raw(b"X" * 20)
     elif args.type == "fragment-subsequent":
         # Subsequent fragment: offset > 0, no L4 header
         ip.frag = args.frag_offset if args.frag_offset else 10
-        pkt = ip / Raw(b"X" * 20)
+        pkt = Ether(dst="ff:ff:ff:ff:ff:ff") / ip / Raw(b"X" * 20)
     else:
         print(f"unknown packet type: {args.type}", file=sys.stderr)
         sys.exit(2)
@@ -159,20 +160,27 @@ def cmd_send(args):
         "ipv4-non-l4-dns-port",
         "non-ipv4-tcp",
         "ipv6-tcp",
+        "fragment-first",
+        "fragment-subsequent",
     }
 
-    try:
-        if args.type in l2_types:
-            scapy_sendp(pkt, iface=args.iface, verbose=False)
-        else:
-            # Use L3 send: the kernel adds the Ethernet header and routes
-            # through the default gateway. The packet hits TC egress on its
-            # way out, which is where the BPF program is attached.
-            scapy_send(pkt, verbose=False)
-    except OSError:
-        # ENOBUFFS / ENETUNREACH is expected when the BPF program
-        # drops the packet at TC egress. The sniffer judges the result.
-        pass
+    for attempt in range(3):
+        try:
+            if args.type in l2_types:
+                scapy_sendp(pkt, iface=args.iface, verbose=False)
+            else:
+                # Use L3 send: the kernel adds the Ethernet header and routes
+                # through the default gateway. The packet hits TC egress on its
+                # way out, which is where the BPF program is attached.
+                scapy_send(pkt, verbose=False)
+            break
+        except OSError as e:
+            if e.errno == 105 and attempt < 2:  # ENOBUFS
+                time.sleep(0.2)
+                continue
+            # ENETUNREACH is expected when the BPF program drops the
+            # packet at TC egress. The sniffer judges the result.
+            break
 
 
 def cmd_sniff(args):


### PR DESCRIPTION
## Summary
- Add Scapy coverage for allow_ipv4, allow_port, allow_dns, and allow_ethertype malformed and boundary packets.
- Extend the Scapy packet generator with raw L2/L3 packet types for invalid IHL, truncated headers, unsupported EtherTypes, IPv6 TCP, VLAN, and QinQ cases.
- Narrow raw marker matching so the sniffer only falls back to payload markers for crafted packets that cannot expose a reliable IPv4 ID.

This PR is test coverage only. It does not change BPF program behavior or documentation.

## Validation
- bash -n test/helpers.bash
- python3 AST parse for test/scapy_packets.py
- git diff --check
- Docker/Arch runner: bats -t -f "allow_ipv4:" test/scapy.bats (3/3)
- Docker/Arch runner: bats -t -f "allow_port:" test/scapy.bats (4/4)
- Docker/Arch runner: bats -t -f "allow_dns:" test/scapy.bats (3/3)
- Docker/Arch runner: bats -t -f "allow_ethertype:" test/scapy.bats (3/3)
- Docker/Arch runner: bats -t test/scapy.bats (26/26)

Draft for review.