### PR TITLE
feat: enforce typed rodata and mode-aware chain behavior

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -61,17 +61,19 @@ USAGE
             traffico --ifname=eth0 --chain \
                 "allow_ethertype:ipv4+arp,allow_port:443"
 
-        A stricter single-flow egress policy can combine L2, L3, and L4 gates
-        when every stage describes the same flow:
+        Chains compose checks linearly: each stage narrows the traffic that
+        reaches the next stage. That works well for single-path policies such
+        as HTTPS to one service:
             traffico --ifname=eth0 --at=EGRESS --chain \
                 "allow_ethertype:ipv4+arp,allow_ipv4:10.0.0.10,allow_proto:tcp,allow_port:443"
 
-        As an alternative policy, DNS resolver restrictions can be expressed
-        with their own chain. Do not run this alongside the HTTPS example
-        expecting OR semantics: separate traffico invocations on the same hook
-        are not a managed multi-flow policy.
+        Or DNS to one resolver:
             traffico --ifname=eth0 --at=EGRESS --chain \
                 "allow_ethertype:ipv4+arp,allow_dns:10.0.0.53"
+
+        These examples are alternative linear policies, not an additive
+        multi-flow allowlist. Full policies such as "DNS to resolver OR HTTPS
+        to service" need explicit OR composition.
 
         Chain order is validated before attach. If a chain contains any L3/L4
         program, slot 0 must be allow_ethertype, and the layer order must be

--- a/README.txt
+++ b/README.txt
@@ -61,9 +61,16 @@ USAGE
             traffico --ifname=eth0 --chain \
                 "allow_ethertype:ipv4+arp,allow_port:443"
 
-        A fuller quarantine-style egress policy can combine L2, L3, and L4 gates:
+        A stricter single-flow egress policy can combine L2, L3, and L4 gates
+        when every stage describes the same flow:
             traffico --ifname=eth0 --at=EGRESS --chain \
-                "allow_ethertype:ipv4+arp,allow_ipv4:10.0.0.10,allow_proto:tcp+udp,allow_dns:10.0.0.53,allow_port:443"
+                "allow_ethertype:ipv4+arp,allow_ipv4:10.0.0.10,allow_proto:tcp,allow_port:443"
+
+        DNS resolver restrictions are a separate policy shape, not an OR branch
+        inside the HTTPS chain above. This restricts DNS resolver choice; it
+        does not make a full egress allowlist:
+            traffico --ifname=eth0 --at=EGRESS --chain \
+                "allow_ethertype:ipv4+arp,allow_dns:10.0.0.53"
 
         Chain order is validated before attach. If a chain contains any L3/L4
         program, slot 0 must be allow_ethertype, and the layer order must be

--- a/README.txt
+++ b/README.txt
@@ -66,9 +66,10 @@ USAGE
             traffico --ifname=eth0 --at=EGRESS --chain \
                 "allow_ethertype:ipv4+arp,allow_ipv4:10.0.0.10,allow_proto:tcp,allow_port:443"
 
-        DNS resolver restrictions are a separate policy shape, not an OR branch
-        inside the HTTPS chain above. This restricts DNS resolver choice; it
-        does not make a full egress allowlist:
+        As an alternative policy, DNS resolver restrictions can be expressed
+        with their own chain. Do not run this alongside the HTTPS example
+        expecting OR semantics: separate traffico invocations on the same hook
+        are not a managed multi-flow policy.
             traffico --ifname=eth0 --at=EGRESS --chain \
                 "allow_ethertype:ipv4+arp,allow_dns:10.0.0.53"
 

--- a/README.txt
+++ b/README.txt
@@ -144,10 +144,10 @@ DESIGN PRINCIPLES
 BUILT-IN PROGRAMS
 
     allow_dns
-        allow_dns allows IPv4 DNS traffic (UDP/TCP port 53) to the input
-        resolver address, drops the rest. Other traffic passes through.
-        Non-IPv4 traffic passes through unchanged in this program; put
-        allow_ethertype first in a chain when L2 filtering is required.
+        allow_dns allows IPv4 DNS traffic (TCP/UDP port 53) to the
+        input resolver address. Other IPv4 traffic passes through.
+        Standalone mode blocks non-IPv4 traffic. Chain mode passes
+        non-IPv4 traffic to the next stage.
 
     allow_ethertype
         allow_ethertype is an L2 gatekeeper that drops Ethernet frames
@@ -157,10 +157,10 @@ BUILT-IN PROGRAMS
         supported.
         Example: allow_ethertype ipv4+arp
 
-        In a chain, allow_ethertype must be the first program. L3+
-        programs (allow_ipv4, allow_port, etc.) pass through traffic
-        outside their domain (e.g., non-IPv4 frames), which bypasses
-        any downstream allow_ethertype filter.
+        If a chain contains any L3/L4 program, allow_ethertype must be
+        first. Chain order must be non-decreasing by layer:
+        L2 -> L3 -> L4. Same-layer programs are allowed, and chains may
+        skip L3 after the L2 gate.
 
         Standalone allow_ethertype compares the outer Ethernet header
         EtherType only; it does not unwrap VLAN tags or match the inner
@@ -173,29 +173,28 @@ BUILT-IN PROGRAMS
 
     allow_proto
         allow_proto is an L3 gatekeeper that drops IPv4 packets whose IP
-        protocol is not in the allowed set. Non-IPv4 traffic passes
-        through (L2 filtering is allow_ethertype's job). Multiple
-        protocols can be specified by joining them with +. Symbolic
-        names (tcp, udp, icmp, sctp) and decimal numbers (6, 17) are
-        both supported.
+        protocol is not in the allowed set. Multiple protocols can be
+        specified by joining them with +. Symbolic names (tcp, udp,
+        icmp, sctp) and decimal numbers (6, 17) are both supported.
         Example: allow_proto tcp+udp
 
-        In a chain, allow_proto should be placed after allow_ethertype
-        and before allow_port (L2 -> L3 -> L4 ordering).
         VLAN/QinQ-tagged IPv4 is unwrapped before checking the IP
         protocol; truncated VLAN headers and unsupported additional
-        VLAN nesting fail closed.
+        VLAN nesting fail closed. Standalone mode blocks non-IPv4
+        traffic after VLAN unwrap. Chain mode passes non-IPv4 traffic to
+        the next stage.
 
     allow_ipv4
-        allow_ipv4 allows IPv4 traffic to the input address, drops the
-        rest. Non-IPv4 traffic passes through and should be constrained
-        by L2 or chain policy when needed. Localhost (127.0.0.0/8)
-        traffic is always allowed.
+        allow_ipv4 allows IPv4 traffic to the input address, drops other
+        IPv4 destinations, and always allows localhost (127.0.0.0/8).
+        Standalone mode blocks non-IPv4 traffic. Chain mode passes
+        non-IPv4 traffic to the next stage.
 
     allow_port
         allow_port allows IPv4 TCP/UDP traffic to the input destination
-        port, drops the rest. Other IPv4 protocols (ICMP, GRE, etc.)
-        pass through. Non-IPv4 traffic and TCP/UDP subsequent fragments
+        port. Other IPv4 protocols (ICMP, GRE, etc.) pass through.
+        Standalone mode blocks non-IPv4 traffic. Chain mode passes
+        non-IPv4 traffic to the next stage. TCP/UDP subsequent fragments
         are blocked.
 
     block_private_ipv4

--- a/README.txt
+++ b/README.txt
@@ -41,13 +41,33 @@ USAGE
         You can choose an interface and choose whether the program will be loaded in
         "INGRESS" or "EGRESS".
 
-        Example usage:
+        Start with a standalone block program when the policy targets specific
+        traffic and should leave everything else alone:
             traffico --ifname=eth0 --at=INGRESS block_private_ipv4
 
         Programs that accept runtime input (marked [input] in --help) take it
         as a second positional argument:
             traffico --ifname=eth0 block_ipv4 10.0.0.1
             traffico --ifname=eth0 block_port 443
+
+        Use standalone allow programs when the interface should admit only the
+        traffic described by that one program:
+            traffico --ifname=eth0 allow_ipv4 10.0.0.10
+            traffico --ifname=eth0 allow_proto tcp+udp
+            traffico --ifname=eth0 allow_ethertype ipv4+arp
+
+        Use --chain when the policy needs multiple ordered stages. Chains that
+        contain L3/L4 programs must start with the L2 gate allow_ethertype:
+            traffico --ifname=eth0 --chain \
+                "allow_ethertype:ipv4+arp,allow_port:443"
+
+        A fuller quarantine-style egress policy can combine L2, L3, and L4 gates:
+            traffico --ifname=eth0 --at=EGRESS --chain \
+                "allow_ethertype:ipv4+arp,allow_ipv4:10.0.0.10,allow_proto:tcp+udp,allow_dns:10.0.0.53,allow_port:443"
+
+        Chain order is validated before attach. If a chain contains any L3/L4
+        program, slot 0 must be allow_ethertype, and the layer order must be
+        L2 -> L3 -> L4.
 
     traffico-cni
         traffico-cni is a meta CNI plugin that allows the traffico programs to be used in CNI.

--- a/api/api.$progname.h.in
+++ b/api/api.$progname.h.in
@@ -15,62 +15,7 @@ int ${OPERATION}${PROGNAME}(struct config *conf, after_attach_fn_t cb)
         return 1;
     }
 
