### PR TITLE
docs: add Ubuntu Linux test runner skill

### DIFF
--- a/.agents/skills/running-traffico-linux-tests/SKILL.md
+++ b/.agents/skills/running-traffico-linux-tests/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: running-traffico-linux-tests
+description: Use when working in the traffico repository and needing to run or verify Linux BATS, CNI, Scapy, network namespace, veth, tc, or eBPF tests from macOS or Apple Silicon Docker Desktop
+---
+
+# Running Traffico Linux Tests
+
+## Overview
+
+Traffico's full BATS suite needs a privileged Linux/AMD64 Arch container. Use this runner so CNI, Scapy, netns, veth, tc, and eBPF tests run with expected packages while xmake stays cached.
+
+## When To Use
+
+- Running `xmake run test` for traffico from macOS or Apple Silicon
+- Verifying PRs touching BATS, CNI fixtures, Scapy packets, tc attachment, netns, veth, or eBPF programs
+- Re-running tests without rebuilding packages
+
+Do not substitute Ubuntu or direct `bats test`; this runner depends on Arch packages and xmake-managed dependencies.
+
+## Quick Reference
+
+| Need | Command |
+| --- | --- |
+| Build image | `docker build --platform linux/amd64 -t traffico-arch-test:latest -f /tmp/traffico-arch-test.Dockerfile /tmp` |
+| Create cache | `docker volume create traffico-xmake-cache` |
+| Run tests | `docker start -ai traffico-arch-test-runner` |
+| Inspect runner | `docker ps -a --filter name=^/traffico-arch-test-runner$` |
+
+## Prerequisites
+
+- Docker must be running.
+- Docker must support privileged Linux/AMD64 containers.
+- On Apple Silicon, keep `--platform linux/amd64`; BPF tooling and generated artifacts are verified through the AMD64 Linux path.
+
+## Dockerfile
+
+Create `/tmp/traffico-arch-test.Dockerfile`:
+
+```Dockerfile
+FROM --platform=linux/amd64 docker.io/library/archlinux:latest
+
+ENV XMAKE_ROOT=y
+
+RUN sed -i 's/^#DisableSandbox/DisableSandbox/' /etc/pacman.conf \
+    && pacman -Syy --noconfirm \
+    && pacman -S --noconfirm \
+        clang llvm gcc linux-headers bpf \
+        make cmake xmake sudo diffutils \
+        curl iproute2 iputils \
+        python-scapy git base-devel unzip \
+    && pacman -Scc --noconfirm
+
+WORKDIR /workspaces/traffico
+```
+
+`DisableSandbox` avoids pacman seccomp failures under Docker Desktop AMD64 emulation. `XMAKE_ROOT=y` matches CI.
+
+## Setup
+
+From the traffico repository root:
+
+```sh
+docker build \
+  --platform linux/amd64 \
+  -t traffico-arch-test:latest \
+  -f /tmp/traffico-arch-test.Dockerfile \
+  /tmp
+
+docker volume create traffico-xmake-cache
+
+docker create \
+  --platform linux/amd64 \
+  --privileged \
+  --name traffico-arch-test-runner \
+  -v "$PWD:/workspaces/traffico" \
+  -v traffico-xmake-cache:/root/.xmake \
+  -w /workspaces/traffico \
+  traffico-arch-test:latest \
+  bash -lc 'xmake f -c -y --generate-vmlinux=y && xmake build -y && xmake run test'
+```
+
+Run or rerun:
+
+```sh
+docker start -ai traffico-arch-test-runner
+```
+
+The container is persistent. After success it should remain as `Exited (0)` and can be started again.
+
+## Recreate Runner
+
+If the command or mount needs to change, remove only the named container. Keep the image and `traffico-xmake-cache` volume.
+
+```sh
+docker rm traffico-arch-test-runner
+docker create \
+  --platform linux/amd64 \
+  --privileged \
+  --name traffico-arch-test-runner \
+  -v "$PWD:/workspaces/traffico" \
+  -v traffico-xmake-cache:/root/.xmake \
+  -w /workspaces/traffico \
+  traffico-arch-test:latest \
+  bash -lc 'xmake f -c -y --generate-vmlinux=y && xmake build -y && xmake run test'
+```
+
+## Common Mistakes
+
+| Mistake | Fix |
+| --- | --- |
+| Using Ubuntu and `apt` | Use the Arch image above. |
+| Running `bats test` directly | Use `xmake run test`. |
+| Omitting `--platform linux/amd64` | Keep it on build and create, especially on Apple Silicon. |
+| Omitting `--privileged` | Required for netns, veth, tc qdiscs, and eBPF attachment. |
+| Removing `traffico-xmake-cache` | Keep it unless intentionally forcing dependency rebuilds. |
+| Skipping `xmake f -c` on a new volume | Clean configure prevents stale package metadata paths. |

