### PR TITLE
docs: document design principles

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -108,6 +108,34 @@ USAGE
             ]
         }
 
+DESIGN PRINCIPLES
+
+    +-----------------------------+---------------------------------------------+---------------------------------------------+
+    | Principle                   | Rule                                        | Why                                         |
+    +-----------------------------+---------------------------------------------+---------------------------------------------+
+    | Standalone vs chained       | Standalone programs are the only filter on  | Standalone programs must make the final     |
+    |                             | the interface and handle all traffic types  | decision. Chained programs trust that an    |
+    |                             | themselves. Chained programs are part of a  | upstream filter, typically allow_ethertype, |
+    |                             | pipeline and pass traffic they do not       | already constrained the traffic.            |
+    |                             | handle to the next program.                 |                                             |
+    +-----------------------------+---------------------------------------------+---------------------------------------------+
+    | Boundary failures           | block_* programs fail open on truncated     | block_* programs target specific traffic,   |
+    |                             | headers, unsupported protocols, and         | so everything else should pass. allow_*     |
+    |                             | subsequent fragments by returning           | programs define permitted traffic, so       |
+    |                             | TC_ACT_OK. allow_* programs fail closed on  | everything else should be denied.           |
+    |                             | the same failures by returning TC_ACT_SHOT. |                                             |
+    +-----------------------------+---------------------------------------------+---------------------------------------------+
+    | L2 -> L3 -> L4 ordering     | Run cheapest and broadest checks first:     | Broad L2/L3 filters reduce what later,      |
+    |                             | allow_ethertype (L2), then allow_proto      | narrower L4 programs need to inspect.       |
+    |                             | (L3), then allow_port or allow_dns (L4).    | Layered ordering also keeps each program's  |
+    |                             | allow_ipv4 fits after L2 and alongside or   | responsibility clear.                       |
+    |                             | after L3 protocol filtering.                |                                             |
+    +-----------------------------+---------------------------------------------+---------------------------------------------+
+    | Non-IPv4 passthrough in     | In chains, L3 and L4 programs pass non-IPv4 | L2 filtering is allow_ethertype's job. ARP, |
+    | chains                      | traffic to the next program via             | IPv6, and other non-IPv4 traffic allowed by |
+    |                             | tail_call_next().                           | L2 must not be silently dropped downstream. |
+    +-----------------------------+---------------------------------------------+---------------------------------------------+
+
 BUILT-IN PROGRAMS
 
     allow_dns

--- a/docs/README.md
+++ b/docs/README.md
@@ -115,6 +115,15 @@ Here's an example CNI config file featuring `traffico-cni`.
 }
 ```
 
+## Design principles
+
+| Principle | Rule | Why |
+|---|---|---|
+| Standalone vs chained | Standalone programs are the only filter on the interface and handle all traffic types themselves.<br>Chained programs are part of a pipeline and pass traffic they do not handle to the next program. | Standalone programs must make the final decision.<br>Chained programs trust that an upstream filter, typically `allow_ethertype`, already constrained the traffic. |
+| Boundary failures | `block_*` programs fail open on truncated headers, unsupported protocols, and subsequent fragments by returning `TC_ACT_OK`.<br>`allow_*` programs fail closed on the same failures by returning `TC_ACT_SHOT`. | `block_*` programs target specific traffic, so everything else should pass.<br>`allow_*` programs define permitted traffic, so everything else should be denied. |
+| L2 -> L3 -> L4 ordering | Run cheapest and broadest checks first: `allow_ethertype` (L2), then `allow_proto` (L3), then `allow_port` or `allow_dns` (L4).<br>`allow_ipv4` fits after L2 and alongside or after L3 protocol filtering. | Broad L2/L3 filters reduce what later, narrower L4 programs need to inspect.<br>Layered ordering also keeps each program's responsibility clear. |
+| Non-IPv4 passthrough in chains | In chains, L3 and L4 programs pass non-IPv4 traffic to the next program via `tail_call_next()`. | L2 filtering is `allow_ethertype`'s job.<br>ARP, IPv6, and other non-IPv4 traffic allowed by L2 must not be silently dropped downstream. |
+
 ## Built-in programs
 
 | Program | Description |


### PR DESCRIPTION
## Summary

- Adds a design principles section to README.txt and docs/README.md.
- Documents standalone/chained mode behavior, boundary failure posture, chain ordering, and non-IPv4 passthrough.
- Keeps the two README documents equivalent using ASCII and markdown table formats.