-    // Set read-only data (between open and load).
-    // Copies the input field struct at offset 0 in .rodata. This covers
-    // both single-value inputs (e.g., a __u32 IP) and multi-value inputs
-    // (e.g., ethertypes: __u16[8] + __u8 count). Additional globals like
-    // `slot` (used for chain support) are not set here — they default to
-    // zero from calloc, which is correct for standalone mode.
-#if ${PROGNAME_WITH_RODATA}
-    if (conf->has_input)
-    {
-        struct bpf_map *rodata_map = obj->maps.rodata;
-        if (!rodata_map)
-        {
-            log_err(conf, "fail: .rodata map not found in skeleton\n");
-            goto destroy_${PROGNAME};
-        }
-        size_t rodata_sz = bpf_map__value_size(rodata_map);
-        void *rodata_buf = calloc(1, rodata_sz);
-        if (!rodata_buf)
-        {
-            log_err(conf, "fail: allocating rodata buffer\n");
-            goto destroy_${PROGNAME};
-        }
-#if ${PROGNAME_IS_MULTI_VALUE}
-        size_t input_sz = sizeof(conf->input.${PROGNAME_INPUT_FIELD}.values) +
-                          sizeof(conf->input.${PROGNAME_INPUT_FIELD}.count);
-#else
-        size_t input_sz = sizeof(conf->input.${PROGNAME_INPUT_FIELD});
-#endif
-        if (input_sz > rodata_sz)
-        {
-            log_err(conf, "fail: rodata map too small for input\n");
-            free(rodata_buf);
-            err = 1;
-            goto destroy_${PROGNAME};
-        }
-
-#if ${PROGNAME_IS_MULTI_VALUE}
-        memcpy(rodata_buf,
-               conf->input.${PROGNAME_INPUT_FIELD}.values,
-               sizeof(conf->input.${PROGNAME_INPUT_FIELD}.values));
-        memcpy((char *)rodata_buf + sizeof(conf->input.${PROGNAME_INPUT_FIELD}.values),
-               &conf->input.${PROGNAME_INPUT_FIELD}.count,
-               sizeof(conf->input.${PROGNAME_INPUT_FIELD}.count));
-#else
-        memcpy(rodata_buf, &conf->input.${PROGNAME_INPUT_FIELD}, sizeof(conf->input.${PROGNAME_INPUT_FIELD}));
-#endif
-        err = bpf_map__set_initial_value(rodata_map, rodata_buf, rodata_sz);
-        free(rodata_buf);
-        if (err)
-        {
-            log_err(conf, "fail: setting .rodata map\n");
-            goto destroy_${PROGNAME};
-        }
-        log_out(conf, "done: setting rodata input\n");
-    }
-#endif
+${PROGNAME_RODATA_ASSIGNMENT}
 
     err = ${PROGNAME}_bpf__load(obj);
     if (err)

--- a/api/chain.$progname.h.in
+++ b/api/chain.$progname.h.in
@@ -15,20 +15,10 @@
             return 1;
         }
 
-#if ${PROGNAME_WITH_RODATA}
-        if (entry->has_input)
-        {
-            err = set_chain_rodata(obj->maps.rodata,
-                                   &entry->input.${PROGNAME_INPUT_FIELD}, sizeof(entry->input.${PROGNAME_INPUT_FIELD}),
-                                   slot);
-            if (err)
-            {
-                log_err(conf, "fail: setting rodata for ${PROGNAME}\n");
-                ${PROGNAME}_bpf__destroy(obj);
-                return 1;
-            }
-        }
-#endif
+${PROGNAME_CHAIN_INPUT_ASSIGNMENT}
+
+        obj->rodata->slot = slot;
+        obj->rodata->chained = 1;
 
         err = ${PROGNAME}_bpf__load(obj);
         if (err)

--- a/api/chain.h.in
+++ b/api/chain.h.in
@@ -120,6 +120,78 @@ static inline bool program_supports_chaining(program_t program)
     return ${CHAIN_SUPPORTS_CHECK};
 }
 