--- a/.agents/skills/running-traffico-linux-tests/SKILL.md
+++ b/.agents/skills/running-traffico-linux-tests/SKILL.md
@@ -7,15 +7,9 @@ description: Use when working in the traffico repository and needing to run or v
 
 ## Overview
 
-Traffico's full BATS suite needs a privileged Linux/AMD64 container. Use this Ubuntu 24.04 runner so CNI, Scapy, netns, veth, tc, and eBPF tests run with the same distro family as CI while xmake dependencies stay cached.
+Traffico's full BATS suite needs a privileged Linux/AMD64 container. Use the Ubuntu 24.04 runner by default; it matches CI's distro family and avoids the Arch/pacman sandbox override.
 
-Ubuntu avoids the Arch/pacman sandbox override. The container still needs `--privileged` at runtime because the tests create network namespaces, veth pairs, tc qdiscs, and eBPF attachments.
-
-## When To Use
-
-- Running `xmake run test` for traffico from macOS or Apple Silicon
-- Verifying PRs touching BATS, CNI fixtures, Scapy packets, tc attachment, netns, veth, or eBPF programs
-- Re-running tests without rebuilding xmake packages
+The runner still needs `--privileged` because tests create network namespaces, veth pairs, tc qdiscs, and eBPF attachments.
 
 ## Quick Reference
 
@@ -26,13 +20,7 @@ Ubuntu avoids the Arch/pacman sandbox override. The container still needs `--pri
 | Run tests | `docker start -ai traffico-ubuntu-test-runner` |
 | Inspect runner | `docker ps -a --filter name=^/traffico-ubuntu-test-runner$` |
 
-## Prerequisites
-
-- Docker must be running.
-- Docker must support privileged Linux/AMD64 containers.
-- On Apple Silicon, keep `--platform linux/amd64`; BPF tooling and generated artifacts are verified through the AMD64 Linux path.
-
-## Dockerfile
+## Ubuntu Runner
 
 Create `/tmp/traffico-ubuntu-test.Dockerfile`:
 
@@ -62,11 +50,7 @@ RUN curl -fsSL https://xmake.io/shget.text | bash
 WORKDIR /workspaces/traffico
 ```
 
-Keep the extra packages even when they look redundant with CI. A clean Ubuntu image is smaller than a GitHub-hosted runner, and xmake's dependency graph needs `g++`, archive tools, `m4`, `pkg-config`, Python build prerequisites, Scapy, and `killall` from `psmisc`.
-
-## Setup
-
-From the traffico repository root:
+Build the image and create the persistent runner from the traffico repository root:
 
 ```sh
 docker build \
@@ -94,24 +78,13 @@ Run or rerun:
 docker start -ai traffico-ubuntu-test-runner
 ```
 
-The container is persistent. After success it should remain as `Exited (0)` and can be started again.
+If the runner command, image, or mount changes, remove only the named container and recreate it. Keep `traffico-ubuntu-xmake-cache` unless intentionally forcing xmake to rebuild package dependencies.
 
