### PR TITLE
docs: clarify allow program packet scope

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -113,8 +113,8 @@ BUILT-IN PROGRAMS
     allow_dns
         allow_dns allows IPv4 DNS traffic (UDP/TCP port 53) to the input
         resolver address, drops the rest. Other traffic passes through.
-        Non-IPv4 traffic passes through and should be constrained by L2
-        or chain policy when needed.
+        Non-IPv4 traffic passes through unchanged in this program; put
+        allow_ethertype first in a chain when L2 filtering is required.
 
     allow_ethertype
         allow_ethertype is an L2 gatekeeper that drops Ethernet frames
@@ -129,10 +129,14 @@ BUILT-IN PROGRAMS
         outside their domain (e.g., non-IPv4 frames), which bypasses
         any downstream allow_ethertype filter.
 
+        Standalone allow_ethertype compares the outer Ethernet header
+        EtherType only; it does not unwrap VLAN tags or match the inner
+        payload EtherType.
+
         Symbolic names vlan (0x8100) and qinq (0x88A8) are available.
         VLAN TPIDs are only supported in standalone mode. In chains,
-        they are rejected because downstream L3/L4 programs cannot
-        yet parse VLAN-encapsulated payloads.
+        they are rejected because VLAN-aware parsing is not uniform
+        across downstream programs.
 
     allow_proto
         allow_proto is an L3 gatekeeper that drops IPv4 packets whose IP
@@ -157,8 +161,9 @@ BUILT-IN PROGRAMS
 
     allow_port
         allow_port allows IPv4 TCP/UDP traffic to the input destination
-        port, drops the rest. Other protocols (ICMP, etc.) pass
-        through. Non-IPv4 traffic is blocked.
+        port, drops the rest. Other IPv4 protocols (ICMP, GRE, etc.)
+        pass through. Non-IPv4 traffic and TCP/UDP subsequent fragments
+        are blocked.
 
     block_private_ipv4
         block_private_ipv4 is a program that can be used to block

--- a/bpf/allow_dns.bpf.c
+++ b/bpf/allow_dns.bpf.c
@@ -63,6 +63,7 @@ int allow_dns(struct __sk_buff *skb)
     }
 
     // Only TCP/UDP headers have the port layout checked below.
+    // Do not classify arbitrary non-TCP/UDP bytes as DNS ports.
     if (ip_header->protocol != IPPROTO_TCP && ip_header->protocol != IPPROTO_UDP)
     {
         bpf_printk("allow_dns: [iph] protocol %d is not TCP/UDP: allow", ip_header->protocol);

--- a/bpf/allow_port.bpf.c
+++ b/bpf/allow_port.bpf.c
@@ -55,6 +55,7 @@ int allow_port(struct __sk_buff *skb)
     }
 
     // Only TCP/UDP headers have the port layout checked below.
+    // Keep this before fragment handling so non-TCP/UDP fragments pass through here.
     if (ip_header->protocol != IPPROTO_TCP && ip_header->protocol != IPPROTO_UDP)
     {
         bpf_printk("allow_port: [iph] protocol %d is not TCP/UDP: allow", ip_header->protocol);

--- a/docs/README.md
+++ b/docs/README.md
@@ -119,10 +119,10 @@ Here's an example CNI config file featuring `traffico-cni`.
 
 | Program | Description |
 |---|---|
-| `allow_dns` | Allows IPv4 DNS traffic (port 53) to the input resolver, drops the rest. Other traffic passes through. Non-IPv4 passes through for L2/chain policy. |
-| `allow_ethertype` | L2 gatekeeper: drops frames whose EtherType is not in the allowed set (e.g., `ipv4+arp`). Must be first in a chain (see notes below). |
+| `allow_dns` | Allows IPv4 DNS traffic (port 53) to the input resolver, drops the rest. Non-IPv4 traffic passes through unchanged in this program. |
+| `allow_ethertype` | L2 gatekeeper: drops frames whose outer EtherType is not in the allowed set (e.g., `ipv4+arp`). Must be first in a chain (see notes below). |
 | `allow_ipv4` | Allows IPv4 traffic to the input address, drops the rest. Non-IPv4 passes through for L2/chain policy. Localhost (127.0.0.0/8) always allowed. |
-| `allow_port` | Allows IPv4 TCP/UDP traffic to the input port, drops the rest. Other protocols (ICMP, etc.) pass through. Non-IPv4 blocked. |
+| `allow_port` | Allows IPv4 TCP/UDP traffic to the input port, drops the rest. Other IPv4 protocols pass through. Non-IPv4 traffic and TCP/UDP subsequent fragments are blocked. |
 | `allow_proto` | L3 gatekeeper: drops IPv4 packets whose IP protocol is not in the allowed set (e.g., `tcp+udp`). Non-IPv4 passes through. |
 | `block_private_ipv4` | Blocks private IPv4 addresses subnets allowing only SSH access on port 22 |
 | `block_ipv4` | Drops packets with destination equal to the input IPv4 address |
@@ -133,7 +133,7 @@ Here's an example CNI config file featuring `traffico-cni`.
 
 **Chain ordering:** In a chain, `allow_ethertype` must be the first program. L3+ programs (`allow_ipv4`, `allow_port`, etc.) pass through traffic outside their domain (e.g., non-IPv4 frames return `TC_ACT_OK` directly), which bypasses any downstream `allow_ethertype` filter.
 
-**VLAN-tagged networks:** Symbolic names `vlan` (0x8100) and `qinq` (0x88A8) are available. VLAN TPIDs are only supported in standalone mode. In chains, they are rejected because downstream L3/L4 programs cannot yet parse VLAN-encapsulated payloads. Example (standalone): `allow_ethertype ipv4+arp+vlan`.
+**VLAN-tagged networks:** Standalone `allow_ethertype` compares the EtherType in the outer Ethernet header only; it does not unwrap VLAN tags or match the inner payload EtherType. Symbolic names `vlan` (0x8100) and `qinq` (0x88A8) are available for standalone filters. In multi-program chains, VLAN TPIDs are rejected because VLAN-aware parsing is not uniform across downstream programs. Example (standalone): `allow_ethertype ipv4+arp+vlan`.
 
 ### Notes on `allow_proto`
 


### PR DESCRIPTION
## Summary
- Clarify that standalone allow_ethertype compares only the outer Ethernet EtherType and does not unwrap VLAN tags.
- Clarify current allow_dns non-IPv4 passthrough behavior.
- Clarify current allow_port non-IPv4 and TCP/UDP subsequent-fragment behavior.
- Explain that VLAN TPIDs are rejected in multi-program chains because VLAN-aware parsing is not uniform across downstream programs.
- Add narrow BPF comments for two parsing choices: non-TCP/UDP bytes are not DNS ports, and allow_port checks protocol before fragment handling so non-TCP/UDP fragments keep passthrough behavior.