+static int validate_chain_entries(struct chain_entry *entries, int chain_len,
+                                  const char **err_msg, program_t *err_program)
+{
+    if (err_msg)
+        *err_msg = NULL;
+    if (err_program)
+        *err_program = (program_t)NUM_PROGRAMS;
+
+    if (chain_len < 1 || chain_len > MAX_CHAIN_LEN)
+    {
+        if (err_msg)
+            *err_msg = "chain length out of range";
+        return 1;
+    }
+
+    bool has_l3_l4 = false;
+
+    for (int i = 0; i < chain_len; i++)
+    {
+        if (!program_supports_chaining(entries[i].program))
+        {
+            if (err_msg)
+                *err_msg = "program does not support chaining";
+            if (err_program)
+                *err_program = entries[i].program;
+            return 1;
+        }
+
+        enum chain_layer layer = program_chain_layer(entries[i].program);
+        if (layer >= CHAIN_LAYER_L3)
+            has_l3_l4 = true;
+    }
+
+    if (has_l3_l4 && entries[0].program != program_allow_ethertype)
+    {
+        if (err_msg)
+            *err_msg = "L3/L4 chains must start with allow_ethertype";
+        return 1;
+    }
+
+    enum chain_layer previous_layer = CHAIN_LAYER_NONE;
+    for (int i = 0; i < chain_len; i++)
+    {
+        enum chain_layer layer = program_chain_layer(entries[i].program);
+        if (previous_layer != CHAIN_LAYER_NONE &&
+            layer != CHAIN_LAYER_NONE &&
+            layer < previous_layer)
+        {
+            if (err_msg)
+                *err_msg = "chain order must be L2 -> L3 -> L4";
+            return 1;
+        }
+
+        if (layer != CHAIN_LAYER_NONE)
+            previous_layer = layer;
+    }
+
+    for (int i = 0; i < chain_len; i++)
+    {
+        if (entries[i].program == program_allow_ethertype &&
+            chain_len > 1 &&
+            chain_entry_has_vlan_tpid(&entries[i]))
+        {
+            if (err_msg)
+                *err_msg = "VLAN EtherTypes in allow_ethertype chains require VLAN-aware L3/L4 parsing";
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
 /// Attach a chain of programs using the dispatcher + tail calls.
 ///
 /// 1. Validate all chain entries before touching TC
@@ -138,61 +210,26 @@ int attach_chain(struct config *conf,
     char buf[100];
     buf[sizeof(buf) - 1] = '\0';
 
-    if (chain_len < 1 || chain_len > MAX_CHAIN_LEN)
-    {
-        log_err(conf, "fail: chain length %d out of range [1, %d]\n",
-                chain_len, MAX_CHAIN_LEN);
-        return 1;
-    }
-
     // 1. Validate all chain entries before attaching anything.
-    bool has_l3_l4 = false;
-
-    for (int i = 0; i < chain_len; i++)
+    const char *validation_err = NULL;
+    program_t validation_program = (program_t)NUM_PROGRAMS;
+    if (validate_chain_entries(entries, chain_len, &validation_err, &validation_program) != 0)
     {
-        if (!program_supports_chaining(entries[i].program))
+        if (validation_program != (program_t)NUM_PROGRAMS)
         {
             log_err(conf, "fail: program '%s' does not support chaining\n",
-                    g_programs_name[entries[i].program]);
-            return 1;
+                    g_programs_name[validation_program]);
         }
-
-        enum chain_layer layer = program_chain_layer(entries[i].program);
-        if (layer >= CHAIN_LAYER_L3)
-            has_l3_l4 = true;
-    }
-
-    if (has_l3_l4 && entries[0].program != program_allow_ethertype)
-    {
-        log_err(conf, "fail: L3/L4 chains must start with allow_ethertype\n");
+        else if (validation_err && strcmp(validation_err, "chain length out of range") == 0)
+        {
+            log_err(conf, "fail: chain length %d out of range [1, %d]\n",
+                    chain_len, MAX_CHAIN_LEN);
+        }
+        else
+        {
+            log_err(conf, "fail: %s\n", validation_err);
+        }
         return 1;
-    }
-
-    enum chain_layer previous_layer = CHAIN_LAYER_NONE;
-    for (int i = 0; i < chain_len; i++)
-    {
-        enum chain_layer layer = program_chain_layer(entries[i].program);
-        if (previous_layer != CHAIN_LAYER_NONE &&
-            layer != CHAIN_LAYER_NONE &&
-            layer < previous_layer)
-        {
-            log_err(conf, "fail: chain order must be L2 -> L3 -> L4\n");
-            return 1;
-        }
-
-        if (layer != CHAIN_LAYER_NONE)
-            previous_layer = layer;
-    }
-
-    for (int i = 0; i < chain_len; i++)
-    {
-        if (entries[i].program == program_allow_ethertype &&
-            chain_len > 1 &&
-            chain_entry_has_vlan_tpid(&entries[i]))
-        {
-            log_err(conf, "fail: VLAN EtherTypes in allow_ethertype chains require VLAN-aware L3/L4 parsing\n");
-            return 1;
-        }
     }
 
     // 2. Load the dispatcher and populate its prog_array before replacing

--- a/api/chain.h.in
+++ b/api/chain.h.in
@@ -55,6 +55,24 @@ static inline bool chain_entry_has_vlan_tpid(const struct chain_entry *entry)
     return false;
 }
 
+enum chain_layer
+{
+    CHAIN_LAYER_NONE = 0,
+    CHAIN_LAYER_L2 = 1,
+    CHAIN_LAYER_L3 = 2,
+    CHAIN_LAYER_L4 = 3,
+};
+
+static inline enum chain_layer program_chain_layer(program_t program)
+{
+    switch (program)
+    {
+    ${CHAIN_LAYER_CASES}
+    default:
+        return CHAIN_LAYER_NONE;
+    }
+}
+
 /// Ensure a directory exists, creating parents as needed.
 static int ensure_dir(const char *dir)
 {
@@ -160,7 +178,9 @@ int attach_chain(struct config *conf,
         return 1;
     }
 
-    // 1. Validate all chain entries before attaching anything
+    // 1. Validate all chain entries before attaching anything.
+    bool has_l3_l4 = false;
+
     for (int i = 0; i < chain_len; i++)
     {
         if (!program_supports_chaining(entries[i].program))
@@ -169,18 +189,42 @@ int attach_chain(struct config *conf,
                     g_programs_name[entries[i].program]);
             return 1;
         }
-        if (entries[i].program == program_allow_ethertype)
+
+        enum chain_layer layer = program_chain_layer(entries[i].program);
+        if (layer >= CHAIN_LAYER_L3)
+            has_l3_l4 = true;
+    }
+
+    if (has_l3_l4 && entries[0].program != program_allow_ethertype)
+    {
+        log_err(conf, "fail: L3/L4 chains must start with allow_ethertype\n");
+        return 1;
+    }
+
+    enum chain_layer previous_layer = CHAIN_LAYER_NONE;
+    for (int i = 0; i < chain_len; i++)
+    {
+        enum chain_layer layer = program_chain_layer(entries[i].program);
+        if (previous_layer != CHAIN_LAYER_NONE &&
+            layer != CHAIN_LAYER_NONE &&
+            layer < previous_layer)
         {
-            if (i != 0)
-            {
-                log_err(conf, "fail: program 'allow_ethertype' must be first in a chain\n");
-                return 1;
-            }
-            if (chain_len > 1 && chain_entry_has_vlan_tpid(&entries[i]))
-            {
-                log_err(conf, "fail: VLAN EtherTypes in allow_ethertype chains require VLAN-aware L3/L4 parsing\n");
-                return 1;
-            }
+            log_err(conf, "fail: chain order must be L2 -> L3 -> L4\n");
+            return 1;
+        }
+
+        if (layer != CHAIN_LAYER_NONE)
+            previous_layer = layer;
+    }
+
+    for (int i = 0; i < chain_len; i++)
+    {
+        if (entries[i].program == program_allow_ethertype &&
+            chain_len > 1 &&
+            chain_entry_has_vlan_tpid(&entries[i]))
+        {
+            log_err(conf, "fail: VLAN EtherTypes in allow_ethertype chains require VLAN-aware L3/L4 parsing\n");
+            return 1;
         }
     }
 

--- a/api/chain.h.in
+++ b/api/chain.h.in
@@ -91,39 +91,6 @@ static int ensure_dir(const char *dir)
     return mkdir(tmp, 0755) == 0 || errno == EEXIST ? 0 : -errno;
 }
 
-/// Set rodata for a program's skeleton map.
-/// Writes the input value at offset 0 and the slot index at the
-/// appropriate offset in the rodata buffer.
-static int set_chain_rodata(struct bpf_map *rodata_map,
-                            const void *input_val, size_t input_sz,
-                            __u32 slot)
-{
-    if (!rodata_map)
-        return -EINVAL;
-
-    size_t rodata_sz = bpf_map__value_size(rodata_map);
-
-    // Validate that the input fits in the rodata map
-    if (input_sz > rodata_sz)
-        return -ENOSPC;
-
-    size_t slot_offset = (input_sz + 3) & ~3;
-    if (slot_offset + sizeof(__u32) > rodata_sz)
-        return -ENOSPC;
-
-    void *buf = calloc(1, rodata_sz);
-    if (!buf)
-        return -ENOMEM;
-
-    // Layout: input at offset 0, slot at offset aligned to 4 bytes after input
-    memcpy(buf, input_val, input_sz);
-    memcpy((char *)buf + slot_offset, &slot, sizeof(slot));
-
-    int err = bpf_map__set_initial_value(rodata_map, buf, rodata_sz);
-    free(buf);
-    return err;
-}
-
 /// Load a chain program, set its rodata, reuse the dispatcher's prog_array,
 /// and insert it into the prog_array at the given slot.
 static int load_chain_program(struct config *conf,

--- a/bpf/allow_dns.bpf.c
+++ b/bpf/allow_dns.bpf.c
@@ -28,12 +28,19 @@ int allow_dns(struct __sk_buff *skb)
         return TC_ACT_SHOT;
     }
 
-    // This filter parses IPv4 DNS only; other EtherTypes pass through unchanged here.
+    // Standalone mode is the complete policy and blocks non-IPv4.
+    // Chain mode leaves L2 decisions to allow_ethertype and advances.
     if (eth->h_proto != bpf_htons(ETH_P_IP))
     {
-        bpf_printk("allow_dns: [eth] protocol is %d: continue", eth->h_proto);
-        tail_call_next(skb, slot);
-        return TC_ACT_OK;
+        if (chained)
+        {
+            bpf_printk("allow_dns: [eth] protocol is %d: continue", eth->h_proto);
+            tail_call_next(skb, slot);
+            return TC_ACT_OK;
+        }
+
+        bpf_printk("allow_dns: [eth] unsupported ethertype %d: block", eth->h_proto);
+        return TC_ACT_SHOT;
     }
 
     struct iphdr *ip_header = data + l3_offset;

--- a/bpf/allow_dns.bpf.c
+++ b/bpf/allow_dns.bpf.c
@@ -7,6 +7,7 @@ char LICENSE[] SEC("license") = "Dual BSD/GPL";
 
 const volatile __u32 input = 0; // approved DNS resolver IP (host byte order)
 const volatile __u32 slot = 0;  // position in the chain (set by userspace)
+const volatile __u8 chained = 0; // true when loaded as one stage in a chain
 
 DEFINE_PROG_ARRAY();
 

--- a/bpf/allow_ethertype.bpf.c
+++ b/bpf/allow_ethertype.bpf.c
@@ -8,6 +8,7 @@ char LICENSE[] SEC("license") = "Dual BSD/GPL";
 const volatile __u16 allowed[MAX_MULTI_VALUES] = {};
 const volatile __u8 num_allowed = 0;
 const volatile __u32 slot = 0; // position in the chain (set by userspace)
+const volatile __u8 chained = 0; // true when loaded as one stage in a chain
 
 DEFINE_PROG_ARRAY();
 

--- a/bpf/allow_ipv4.bpf.c
+++ b/bpf/allow_ipv4.bpf.c
@@ -28,9 +28,15 @@ int allow_ipv4(struct __sk_buff *skb)
 
     if (eth->h_proto != bpf_htons(ETH_P_IP))
     {
-        bpf_printk("allow_ipv4: [eth] protocol is %d: continue", eth->h_proto);
-        tail_call_next(skb, slot);
-        return TC_ACT_OK;
+        if (chained)
+        {
+            bpf_printk("allow_ipv4: [eth] protocol is %d: continue", eth->h_proto);
+            tail_call_next(skb, slot);
+            return TC_ACT_OK;
+        }
+
+        bpf_printk("allow_ipv4: [eth] unsupported ethertype %d: block", eth->h_proto);
+        return TC_ACT_SHOT;
     }
 
     struct iphdr *ip_header = data + l3_offset;

--- a/bpf/allow_ipv4.bpf.c
+++ b/bpf/allow_ipv4.bpf.c
@@ -7,6 +7,7 @@ char LICENSE[] SEC("license") = "Dual BSD/GPL";
 
 const volatile __u32 input = 0; // address to allow (host byte order)
 const volatile __u32 slot = 0;  // position in the chain (set by userspace)
+const volatile __u8 chained = 0; // true when loaded as one stage in a chain
 
 DEFINE_PROG_ARRAY();
 

--- a/bpf/allow_port.bpf.c
+++ b/bpf/allow_port.bpf.c
@@ -26,10 +26,15 @@ int allow_port(struct __sk_buff *skb)
         return TC_ACT_SHOT;
     }
 
-    // Fail closed for unsupported L3. IPv6 TCP/UDP has destination ports too,
-    // and passing it here would bypass this L4 allowlist.
     if (eth->h_proto != bpf_htons(ETH_P_IP))
     {
+        if (chained)
+        {
+            bpf_printk("allow_port: [eth] protocol is %d: continue", eth->h_proto);
+            tail_call_next(skb, slot);
+            return TC_ACT_OK;
+        }
+
         bpf_printk("allow_port: [eth] unsupported ethertype %d: block", eth->h_proto);
         return TC_ACT_SHOT;
     }

--- a/bpf/allow_port.bpf.c
+++ b/bpf/allow_port.bpf.c
@@ -7,6 +7,7 @@ char LICENSE[] SEC("license") = "Dual BSD/GPL";
 
 const volatile __u16 input = 0; // destination port to allow (host byte order)
 const volatile __u32 slot = 0;  // position in the chain (set by userspace)
+const volatile __u8 chained = 0; // true when loaded as one stage in a chain
 
 DEFINE_PROG_ARRAY();
 

--- a/bpf/allow_proto.bpf.c
+++ b/bpf/allow_proto.bpf.c
@@ -14,6 +14,7 @@ struct traffico_vlan_hdr
 const volatile __u8 allowed[MAX_MULTI_VALUES] = {};
 const volatile __u8 num_allowed = 0;
 const volatile __u32 slot = 0; // position in the chain (set by userspace)