-## Recreate Runner
+## Arch Fallback
 
-If the command, image, or mount needs to change, remove only the named container. Keep the image and `traffico-ubuntu-xmake-cache` volume unless intentionally forcing dependency rebuilds.
+Use [arch-runner.md](arch-runner.md) only when the Ubuntu runner cannot be built or run, an existing Arch runner/cache is already available and known good, or Arch-specific package/build behavior must be reproduced.
 
-```sh
-docker rm traffico-ubuntu-test-runner
-docker create \
-  --platform linux/amd64 \
-  --privileged \
-  --name traffico-ubuntu-test-runner \
-  -v "$PWD:/workspaces/traffico" \
-  -v traffico-ubuntu-xmake-cache:/root/.xmake \
-  -w /workspaces/traffico \
-  traffico-ubuntu-test:latest \
-  bash -lc 'xmake f -c -y --generate-vmlinux=y --require-bpftool=y && xmake build -y && xmake run test'
-```
+Do not choose Arch by default just because the fallback exists.
 
 ## Common Mistakes
 
@@ -119,8 +92,5 @@ docker create \
 | --- | --- |
 | Omitting `--platform linux/amd64` | Keep it on build and create, especially on Apple Silicon. |
 | Omitting `--privileged` | Required for netns, veth, tc qdiscs, and eBPF attachment. |
-| Omitting `XMAKE_ROOT=y` | xmake refuses root execution without it. |
 | Dropping `psmisc` | `test/cli.bats` uses `killall`; without it the suite fails and can hang. |
-| Using a bare Ubuntu package set | Keep the package list above; clean Ubuntu lacks GitHub runner preinstalls. |
 | Running `bats test` directly | Use `xmake run test`. |
-| Reusing a failed cache after changing the image | Use a fresh volume or recreate the runner/cache deliberately. |

--- a/.agents/skills/running-traffico-linux-tests/SKILL.md
+++ b/.agents/skills/running-traffico-linux-tests/SKILL.md
@@ -7,24 +7,24 @@ description: Use when working in the traffico repository and needing to run or v
 
 ## Overview
 
-Traffico's full BATS suite needs a privileged Linux/AMD64 Arch container. Use this runner so CNI, Scapy, netns, veth, tc, and eBPF tests run with expected packages while xmake stays cached.
+Traffico's full BATS suite needs a privileged Linux/AMD64 container. Use this Ubuntu 24.04 runner so CNI, Scapy, netns, veth, tc, and eBPF tests run with the same distro family as CI while xmake dependencies stay cached.
+
+Ubuntu avoids the Arch/pacman sandbox override. The container still needs `--privileged` at runtime because the tests create network namespaces, veth pairs, tc qdiscs, and eBPF attachments.
 
 ## When To Use
 
 - Running `xmake run test` for traffico from macOS or Apple Silicon
 - Verifying PRs touching BATS, CNI fixtures, Scapy packets, tc attachment, netns, veth, or eBPF programs
-- Re-running tests without rebuilding packages
-
-Do not substitute Ubuntu or direct `bats test`; this runner depends on Arch packages and xmake-managed dependencies.
+- Re-running tests without rebuilding xmake packages
 
 ## Quick Reference
 
 | Need | Command |
 | --- | --- |
-| Build image | `docker build --platform linux/amd64 -t traffico-arch-test:latest -f /tmp/traffico-arch-test.Dockerfile /tmp` |
-| Create cache | `docker volume create traffico-xmake-cache` |
-| Run tests | `docker start -ai traffico-arch-test-runner` |
-| Inspect runner | `docker ps -a --filter name=^/traffico-arch-test-runner$` |
+| Build image | `docker build --platform linux/amd64 -t traffico-ubuntu-test:latest -f /tmp/traffico-ubuntu-test.Dockerfile /tmp` |
+| Create cache | `docker volume create traffico-ubuntu-xmake-cache` |
+| Run tests | `docker start -ai traffico-ubuntu-test-runner` |
+| Inspect runner | `docker ps -a --filter name=^/traffico-ubuntu-test-runner$` |
 
 ## Prerequisites
 
