### PR TITLE
test: cover allow_proto VLAN parsing

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -24,7 +24,7 @@ scapy_needs_marker_match() {
   for arg in "$@"; do
     if [ "$expect_type" -eq 1 ]; then
       case "$arg" in
-        ipv4-invalid-ihl|ethernet-truncated|qinq-inner-ipv4|non-ipv4-tcp|ipv6-tcp)
+        ipv4-invalid-ihl|ethernet-truncated|vlan-inner-ipv4|qinq-inner-ipv4|non-ipv4-tcp|ipv6-tcp)
           return 0
           ;;
       esac

--- a/test/scapy.bats
+++ b/test/scapy.bats
@@ -187,6 +187,24 @@ teardown() {
     echo "# blocked IPv4 TCP packet whose IHL extends beyond packet data" >&3
 }
 
+@test "allow_proto: drops VLAN IPv4 when inner protocol is denied" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_proto tcp >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_blocked "${NETNS}" 8002 \
+        --type vlan-inner-ipv4 --dst-ip "${VETH_ADDR}" --proto-override 1
+    echo "# blocked VLAN-tagged IPv4 ICMP packet when only TCP is allowed" >&3
+}
+
+@test "allow_proto: allows QinQ IPv4 when inner protocol is allowed" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_proto tcp >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_seen "${NETNS}" 8003 \
+        --type qinq-inner-ipv4 --dst-ip "${VETH_ADDR}" --proto-override 6
+    echo "# allowed QinQ-tagged IPv4 TCP packet" >&3
+}
+
 # --------------------------------------------------------------------------
 # block_ipv4
 # --------------------------------------------------------------------------

--- a/test/scapy_packets.py
+++ b/test/scapy_packets.py
@@ -55,6 +55,11 @@ def ipv4_header(args, ihl=5, total_length=20, proto=6):
     )
 
 
+def ip_proto(args, default=6):
+    """Return the requested IP protocol number for raw IPv4 headers."""
+    return int(args.proto_override) if args.proto_override else default
+
+
 def build_ip_layer(args):
     """Build an IP layer with optional IP options (NOP padding to force IHL > 5)."""
     ip = IP(src=args.src_ip, dst=args.dst_ip, id=args.ip_id)
@@ -85,12 +90,21 @@ def cmd_send(args):
         )
     elif args.type == "ethernet-truncated":
         pkt = Raw(marker_for(args.ip_id))
+    elif args.type == "vlan-inner-ipv4":
+        pkt = (
+            ether(0x8100)
+            / Raw(
+                struct.pack("!HH", 0, 0x0800)
+                + ipv4_header(args, ihl=5, total_length=30, proto=ip_proto(args))
+                + marker_for(args.ip_id)
+            )
+        )
     elif args.type == "qinq-inner-ipv4":
         pkt = (
             ether(0x88A8)
             / Raw(
                 struct.pack("!HHHH", 0, 0x8100, 0, 0x0800)
-                + ipv4_header(args, ihl=5, total_length=30)
+                + ipv4_header(args, ihl=5, total_length=30, proto=ip_proto(args))
                 + marker_for(args.ip_id)
             )
         )
@@ -154,6 +168,7 @@ def cmd_send(args):
     l2_types = {
         "ipv4-invalid-ihl",
         "ethernet-truncated",
+        "vlan-inner-ipv4",
         "qinq-inner-ipv4",
         "ipv4-truncated-ihl",
         "ipv4-truncated-l4",
@@ -226,7 +241,7 @@ def main():
                         choices=["tcp", "udp", "icmp", "gre",
                                  "fragment-first", "fragment-subsequent",
                                  "ipv4-invalid-ihl", "ethernet-truncated",
-                                 "qinq-inner-ipv4",
+                                 "vlan-inner-ipv4", "qinq-inner-ipv4",
                                  "ipv4-truncated-ihl",
                                  "ipv4-truncated-l4",
                                  "ipv4-non-l4-dns-port",


### PR DESCRIPTION
## Summary
- Add Scapy coverage for allow_proto parsing VLAN-tagged IPv4 packets.
- Add a single-VLAN raw packet helper and make the existing QinQ helper honor --proto-override.
- Verify allow_proto drops VLAN IPv4 when the inner protocol is denied and allows QinQ IPv4 when the inner protocol is allowed.

## Validation
- Red check: focused allow_proto Scapy run failed before helper support because vlan-inner-ipv4 was not a valid packet type.
- Focused Docker/Arch runner: bats -t -f "allow_proto:" test/scapy.bats (3/3)
- Full Docker/Arch runner: bats -t test/scapy.bats (29/29)
- git diff --check
- bash -n test/helpers.bash
- python3 -m py_compile test/scapy_packets.py