+const volatile __u8 chained = 0; // true when loaded as one stage in a chain
 
 DEFINE_PROG_ARRAY();
 

--- a/bpf/allow_proto.bpf.c
+++ b/bpf/allow_proto.bpf.c
@@ -62,13 +62,19 @@ int allow_proto(struct __sk_buff *skb)
         return TC_ACT_SHOT;
     }
 
-    // Passthrough: not IPv4 - protocol filtering doesn't apply.
-    // Non-IPv4 filtering is allow_ethertype's job.
+    // Standalone mode is the complete policy and blocks non-IPv4 after VLAN unwrap.
+    // Chain mode leaves L2 decisions to allow_ethertype and advances.
     if (h_proto != bpf_htons(ETH_P_IP))
     {
-        bpf_printk("allow_proto: [eth] protocol is %d: continue", bpf_ntohs(h_proto));
-        tail_call_next(skb, slot);
-        return TC_ACT_OK;
+        if (chained)
+        {
+            bpf_printk("allow_proto: [eth] protocol is %d: continue", bpf_ntohs(h_proto));
+            tail_call_next(skb, slot);
+            return TC_ACT_OK;
+        }
+
+        bpf_printk("allow_proto: [eth] unsupported ethertype %d: block", bpf_ntohs(h_proto));
+        return TC_ACT_SHOT;
     }
 
     struct iphdr *ip_header = data + l3_offset;

--- a/docs/README.md
+++ b/docs/README.md
@@ -66,10 +66,21 @@ L3/L4 programs must start with the L2 gate `allow_ethertype`:
 traffico --ifname=eth0 --chain "allow_ethertype:ipv4+arp,allow_port:443"
 ```
 
-A fuller quarantine-style egress policy can combine L2, L3, and L4 gates:
+A stricter single-flow egress policy can combine L2, L3, and L4 gates when every
+stage describes the same flow:
 
 ```bash
-traffico --ifname=eth0 --at=EGRESS --chain "allow_ethertype:ipv4+arp,allow_ipv4:10.0.0.10,allow_proto:tcp+udp,allow_dns:10.0.0.53,allow_port:443"
+traffico --ifname=eth0 --at=EGRESS --chain \
+  "allow_ethertype:ipv4+arp,allow_ipv4:10.0.0.10,allow_proto:tcp,allow_port:443"
+```
+
+DNS resolver restrictions are a separate policy shape, not an OR branch inside
+the HTTPS chain above. This restricts DNS resolver choice; it does not make a
+full egress allowlist:
+
+```bash
+traffico --ifname=eth0 --at=EGRESS --chain \
+  "allow_ethertype:ipv4+arp,allow_dns:10.0.0.53"
 ```
 
 Chain order is validated before attach. If a chain contains any L3/L4 program,

--- a/docs/README.md
+++ b/docs/README.md
@@ -128,11 +128,11 @@ Here's an example CNI config file featuring `traffico-cni`.
 
 | Program | Description |
 |---|---|
-| `allow_dns` | Allows IPv4 DNS traffic (port 53) to the input resolver, drops the rest. Non-IPv4 traffic passes through unchanged in this program. |
-| `allow_ethertype` | L2 gatekeeper: drops frames whose outer EtherType is not in the allowed set (e.g., `ipv4+arp`). Must be first in a chain (see notes below). |
-| `allow_ipv4` | Allows IPv4 traffic to the input address, drops the rest. Non-IPv4 passes through for L2/chain policy. Localhost (127.0.0.0/8) always allowed. |
-| `allow_port` | Allows IPv4 TCP/UDP traffic to the input port, drops the rest. Other IPv4 protocols pass through. Non-IPv4 traffic and TCP/UDP subsequent fragments are blocked. |
-| `allow_proto` | L3 gatekeeper: drops IPv4 packets whose IP protocol is not in the allowed set (e.g., `tcp+udp`). Non-IPv4 passes through. |
+| `allow_dns` | Allows IPv4 DNS traffic (TCP/UDP port 53) to the input resolver. Other IPv4 traffic passes through. Standalone mode blocks non-IPv4; chain mode passes non-IPv4 to the next stage. |
+| `allow_ethertype` | L2 gatekeeper: drops frames whose outer EtherType is not in the allowed set (e.g., `ipv4+arp`). Required first when a chain contains L3/L4 programs. |
+| `allow_ipv4` | Allows IPv4 traffic to the input address, drops other IPv4 destinations except localhost (127.0.0.0/8). Standalone mode blocks non-IPv4; chain mode passes non-IPv4 to the next stage. |
+| `allow_port` | Allows IPv4 TCP/UDP traffic to the input port. Other IPv4 protocols pass through. Standalone mode blocks non-IPv4; chain mode passes non-IPv4 to the next stage. TCP/UDP subsequent fragments are blocked. |
+| `allow_proto` | L3 gatekeeper: drops IPv4 packets whose IP protocol is not in the allowed set (e.g., `tcp+udp`). It unwraps supported VLAN/QinQ tags before the IPv4 protocol check. Standalone mode blocks non-IPv4 after VLAN unwrap; chain mode passes it to the next stage. |
 | `block_private_ipv4` | Blocks private IPv4 addresses subnets allowing only SSH access on port 22 |
 | `block_ipv4` | Drops packets with destination equal to the input IPv4 address |
 | `block_port` | Drops packets with the destination port equal to the input port number |
@@ -140,17 +140,17 @@ Here's an example CNI config file featuring `traffico-cni`.
 
 ### Notes on `allow_ethertype`
 
-**Chain ordering:** In a chain, `allow_ethertype` must be the first program. L3+ programs (`allow_ipv4`, `allow_port`, etc.) pass through traffic outside their domain (e.g., non-IPv4 frames return `TC_ACT_OK` directly), which bypasses any downstream `allow_ethertype` filter.
+**Chain ordering:** If a chain contains any L3/L4 program, slot 0 must be `allow_ethertype`. Chain order must be non-decreasing by layer: `L2 -> L3 -> L4`. Same-layer programs are allowed, and chains may skip L3 after the L2 gate, such as `--chain "allow_ethertype:ipv4+arp,allow_port:443"`.
 
 **VLAN-tagged networks:** Standalone `allow_ethertype` compares the EtherType in the outer Ethernet header only; it does not unwrap VLAN tags or match the inner payload EtherType. Symbolic names `vlan` (0x8100) and `qinq` (0x88A8) are available for standalone filters. In multi-program chains, VLAN TPIDs are rejected because VLAN-aware parsing is not uniform across downstream programs. Example (standalone): `allow_ethertype ipv4+arp+vlan`.
 
 ### Notes on `allow_proto`
 
-**Chain ordering:** In a chain, `allow_proto` should be placed after `allow_ethertype` and before `allow_port`/`allow_dns`. This gives L2 → L3 → L4 ordering with cheapest checks first. Example: `--chain "allow_ethertype:ipv4+arp,allow_proto:tcp+udp,allow_port:8080"`.
+**Chain ordering:** In a chain, `allow_proto` should be placed after `allow_ethertype` and before `allow_port`/`allow_dns`. This gives `L2 -> L3 -> L4` ordering with cheapest checks first. Example: `--chain "allow_ethertype:ipv4+arp,allow_proto:tcp+udp,allow_port:8080"`.
 
 **VLAN-tagged IPv4:** `allow_proto` unwraps supported 802.1Q and QinQ tags before reading the IPv4 protocol. Truncated VLAN headers and unsupported additional VLAN nesting fail closed.
 
-**Non-IPv4 passthrough:** Non-IPv4 traffic (ARP, IPv6) passes through unfiltered. L2 filtering is `allow_ethertype`'s responsibility.
+**Non-IPv4 behavior:** In standalone mode, non-IPv4 traffic is blocked after VLAN unwrap because the program is the complete policy. In chain mode, non-IPv4 traffic is passed to the next stage because L2 policy belongs to `allow_ethertype`.
 
 ## Build
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -66,23 +66,25 @@ L3/L4 programs must start with the L2 gate `allow_ethertype`:
 traffico --ifname=eth0 --chain "allow_ethertype:ipv4+arp,allow_port:443"
 ```
 
-A stricter single-flow egress policy can combine L2, L3, and L4 gates when every
-stage describes the same flow:
+Chains compose checks linearly: each stage narrows the traffic that reaches the
+next stage. That works well for single-path policies such as HTTPS to one
+service:
 
 ```bash
 traffico --ifname=eth0 --at=EGRESS --chain \
   "allow_ethertype:ipv4+arp,allow_ipv4:10.0.0.10,allow_proto:tcp,allow_port:443"
 ```
 
-As an alternative policy, DNS resolver restrictions can be expressed with their
-own chain. Do not run this alongside the HTTPS example expecting OR semantics:
-separate `traffico` invocations on the same hook are not a managed multi-flow
-policy.
+Or DNS to one resolver:
 
 ```bash
 traffico --ifname=eth0 --at=EGRESS --chain \
   "allow_ethertype:ipv4+arp,allow_dns:10.0.0.53"
 ```