@@ -34,26 +34,35 @@ Do not substitute Ubuntu or direct `bats test`; this runner depends on Arch pack
 
 ## Dockerfile
 
-Create `/tmp/traffico-arch-test.Dockerfile`:
+Create `/tmp/traffico-ubuntu-test.Dockerfile`:
 
 ```Dockerfile
-FROM --platform=linux/amd64 docker.io/library/archlinux:latest
+FROM docker.io/library/ubuntu:24.04
 
+ENV DEBIAN_FRONTEND=noninteractive
 ENV XMAKE_ROOT=y
+ENV PATH=/root/.local/bin:$PATH
 
-RUN sed -i 's/^#DisableSandbox/DisableSandbox/' /etc/pacman.conf \
-    && pacman -Syy --noconfirm \
-    && pacman -S --noconfirm \
-        clang llvm gcc linux-headers bpf \
-        make cmake xmake sudo diffutils \
-        curl iproute2 iputils \
-        python-scapy git base-devel unzip \
-    && pacman -Scc --noconfirm
+RUN apt-get update -qq \
+    && apt-get install -y -qq --no-install-recommends \
+        ca-certificates \
+        clang llvm gcc g++ \
+        make cmake ninja-build pkg-config git sudo diffutils unzip \
+        m4 \
+        xz-utils bzip2 \
+        linux-headers-generic \
+        libelf-dev libffi-dev libssl-dev zlib1g-dev \
+        curl iproute2 iputils-ping \
+        psmisc \
+        python3-scapy python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://xmake.io/shget.text | bash
 
 WORKDIR /workspaces/traffico
 ```
 
-`DisableSandbox` avoids pacman seccomp failures under Docker Desktop AMD64 emulation. `XMAKE_ROOT=y` matches CI.
+Keep the extra packages even when they look redundant with CI. A clean Ubuntu image is smaller than a GitHub-hosted runner, and xmake's dependency graph needs `g++`, archive tools, `m4`, `pkg-config`, Python build prerequisites, Scapy, and `killall` from `psmisc`.
 
 ## Setup
 
@@ -62,55 +71,56 @@ From the traffico repository root:
 ```sh
 docker build \
   --platform linux/amd64 \
-  -t traffico-arch-test:latest \
-  -f /tmp/traffico-arch-test.Dockerfile \
+  -t traffico-ubuntu-test:latest \
+  -f /tmp/traffico-ubuntu-test.Dockerfile \
   /tmp
 
-docker volume create traffico-xmake-cache
+docker volume create traffico-ubuntu-xmake-cache
 
 docker create \
   --platform linux/amd64 \
   --privileged \
-  --name traffico-arch-test-runner \
+  --name traffico-ubuntu-test-runner \
   -v "$PWD:/workspaces/traffico" \
-  -v traffico-xmake-cache:/root/.xmake \
+  -v traffico-ubuntu-xmake-cache:/root/.xmake \
   -w /workspaces/traffico \
-  traffico-arch-test:latest \
-  bash -lc 'xmake f -c -y --generate-vmlinux=y && xmake build -y && xmake run test'
+  traffico-ubuntu-test:latest \
+  bash -lc 'xmake f -c -y --generate-vmlinux=y --require-bpftool=y && xmake build -y && xmake run test'
 ```
 
 Run or rerun:
 
 ```sh
-docker start -ai traffico-arch-test-runner
+docker start -ai traffico-ubuntu-test-runner
 ```
 
 The container is persistent. After success it should remain as `Exited (0)` and can be started again.
 
 ## Recreate Runner
 
-If the command or mount needs to change, remove only the named container. Keep the image and `traffico-xmake-cache` volume.
+If the command, image, or mount needs to change, remove only the named container. Keep the image and `traffico-ubuntu-xmake-cache` volume unless intentionally forcing dependency rebuilds.
 
 ```sh
-docker rm traffico-arch-test-runner
+docker rm traffico-ubuntu-test-runner
 docker create \
   --platform linux/amd64 \
   --privileged \
-  --name traffico-arch-test-runner \
+  --name traffico-ubuntu-test-runner \
   -v "$PWD:/workspaces/traffico" \
-  -v traffico-xmake-cache:/root/.xmake \
+  -v traffico-ubuntu-xmake-cache:/root/.xmake \
   -w /workspaces/traffico \
-  traffico-arch-test:latest \
-  bash -lc 'xmake f -c -y --generate-vmlinux=y && xmake build -y && xmake run test'
+  traffico-ubuntu-test:latest \
+  bash -lc 'xmake f -c -y --generate-vmlinux=y --require-bpftool=y && xmake build -y && xmake run test'
 ```
 
 ## Common Mistakes
 
 | Mistake | Fix |
 | --- | --- |
-| Using Ubuntu and `apt` | Use the Arch image above. |
-| Running `bats test` directly | Use `xmake run test`. |
 | Omitting `--platform linux/amd64` | Keep it on build and create, especially on Apple Silicon. |
 | Omitting `--privileged` | Required for netns, veth, tc qdiscs, and eBPF attachment. |
-| Removing `traffico-xmake-cache` | Keep it unless intentionally forcing dependency rebuilds. |
-| Skipping `xmake f -c` on a new volume | Clean configure prevents stale package metadata paths. |
+| Omitting `XMAKE_ROOT=y` | xmake refuses root execution without it. |
+| Dropping `psmisc` | `test/cli.bats` uses `killall`; without it the suite fails and can hang. |
+| Using a bare Ubuntu package set | Keep the package list above; clean Ubuntu lacks GitHub runner preinstalls. |
+| Running `bats test` directly | Use `xmake run test`. |
+| Reusing a failed cache after changing the image | Use a fresh volume or recreate the runner/cache deliberately. |