+
+These examples are alternative linear policies, not an additive multi-flow
+allowlist. Full policies such as "DNS to resolver OR HTTPS to service" need
+explicit OR composition.
 
 Chain order is validated before attach. If a chain contains any L3/L4 program,
 slot 0 must be `allow_ethertype`, and the layer order must be `L2 -> L3 -> L4`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,9 +74,10 @@ traffico --ifname=eth0 --at=EGRESS --chain \
   "allow_ethertype:ipv4+arp,allow_ipv4:10.0.0.10,allow_proto:tcp,allow_port:443"
 ```
 
-DNS resolver restrictions are a separate policy shape, not an OR branch inside
-the HTTPS chain above. This restricts DNS resolver choice; it does not make a
-full egress allowlist:
+As an alternative policy, DNS resolver restrictions can be expressed with their
+own chain. Do not run this alongside the HTTPS example expecting OR semantics:
+separate `traffico` invocations on the same hook are not a managed multi-flow
+policy.
 
 ```bash
 traffico --ifname=eth0 --at=EGRESS --chain \

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,7 +36,8 @@ Traffico can be either used standalone or as a CNI plugin.
 You can choose an interface and choose whether the program will be loaded in
 `INGRESS` or `EGRESS`.
 
-Example usage:
+Start with a standalone block program when the policy targets specific traffic
+and should leave everything else alone:
 
 ```bash
 traffico --ifname=eth0 --at=INGRESS block_private_ipv4
@@ -48,6 +49,31 @@ Programs that accept runtime input (marked `[input]` in `--help`) take it as a s
 traffico --ifname=eth0 block_ipv4 10.0.0.1
 traffico --ifname=eth0 block_port 443
 ```
+
+Use standalone allow programs when the interface should admit only the traffic
+described by that one program:
+
+```bash
+traffico --ifname=eth0 allow_ipv4 10.0.0.10
+traffico --ifname=eth0 allow_proto tcp+udp
+traffico --ifname=eth0 allow_ethertype ipv4+arp
+```
+
+Use `--chain` when the policy needs multiple ordered stages. Chains that contain
+L3/L4 programs must start with the L2 gate `allow_ethertype`:
+
+```bash
+traffico --ifname=eth0 --chain "allow_ethertype:ipv4+arp,allow_port:443"
+```
+
+A fuller quarantine-style egress policy can combine L2, L3, and L4 gates:
+
+```bash
+traffico --ifname=eth0 --at=EGRESS --chain "allow_ethertype:ipv4+arp,allow_ipv4:10.0.0.10,allow_proto:tcp+udp,allow_dns:10.0.0.53,allow_port:443"
+```
+
+Chain order is validated before attach. If a chain contains any L3/L4 program,
+slot 0 must be `allow_ethertype`, and the layer order must be `L2 -> L3 -> L4`.
 
 ### traffico-cni
 

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -473,12 +473,12 @@ sys.exit(0)
     echo "# can still reach ${VETH_ADDR}:${SERVER_PORT} (TCP allowed by chain)" >&3
 }
 
-@test "chain allow_ipv4+allow_port allows matching traffic" {
+@test "chain allow_ethertype+allow_ipv4+allow_port allows matching traffic" {
     new_server
     run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
     [ $status -eq 0 ]
     echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
-    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ipv4:${VETH_ADDR},allow_port:${SERVER_PORT}" >/dev/null 3>&- &
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ethertype:ipv4+arp,allow_ipv4:${VETH_ADDR},allow_port:${SERVER_PORT}" >/dev/null 3>&- &
     sleep 1
     run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
     [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
@@ -487,12 +487,12 @@ sys.exit(0)
     echo "# can still reach ${VETH_ADDR}:${SERVER_PORT} (chain allows it)" >&3
 }
 
-@test "chain allow_ipv4+allow_port blocks non-matching IP" {
+@test "chain allow_ethertype+allow_ipv4+allow_port blocks non-matching IP" {
     run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
     [ $status -eq 0 ]
     echo "# can ping ${VETH_ADDR} from the namespace" >&3
     # Allow only PEER_ADDR (not VETH_ADDR) on any port
-    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ipv4:${PEER_ADDR},allow_port:8787" >/dev/null 3>&- &
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ethertype:ipv4+arp,allow_ipv4:${PEER_ADDR},allow_port:8787" >/dev/null 3>&- &
     sleep 1
     run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
     [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
@@ -501,13 +501,13 @@ sys.exit(0)
     echo "# cannot ping ${VETH_ADDR} (chain blocks wrong IP)" >&3
 }
 
-@test "chain allow_ipv4+allow_port blocks non-matching port" {
+@test "chain allow_ethertype+allow_ipv4+allow_port blocks non-matching port" {
     new_server
     run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
     [ $status -eq 0 ]
     echo "# can reach ${VETH_ADDR}:${SERVER_PORT} from the namespace" >&3
     # Allow VETH_ADDR but only port 9999 (not SERVER_PORT)
-    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ipv4:${VETH_ADDR},allow_port:9999" >/dev/null 3>&- &
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ethertype:ipv4+arp,allow_ipv4:${VETH_ADDR},allow_port:9999" >/dev/null 3>&- &
     sleep 1
     run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
     [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
@@ -516,24 +516,12 @@ sys.exit(0)
     echo "# cannot reach ${VETH_ADDR}:${SERVER_PORT} (chain blocks wrong port)" >&3
 }
 
-@test "chain allow_port+allow_ipv4 continues through non-matching traffic" {
-    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
-    [ $status -eq 0 ]
-    # allow_port returns TC_ACT_OK for ICMP; allow_ipv4 must still be reached in chain mode
-    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_port:9999,allow_ipv4:${PEER_ADDR}" >/dev/null 3>&- &
-    sleep 1
-    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
-    [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
-    run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
-    [ $status -eq 1 ]
-}
-
-@test "chain allow_ipv4+allow_dns allows ICMP to resolver" {
+@test "chain allow_ethertype+allow_ipv4+allow_dns allows ICMP to resolver" {
     run ip netns exec "${NETNS}" ping -W1 -4 -c1 "${VETH_ADDR}"
     [ $status -eq 0 ]
     echo "# can ping ${VETH_ADDR} from the namespace" >&3
     # allow_dns passes non-TCP/UDP through; allow_ipv4 gates the destination
-    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ipv4:${VETH_ADDR},allow_dns:${VETH_ADDR}" >/dev/null 3>&- &
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ethertype:ipv4+arp,allow_ipv4:${VETH_ADDR},allow_dns:${VETH_ADDR}" >/dev/null 3>&- &
     sleep 1
     run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
     [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
@@ -547,7 +535,7 @@ sys.exit(0)
     # dispatcher/qdisc state is created, even when --no-cleanup is set.
     run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
     [ "$(echo "$output" | xargs)" == "" ]
-    run ip netns exec "${NETNS}" traffico --verbose --no-cleanup -i "${PEER}" --at egress --chain "allow_ipv4:${PEER_ADDR},block_ipv4:${VETH_ADDR}" >/dev/null 3>&-
+    run ip netns exec "${NETNS}" traffico --verbose --no-cleanup -i "${PEER}" --at egress --chain "allow_ethertype:ipv4+arp,block_ipv4:${VETH_ADDR}" >/dev/null 3>&-
     [ $status -eq 1 ]
     [[ "${output}" == *"does not support chaining"* ]]
     run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -151,6 +151,7 @@ s.close()
 " &
     DNS_PID=$!
     sleep 0.5
+    arp_prewarm "${NETNS}"
     run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_dns "${VETH_ADDR}" >/dev/null 3>&- &
     sleep 1
     run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
@@ -179,6 +180,7 @@ s.close()
 " &
     DNS_PID=$!
     sleep 0.5
+    arp_prewarm "${NETNS}"
     # Allow DNS only to PEER_ADDR (not VETH_ADDR where the server is)
     run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_dns "${PEER_ADDR}" >/dev/null 3>&- &
     sleep 1
@@ -206,6 +208,7 @@ s.close()
 " &
     DNS_PID=$!
     sleep 0.5
+    arp_prewarm "${NETNS}"
     run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_dns "${VETH_ADDR}" >/dev/null 3>&- &
     sleep 1
     run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
@@ -242,6 +245,7 @@ s.close()
 " &
     DNS_PID=$!
     sleep 0.5
+    arp_prewarm "${NETNS}"
     # Allow DNS only to PEER_ADDR (not VETH_ADDR where the server is)
     run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_dns "${PEER_ADDR}" >/dev/null 3>&- &
     sleep 1

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -501,7 +501,7 @@ sys.exit(0)
     echo "# cannot ping ${VETH_ADDR} (chain blocks wrong IP)" >&3
 }
 
-@test "chain allow_ethertype+allow_ipv4+allow_port blocks non-matching port" {
+@test "chain allow_ethertype+allow_ipv4+allow_port reaches later port gate" {
     new_server
     run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
     [ $status -eq 0 ]
@@ -513,7 +513,7 @@ sys.exit(0)
     [ "$(echo $output | xargs)" == "qdisc clsact ffff: parent ffff:fff1" ]
     run ip netns exec "${NETNS}" curl --max-time 1 --silent "${VETH_ADDR}:${SERVER_PORT}" >/dev/null
     [ ! $status -eq 0 ]
-    echo "# cannot reach ${VETH_ADDR}:${SERVER_PORT} (chain blocks wrong port)" >&3
+    echo "# cannot reach ${VETH_ADDR}:${SERVER_PORT} (later L4 gate blocks wrong port)" >&3
 }
 
 @test "chain allow_ethertype+allow_ipv4+allow_dns allows ICMP to resolver" {

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -187,10 +187,26 @@ bats_require_minimum_version 1.7.0
     [ "${lines[0]}" == "traffico: program 'block_private_ipv4' does not support chaining" ]
 }
 
-@test "--chain rejects allow_ethertype not in slot 0" {
-    run traffico -i lo --chain "allow_ipv4:127.0.0.1,allow_ethertype:ipv4+arp"
+@test "--chain rejects allow_ethertype after L3/L4" {
+    run timeout 2 traffico -i lo --chain "allow_ipv4:127.0.0.1,allow_ethertype:ipv4+arp"
     [ $status -eq 1 ]
-    [ "${lines[0]}" == "traffico: program 'allow_ethertype' must be first in a chain" ]
+    [[ "$output" == *"L3/L4 chains must start with allow_ethertype"* ]]
+}
+
+@test "--chain rejects L3/L4 chain without allow_ethertype gate" {
+    run timeout 2 traffico -i lo --chain "allow_port:443"
+    [ $status -eq 1 ]
+    [[ "$output" == *"L3/L4 chains must start with allow_ethertype"* ]]
+
+    run timeout 2 traffico -i lo --chain "allow_ipv4:127.0.0.1,allow_port:443"
+    [ $status -eq 1 ]
+    [[ "$output" == *"L3/L4 chains must start with allow_ethertype"* ]]
+}
+
+@test "--chain rejects layer regression" {
+    run timeout 2 traffico -i lo --chain "allow_ethertype:ipv4+arp,allow_port:443,allow_ipv4:127.0.0.1"
+    [ $status -eq 1 ]
+    [[ "$output" == *"chain order must be L2 -> L3 -> L4"* ]]
 }
 
 @test "--chain rejects VLAN TPIDs in multi-program chain" {

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -24,7 +24,7 @@ scapy_needs_marker_match() {
   for arg in "$@"; do
     if [ "$expect_type" -eq 1 ]; then
       case "$arg" in
-        ipv4-invalid-ihl|ethernet-truncated|vlan-inner-ipv4|qinq-inner-ipv4|non-ipv4-tcp|ipv6-tcp)
+        ipv4-invalid-ihl|ethernet-truncated|vlan-inner-ipv4|qinq-inner-ipv4|vlan-inner-ipv6|non-ipv4-tcp|ipv6-tcp|arp-request)
           return 0
           ;;
       esac

--- a/test/scapy.bats
+++ b/test/scapy.bats
@@ -60,13 +60,13 @@ teardown() {
     echo "# blocked IPv4 packet whose IHL extends beyond packet data" >&3
 }
 
-@test "allow_ipv4: allows non-IPv4 EtherType" {
+@test "allow_ipv4: drops non-IPv4 EtherType in standalone mode" {
     ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_ipv4 "${VETH_ADDR}" >/dev/null 3>&- &
     sleep 1
 
-    assert_packet_seen "${NETNS}" 4003 \
+    assert_packet_blocked "${NETNS}" 4003 \
         --type ipv6-tcp --dst-port 8787
-    echo "# allowed IPv6 TCP packet through IPv4-only allowlist" >&3
+    echo "# blocked IPv6 TCP packet in standalone IPv4 allowlist" >&3
 }
 
 # --------------------------------------------------------------------------
@@ -113,13 +113,13 @@ teardown() {
 # allow_dns
 # --------------------------------------------------------------------------
 
-@test "allow_dns: allows non-IPv4 EtherType" {
+@test "allow_dns: drops non-IPv4 EtherType in standalone mode" {
     ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_dns "${VETH_ADDR}" >/dev/null 3>&- &
     sleep 1
 
-    assert_packet_seen "${NETNS}" 6001 \
+    assert_packet_blocked "${NETNS}" 6001 \
         --type non-ipv4-tcp --dst-ip "${VETH_ADDR}" --dst-port 53
-    echo "# allowed non-IPv4 EtherType carrying DNS-like payload" >&3
+    echo "# blocked non-IPv4 EtherType carrying DNS-like payload in standalone mode" >&3
 }
 
 @test "allow_dns: drops packet with truncated L4 header" {
@@ -187,6 +187,15 @@ teardown() {
     echo "# blocked IPv4 TCP packet whose IHL extends beyond packet data" >&3
 }
 
+@test "allow_proto: drops VLAN-wrapped non-IPv4 in standalone mode" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_proto tcp >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_blocked "${NETNS}" 8004 \
+        --type vlan-inner-ipv6 --dst-ip "${VETH_ADDR}"
+    echo "# blocked VLAN frame whose inner EtherType is non-IPv4 in standalone mode" >&3
+}
+
 @test "allow_proto: drops VLAN IPv4 when inner protocol is denied" {
     ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress allow_proto tcp >/dev/null 3>&- &
     sleep 1
@@ -203,6 +212,37 @@ teardown() {
     assert_packet_seen "${NETNS}" 8003 \
         --type qinq-inner-ipv4 --dst-ip "${VETH_ADDR}" --proto-override 6
     echo "# allowed QinQ-tagged IPv4 TCP packet" >&3
+}
+
+# --------------------------------------------------------------------------
+# chains
+# --------------------------------------------------------------------------
+
+@test "chain allow_ethertype+allow_port allows ARP" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ethertype:ipv4+arp,allow_port:443" >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_seen "${NETNS}" 9001 \
+        --type arp-request --src-ip "${PEER_ADDR}" --dst-ip "${VETH_ADDR}"
+    echo "# observed explicit ARP request through L2 -> L4 chain" >&3
+}
+
+@test "chain allow_ethertype+allow_ipv4 passes IPv6 to next stage" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ethertype:ipv6,allow_ipv4:${VETH_ADDR}" >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_seen "${NETNS}" 9002 \
+        --type ipv6-tcp --dst-port 8787
+    echo "# observed IPv6 through chained L3 IPv4 allowlist" >&3
+}
+
+@test "chain allow_ethertype+allow_port passes IPv6 to next stage" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --chain "allow_ethertype:ipv6,allow_port:8787" >/dev/null 3>&- &
+    sleep 1
+
+    assert_packet_seen "${NETNS}" 9003 \
+        --type ipv6-tcp --dst-port 8787
+    echo "# observed IPv6 through chained L4 port allowlist" >&3
 }
 
 # --------------------------------------------------------------------------

--- a/test/scapy_packets.py
+++ b/test/scapy_packets.py
@@ -8,6 +8,7 @@ import sys
 import time
 
 from scapy.all import (
+    ARP,
     IP,
     IPv6,
     TCP,
@@ -108,6 +109,22 @@ def cmd_send(args):
                 + marker_for(args.ip_id)
             )
         )
+    elif args.type == "vlan-inner-ipv6":
+        pkt = ether(0x8100) / Raw(
+            struct.pack("!HH", 0, 0x86DD) + marker_for(args.ip_id)
+        )
+    elif args.type == "arp-request":
+        pkt = (
+            ether(0x0806)
+            / ARP(
+                op="who-has",
+                psrc=args.src_ip,
+                pdst=args.dst_ip,
+                hwsrc="02:00:00:00:00:02",
+                hwdst="00:00:00:00:00:00",
+            )
+            / Raw(marker_for(args.ip_id))
+        )
     elif args.type == "ipv4-truncated-ihl":
         pkt = ether(0x0800) / Raw(ipv4_header(args, ihl=6, total_length=24))
     elif args.type == "ipv4-truncated-l4":
@@ -170,6 +187,8 @@ def cmd_send(args):
         "ethernet-truncated",
         "vlan-inner-ipv4",
         "qinq-inner-ipv4",
+        "vlan-inner-ipv6",
+        "arp-request",
         "ipv4-truncated-ihl",
         "ipv4-truncated-l4",
         "ipv4-non-l4-dns-port",
@@ -242,6 +261,7 @@ def main():
                                  "fragment-first", "fragment-subsequent",
                                  "ipv4-invalid-ihl", "ethernet-truncated",
                                  "vlan-inner-ipv4", "qinq-inner-ipv4",
+                                 "vlan-inner-ipv6", "arp-request",
                                  "ipv4-truncated-ihl",
                                  "ipv4-truncated-l4",
                                  "ipv4-non-l4-dns-port",

--- a/traffico.c
+++ b/traffico.c
@@ -1,5 +1,6 @@
 #define _GNU_SOURCE
 #include <signal.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include <strings.h>
@@ -275,10 +276,6 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
                 {
                     argp_error(state, "program '%s' does not support chaining", prog_name);
                 }
-                if (g_chain[g_chain_len].program == program_allow_ethertype && g_chain_len != 0)
-                {
-                    argp_error(state, "program 'allow_ethertype' must be first in a chain");
-                }
 
                 // Parse input for this program
                 if (input_str)
@@ -304,6 +301,37 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
             {
                 argp_error(state, "--chain requires at least one program");
             }
+
+            bool has_l3_l4 = false;
+            for (int i = 0; i < g_chain_len; i++)
+            {
+                enum chain_layer layer = program_chain_layer(g_chain[i].program);
+                if (layer >= CHAIN_LAYER_L3)
+                {
+                    has_l3_l4 = true;
+                    break;
+                }
+            }
+            if (has_l3_l4 && g_chain[0].program != program_allow_ethertype)
+            {
+                argp_error(state, "L3/L4 chains must start with allow_ethertype");
+            }
+
+            enum chain_layer previous_layer = CHAIN_LAYER_NONE;
+            for (int i = 0; i < g_chain_len; i++)
+            {
+                enum chain_layer layer = program_chain_layer(g_chain[i].program);
+                if (previous_layer != CHAIN_LAYER_NONE &&
+                    layer != CHAIN_LAYER_NONE &&
+                    layer < previous_layer)
+                {
+                    argp_error(state, "chain order must be L2 -> L3 -> L4");
+                }
+
+                if (layer != CHAIN_LAYER_NONE)
+                    previous_layer = layer;
+            }
+
             if (g_chain_len > 1 && g_chain[0].program == program_allow_ethertype)
             {
                 for (__u8 j = 0; j < g_chain[0].input.ethertypes.count; j++)

--- a/traffico.c
+++ b/traffico.c
@@ -272,11 +272,6 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
                 {
                     argp_error(state, "unknown program in chain: '%s'", prog_name);
                 }
-                if (!program_supports_chaining(g_chain[g_chain_len].program))
-                {
-                    argp_error(state, "program '%s' does not support chaining", prog_name);
-                }
-
                 // Parse input for this program
                 if (input_str)
                 {
@@ -302,46 +297,14 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
                 argp_error(state, "--chain requires at least one program");
             }
 
-            bool has_l3_l4 = false;
-            for (int i = 0; i < g_chain_len; i++)
+            const char *validation_err = NULL;
+            program_t validation_program = (program_t)NUM_PROGRAMS;
+            if (validate_chain_entries(g_chain, g_chain_len, &validation_err, &validation_program) != 0)
             {
-                enum chain_layer layer = program_chain_layer(g_chain[i].program);
-                if (layer >= CHAIN_LAYER_L3)
-                {
-                    has_l3_l4 = true;
-                    break;
-                }
-            }
-            if (has_l3_l4 && g_chain[0].program != program_allow_ethertype)
-            {
-                argp_error(state, "L3/L4 chains must start with allow_ethertype");
-            }
-
-            enum chain_layer previous_layer = CHAIN_LAYER_NONE;
-            for (int i = 0; i < g_chain_len; i++)
-            {
-                enum chain_layer layer = program_chain_layer(g_chain[i].program);
-                if (previous_layer != CHAIN_LAYER_NONE &&
-                    layer != CHAIN_LAYER_NONE &&
-                    layer < previous_layer)
-                {
-                    argp_error(state, "chain order must be L2 -> L3 -> L4");
-                }
-
-                if (layer != CHAIN_LAYER_NONE)
-                    previous_layer = layer;
-            }
-
-            if (g_chain_len > 1 && g_chain[0].program == program_allow_ethertype)
-            {
-                for (__u8 j = 0; j < g_chain[0].input.ethertypes.count; j++)
-                {
-                    __u16 v = g_chain[0].input.ethertypes.values[j];
-                    if (v == 0x8100 || v == 0x88A8)
-                    {
-                        argp_error(state, "VLAN EtherTypes in allow_ethertype chains require VLAN-aware L3/L4 parsing");
-                    }
-                }
+                if (validation_program != (program_t)NUM_PROGRAMS)
+                    argp_error(state, "program '%s' does not support chaining", g_programs_name[validation_program]);
+                else
+                    argp_error(state, "%s", validation_err);
             }
         }
         else

--- a/xmake/modules/api.lua
+++ b/xmake/modules/api.lua
@@ -3,27 +3,33 @@ import("core.project.project")
 -- Build and runtime metadata for every user-facing BPF program.
 --
 -- Each entry controls:
---   input   - rodata union field name (nil if the program takes no input)
---   multi   - true when the input is an array (ethertypes, protos)
+--   input     - userspace config/chain input field (nil if the program takes no input)
+--   multi     - true when the input is an array (ethertypes, protos)
 --   chainable - true when the program may appear in --chain
+--   layer     - l2/l3/l4 for chainable programs
 --
 -- The standalone template uses input/multi for rodata layout.
 -- The chain template uses chainable to decide which programs get a
 -- generated case in load_chain_program() and appear in
--- program_supports_chaining().
+-- program_supports_chaining(). The chain validator uses layer to
+-- enforce L2 -> L3 -> L4 composition.
 --
 -- Every non-internal BPF program MUST have an entry here.
 -- Missing entries cause a build failure (see _get_metadata below).
 local program_metadata = {
-    allow_dns        = { input = "ip",          multi = false, chainable = true  },
-    allow_ethertype  = { input = "ethertypes",  multi = true,  chainable = true  },
-    allow_ipv4       = { input = "ip",          multi = false, chainable = true  },
-    allow_port       = { input = "port",        multi = false, chainable = true  },
-    allow_proto      = { input = "protos",      multi = true,  chainable = true  },
+    allow_dns        = { input = "ip",          multi = false, chainable = true,  layer = "l4" },
+    allow_ethertype  = { input = "ethertypes",  multi = true,  chainable = true,  layer = "l2" },
+    allow_ipv4       = { input = "ip",          multi = false, chainable = true,  layer = "l3" },
+    allow_port       = { input = "port",        multi = false, chainable = true,  layer = "l4" },
+    allow_proto      = { input = "protos",      multi = true,  chainable = true,  layer = "l3" },
     block_ipv4       = { input = "ip",          multi = false, chainable = false },
     block_port       = { input = "port",        multi = false, chainable = false },
-    block_private_ipv4 = {                      multi = false, chainable = false },
-    nop              = {                        multi = false, chainable = false },
+    block_private_ipv4 = {
+        multi = false, chainable = false,
+    },
+    nop = {
+        multi = false, chainable = false,
+    },
 }
 
 -- Internal BPF programs that are not user-facing.
@@ -53,10 +59,23 @@ local function _get_metadata(progname)
     if meta.multi ~= nil and type(meta.multi) ~= "boolean" then
         raise("program '%s' metadata multi must be true or false", progname)
     end
+    local multi = meta.multi or false
+    local valid_layers = { l2 = true, l3 = true, l4 = true }
+    if meta.chainable then
+        if type(meta.layer) ~= "string" then
+            raise("program '%s' with chainable = true must declare layer in program_metadata", progname)
+        end
+        if not valid_layers[meta.layer] then
+            raise("program '%s' metadata layer must be one of l2, l3, or l4", progname)
+        end
+    elseif meta.layer ~= nil and not valid_layers[meta.layer] then
+        raise("program '%s' metadata layer must be one of l2, l3, or l4", progname)
+    end
     return {
         input = meta.input,
-        multi = meta.multi or false,
+        multi = multi,
         chainable = meta.chainable,
+        layer = meta.layer,
     }
 end
 
@@ -196,6 +215,7 @@ function gen_chain(target, source_target)
                 PROGNAME = progname,
                 PROGNAME_WITH_RODATA = has_rodata,
                 PROGNAME_INPUT_FIELD = input_field or "",
+                PROGNAME_CHAIN_LAYER = meta.layer,
             }
         })
 
@@ -222,19 +242,24 @@ function chain(target, components_target)
     local includes = {}
     local cases = {}
     local supports = {}
+    local layers = {}
 
     for i, pv in ipairs(vars) do
         local progname = pv.variables.PROGNAME
+        local layer = pv.variables.PROGNAME_CHAIN_LAYER
         table.insert(includes, '#include "' .. progname .. '.skel.h"')
         table.insert(cases, io.readfile(components[i]))
         table.insert(supports, "program == program_" .. progname)
+        table.insert(layers, "case program_" .. progname .. ": return CHAIN_LAYER_" .. string.upper(layer) .. ";")
     end
 
     table.sort(includes)
     table.sort(supports)
+    table.sort(layers)
 
     v["CHAIN_SKELETON_INCLUDES"] = table.concat(includes, "\n")
     v["CHAIN_CASES"] = table.concat(cases, "\n")
+    v["CHAIN_LAYER_CASES"] = table.concat(layers, "\n    ")
     v["CHAIN_SUPPORTS_CHECK"] =
         #supports > 0 and table.concat(supports, " ||\n           ") or "false"
 

--- a/xmake/modules/api.lua
+++ b/xmake/modules/api.lua
@@ -4,11 +4,13 @@ import("core.project.project")
 --
 -- Each entry controls:
 --   input     - userspace config/chain input field (nil if the program takes no input)
+--   bpf_value - BPF rodata value field for programs with input
+--   bpf_count - BPF rodata count field for multi-value programs
 --   multi     - true when the input is an array (ethertypes, protos)
 --   chainable - true when the program may appear in --chain
 --   layer     - l2/l3/l4 for chainable programs
 --
--- The standalone template uses input/multi for rodata layout.
+-- The standalone template uses input/multi/bpf_* for typed rodata writes.
 -- The chain template uses chainable to decide which programs get a
 -- generated case in load_chain_program() and appear in
 -- program_supports_chaining(). The chain validator uses layer to
@@ -17,13 +19,34 @@ import("core.project.project")
 -- Every non-internal BPF program MUST have an entry here.
 -- Missing entries cause a build failure (see _get_metadata below).
 local program_metadata = {
-    allow_dns        = { input = "ip",          multi = false, chainable = true,  layer = "l4" },
-    allow_ethertype  = { input = "ethertypes",  multi = true,  chainable = true,  layer = "l2" },
-    allow_ipv4       = { input = "ip",          multi = false, chainable = true,  layer = "l3" },
-    allow_port       = { input = "port",        multi = false, chainable = true,  layer = "l4" },
-    allow_proto      = { input = "protos",      multi = true,  chainable = true,  layer = "l3" },
-    block_ipv4       = { input = "ip",          multi = false, chainable = false },
-    block_port       = { input = "port",        multi = false, chainable = false },
+    allow_dns = {
+        input = "ip", bpf_value = "input",
+        multi = false, chainable = true, layer = "l4",
+    },
+    allow_ethertype = {
+        input = "ethertypes", bpf_value = "allowed", bpf_count = "num_allowed",
+        multi = true, chainable = true, layer = "l2",
+    },
+    allow_ipv4 = {
+        input = "ip", bpf_value = "input",
+        multi = false, chainable = true, layer = "l3",
+    },
+    allow_port = {
+        input = "port", bpf_value = "input",
+        multi = false, chainable = true, layer = "l4",
+    },
+    allow_proto = {
+        input = "protos", bpf_value = "allowed", bpf_count = "num_allowed",
+        multi = true, chainable = true, layer = "l3",
+    },
+    block_ipv4 = {
+        input = "ip", bpf_value = "input",
+        multi = false, chainable = false,
+    },
+    block_port = {
+        input = "port", bpf_value = "input",
+        multi = false, chainable = false,
+    },
     block_private_ipv4 = {
         multi = false, chainable = false,
     },
@@ -38,6 +61,32 @@ local program_metadata = {
 local internal_programs = {
     dispatcher = true,
 }
+
+local config_input_fields = {
+    ethertypes = true,
+    ip = true,
+    port = true,
+    protos = true,
+}
+
+local reserved_bpf_rodata_fields = {
+    chained = true,
+    slot = true,
+}
+
+local function _is_c_identifier(value)
+    return type(value) == "string" and value:match("^[A-Za-z_][A-Za-z0-9_]*$") ~= nil
+end
+
+local function _validate_bpf_field(progname, field_name, field_value)
+    if not _is_c_identifier(field_value) then
+        raise("program '%s' metadata %s must be a non-empty C identifier", progname, field_name)
+    end
+    if reserved_bpf_rodata_fields[field_value] then
+        raise("program '%s' metadata %s must not use reserved rodata field '%s'",
+              progname, field_name, field_value)
+    end
+end
 
 -- Look up and validate metadata for a program.
 -- Raises on missing entries or invalid field types so that omitting
@@ -56,11 +105,38 @@ local function _get_metadata(progname)
     if meta.input ~= nil and type(meta.input) ~= "string" then
         raise("program '%s' metadata input must be a string or nil", progname)
     end
+    if meta.input ~= nil and not config_input_fields[meta.input] then
+        raise("program '%s' metadata input must be one of ethertypes, ip, port, or protos", progname)
+    end
     if meta.multi ~= nil and type(meta.multi) ~= "boolean" then
         raise("program '%s' metadata multi must be true or false", progname)
     end
     local multi = meta.multi or false
     local valid_layers = { l2 = true, l3 = true, l4 = true }
+    if meta.input == nil and meta.bpf_value ~= nil then
+        raise("program '%s' without input must not declare bpf_value in program_metadata", progname)
+    end
+    if meta.input ~= nil then
+        if type(meta.bpf_value) ~= "string" then
+            raise("program '%s' with input must declare bpf_value in program_metadata", progname)
+        end
+        _validate_bpf_field(progname, "bpf_value", meta.bpf_value)
+    end
+    if multi and meta.input == nil then
+        raise("program '%s' with multi = true must declare input in program_metadata", progname)
+    end
+    if multi and type(meta.bpf_count) ~= "string" then
+        raise("program '%s' with multi = true must declare bpf_count in program_metadata", progname)
+    end
+    if multi then
+        _validate_bpf_field(progname, "bpf_count", meta.bpf_count)
+    end
+    if multi and meta.bpf_value == meta.bpf_count then
+        raise("program '%s' metadata bpf_value and bpf_count must be distinct", progname)
+    end
+    if not multi and meta.bpf_count ~= nil then
+        raise("program '%s' with multi = false must not declare bpf_count in program_metadata", progname)
+    end
     if meta.chainable then
         if type(meta.layer) ~= "string" then
             raise("program '%s' with chainable = true must declare layer in program_metadata", progname)
@@ -75,8 +151,60 @@ local function _get_metadata(progname)
         input = meta.input,
         multi = multi,
         chainable = meta.chainable,
+        bpf_value = meta.bpf_value,
+        bpf_count = meta.bpf_count,
         layer = meta.layer,
     }
+end
+
+local function _standalone_rodata_assignment(meta)
+    if not meta or not meta.input then
+        return "    // No rodata input for this program."
+    end
+
+    if meta.multi then
+        return string.format([[
+    // Set read-only data through typed skeleton fields before load.
+    if (conf->has_input)
+    {
+        memcpy((void *)obj->rodata->%s,
+               conf->input.%s.values,
+               sizeof(conf->input.%s.values));
+        obj->rodata->%s = conf->input.%s.count;
+        log_out(conf, "done: setting rodata input\n");
+    }]], meta.bpf_value, meta.input, meta.input, meta.bpf_count, meta.input)
+    end
+
+    return string.format([[
+    // Set read-only data through typed skeleton fields before load.
+    if (conf->has_input)
+    {
+        obj->rodata->%s = conf->input.%s;
+        log_out(conf, "done: setting rodata input\n");
+    }]], meta.bpf_value, meta.input)
+end
+
+local function _chain_input_assignment(meta)
+    if not meta.input then
+        return "        // No chain input rodata for this program."
+    end
+
+    if meta.multi then
+        return string.format([[
+        if (entry->has_input)
+        {
+            memcpy((void *)obj->rodata->%s,
+                   entry->input.%s.values,
+                   sizeof(entry->input.%s.values));
+            obj->rodata->%s = entry->input.%s.count;
+        }]], meta.bpf_value, meta.input, meta.input, meta.bpf_count, meta.input)
+    end
+
+    return string.format([[
+        if (entry->has_input)
+        {
+            obj->rodata->%s = entry->input.%s;
+        }]], meta.bpf_value, meta.input)
 end
 
 -- get sourcefiles
@@ -116,7 +244,6 @@ function gen(target, source_target)
         os.cp(configfile_template_path, tempconf)
         local meta = _get_metadata(progname)
         local input_field = meta and meta.input or nil
-        local is_multi = meta and meta.multi or false
         local has_rodata = input_field and 1 or 0
 
         target:add("configfiles", tempconf, {
@@ -124,8 +251,7 @@ function gen(target, source_target)
                 PROGNAME = progname,
                 OPERATION = "attach__",
                 PROGNAME_WITH_RODATA = has_rodata,
-                PROGNAME_INPUT_FIELD = input_field or "",
-                PROGNAME_IS_MULTI_VALUE = is_multi and 1 or 0,
+                PROGNAME_RODATA_ASSIGNMENT = _standalone_rodata_assignment(meta),
             }
         })
     end
@@ -207,15 +333,11 @@ function gen_chain(target, source_target)
         os.tryrm(tempconf)
         os.cp(configfile_template_path, tempconf)
 
-        local input_field = meta.input
-        local has_rodata = input_field and 1 or 0
-
         target:add("configfiles", tempconf, {
             variables = {
                 PROGNAME = progname,
-                PROGNAME_WITH_RODATA = has_rodata,
-                PROGNAME_INPUT_FIELD = input_field or "",
                 PROGNAME_CHAIN_LAYER = meta.layer,
+                PROGNAME_CHAIN_INPUT_ASSIGNMENT = _chain_input_assignment(meta),
             }
         })
 


### PR DESCRIPTION
## Summary

This PR hardens chained allow-program behavior around the project design principles: standalone programs remain complete conservative policies, while chained programs are explicit pipeline stages with typed configuration and enforced layer ownership.

## Outcomes

1. Chain ordering is now enforced before attach. Chains containing any L3/L4 program must start with `allow_ethertype`, and layer order must be non-decreasing as `L2 -> L3 -> L4`. Same-layer programs remain valid.

2. Rodata setup no longer depends on raw byte offsets. Generated standalone and chain loaders assign typed skeleton fields directly, including chain `slot` and `chained` fields.

3. Program metadata is the single source of truth for userspace input fields, BPF rodata fields, chainability, and chain layer. The generator validates missing/invalid metadata such as absent `bpf_value`, missing multi-value counts, reserved rodata names, and invalid layers.

4. Scapy packet support now covers the packets needed by this behavior: explicit ARP requests and VLAN-wrapped non-IPv4 packets.

5. Allow-program behavior is mode-aware. Standalone L3/L4 allow programs block non-IPv4 traffic as complete policies; chained L3/L4 programs pass non-IPv4 traffic to the next stage because L2 policy belongs to `allow_ethertype`.

6. Regression coverage was added for mode-aware non-IPv4 behavior and chain slot progression, including cases that prove later chain gates still run.

7. Documentation in both `docs/README.md` and `README.txt` now describes the same design-principle structure, with a TXT ASCII table kept within GitHub-friendly width.

8. Chain validation is centralized in the generated chain API so CLI parse-time errors and API attach-time errors share the same validation logic.

9. The Usage section now walks from standalone block filters to allow filters, L2 gates, two-stage chains, and a fuller quarantine-style L2/L3/L4 chain.

## Verification

- Ubuntu Docker: `xmake build`, focused `cli.flags` + `scapy` Bats, then `xmake run test` exited 0 before the docs-only conflict rebase.
- Rebased onto current `origin/main` and verified the PR branch now merges cleanly.
- Follow-up chain validation refactor: `xmake build` plus focused `cli.flags` chain validation tests exited 0.
- Usage docs follow-up: docs markers present in both README files, `README.txt` ASCII design table max width remains 78 chars, `git diff --check` clean, and merge check against `origin/main` clean.
- Raw rodata scan clean: no `set_chain_rodata`, `bpf_map__set_initial_value`, `slot_offset`, or `input_sz` in `api/` and `xmake/modules/api.lua`.
- Generated chain code contains typed `slot` and `chained` rodata assignments.