--- a/.agents/skills/running-traffico-linux-tests/arch-runner.md
+++ b/.agents/skills/running-traffico-linux-tests/arch-runner.md
@@ -1,0 +1,93 @@
+# Arch Runner Fallback
+
+Use this fallback only when the Ubuntu runner in `SKILL.md` cannot be built or run, an existing Arch runner/cache is already available and known good, or Arch-specific package/build behavior must be reproduced.
+
+## Dockerfile
+
+Create `/tmp/traffico-arch-test.Dockerfile`:
+
+```Dockerfile
+FROM --platform=linux/amd64 docker.io/library/archlinux:latest
+
+ENV XMAKE_ROOT=y
+
+RUN sed -i 's/^#DisableSandbox/DisableSandbox/' /etc/pacman.conf \
+    && pacman -Syy --noconfirm \
+    && pacman -S --noconfirm \
+        clang llvm gcc linux-headers bpf \
+        make cmake xmake sudo diffutils \
+        curl iproute2 iputils \
+        python-scapy git base-devel unzip \
+    && pacman -Scc --noconfirm
+
+WORKDIR /workspaces/traffico
+```
+
+`DisableSandbox` avoids pacman failures under Docker Desktop AMD64 emulation where pacman can fail with seccomp or `switching to sandbox user 'alpm' failed` errors. `XMAKE_ROOT=y` allows xmake to run as root inside the container.
+
+## Build Image
+
+From the traffico repository root:
+
+```sh
+docker build \
+  --platform linux/amd64 \
+  -t traffico-arch-test:latest \
+  -f /tmp/traffico-arch-test.Dockerfile \
+  /tmp
+```
+
+Use `--platform linux/amd64` on Apple Silicon and ARM64 Docker Desktop. The BPF tooling and generated artifacts are verified through the AMD64 Linux path; Arch may not provide the required ARM64 image path for this runner.
+
+## Xmake Cache
+
+Create the cache volume once:
+
+```sh
+docker volume create traffico-xmake-cache
+```
+
+Mount it at `/root/.xmake` because the runner executes as root and xmake installs package dependencies there. Keep this volume across runner recreation to avoid rebuilding BATS, mini_httpd, cJSON, elfutils, libbpf, ninja, CMake, and related packages.
+
+## Persistent Runner
+
+Create the runner once from the traffico repository root:
+
+```sh
+docker create \
+  --platform linux/amd64 \
+  --privileged \
+  --name traffico-arch-test-runner \
+  -v "$PWD:/workspaces/traffico" \
+  -v traffico-xmake-cache:/root/.xmake \
+  -w /workspaces/traffico \
+  traffico-arch-test:latest \
+  bash -lc 'xmake f -c -y --generate-vmlinux=y && xmake build -y && xmake run test'
+```
+
+`--privileged` is required because the suite creates network namespaces, veth pairs, tc qdiscs, and eBPF attachments. The bind mount keeps the runner on the live working tree.
+
+Run or rerun:
+
+```sh
+docker start -ai traffico-arch-test-runner
+```
+
+The runner is persistent. After a successful run it should remain as `Exited (0)` and can be started again.
+
+## Recreate Runner
+
+If the runner command, image, or mount needs to change, remove and recreate only the named container. Keep the image and cache volume unless intentionally forcing a full xmake dependency rebuild.
+
+```sh
+docker rm traffico-arch-test-runner
+docker create \
+  --platform linux/amd64 \
+  --privileged \
+  --name traffico-arch-test-runner \
+  -v "$PWD:/workspaces/traffico" \
+  -v traffico-xmake-cache:/root/.xmake \
+  -w /workspaces/traffico \
+  traffico-arch-test:latest \
+  bash -lc 'xmake f -c -y --generate-vmlinux=y && xmake build -y && xmake run test'
+```

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode/
 .xmake/
 build/
+.DS_Store


### PR DESCRIPTION
## Summary

- add a repo-local Codex skill for running traffico Linux/BATS/eBPF tests from macOS or Apple Silicon Docker Desktop
- document an Ubuntu 24.04 AMD64 privileged container runner instead of the earlier Arch runner, avoiding the pacman `DisableSandbox` workaround
- document the required clean-Ubuntu package set, xmake cache volume, setup, rerun, and recreate commands
- ignore `.DS_Store` files so macOS metadata does not get committed with `.agents` changes

## Review notes

Reviewed the skill against skill-authoring guidance before publishing: the trigger description starts with `Use when`, stays focused on when to load the skill, and the body remains a single `SKILL.md`.

Ubuntu validation found that a bare `ubuntu:24.04` image is missing several packages that GitHub-hosted runners already have. The final package list keeps the xmake dependency graph working and includes `psmisc` because `test/cli.bats` uses `killall`.

## Validation

- removed prior traffico-specific Docker runners, test images, and xmake cache volumes
- rebuilt the Ubuntu image from the skill Dockerfile with `docker build --no-cache --platform linux/amd64 -t traffico-ubuntu-test:latest -f /tmp/traffico-ubuntu-test.Dockerfile /tmp`
- recreated the documented `traffico-ubuntu-xmake-cache` volume and `traffico-ubuntu-test-runner` container
- ran the documented runner command: `xmake f -c -y --generate-vmlinux=y --require-bpftool=y && xmake build -y && xmake run test`
- full suite passed in the Ubuntu runner: 137/137 BATS tests, runner exited 0
- removed the final validation runner, cache volume, and `traffico-ubuntu-test:latest` image after the run
- `git diff --check`
