### PR TITLE
feat(intent): add intent IR and focused tests

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -270,5 +270,4 @@ TEST
 
     To run the test suite you can do this:
 
-    xmake -b test
     xmake run test

--- a/api/intent.h
+++ b/api/intent.h
@@ -352,6 +352,11 @@ static inline int intent_add_permit(struct intent *intent,
 
     if (strcmp(kind, "dns") == 0)
     {
+        /*
+         * dns/IP is a service shortcut for TCP+UDP destination port 53.
+         * Keep dns/IP:PORT rejected so custom ports must be spelled
+         * explicitly as tcp/IP:PORT and udp/IP:PORT.
+         */
         if (strchr(target, ':'))
             return intent_fail(err_msg, "dns permits do not accept a port");
         return intent_add_dns_permit(intent, target, err_msg);

--- a/api/intent.h
+++ b/api/intent.h
@@ -170,14 +170,63 @@ static inline int intent_predicate_compare(const struct intent_predicate *left,
     return 0;
 }
 
+static inline int intent_value_qsort_compare(const void *left,
+                                             const void *right)
+{
+    uint32_t a = *(const uint32_t *)left;
+    uint32_t b = *(const uint32_t *)right;
+
+    if (a == b)
+        return 0;
+    return a < b ? -1 : 1;
+}
+
 static inline int intent_predicate_qsort_compare(const void *left,
                                                  const void *right)
 {
     return intent_predicate_compare(left, right);
 }
 
+static inline void intent_normalize_predicate_values(struct intent_predicate *predicate)
+{
+    qsort(predicate->values.values,
+          predicate->values.count,
+          sizeof(predicate->values.values[0]),
+          intent_value_qsort_compare);
+}
+
+static inline int intent_validate_predicate_shape(const struct intent_predicate *predicate,
+                                                  const char **err_msg)
+{
+    if (predicate->values.count == 0 ||
+        predicate->values.count > MAX_INTENT_SET_VALUES)
+        return intent_fail(err_msg, "invalid permit");
+
+    if (predicate->op == INTENT_OP_EQ)
+    {
+        if (predicate->values.count != 1)
+            return intent_fail(err_msg, "invalid permit");
+        return 0;
+    }
+
+    if (predicate->op != INTENT_OP_IN)
+        return intent_fail(err_msg, "invalid permit");
+
+    if (predicate->values.count < 2)
+        return intent_fail(err_msg, "invalid permit");
+    for (size_t i = 1; i < predicate->values.count; i++)
+    {
+        if (predicate->values.values[i - 1] == predicate->values.values[i])
+            return intent_fail(err_msg, "invalid permit");
+    }
+    return 0;
+}
+
 static inline void intent_normalize_permit(struct intent_permit *permit)
 {
+    for (size_t i = 0; i < permit->predicate_count; i++)
+        intent_normalize_predicate_values(&permit->predicates[i]);
+
     /* Canonical predicate order makes duplicate detection order independent. */
     qsort(permit->predicates,
           permit->predicate_count,
@@ -206,18 +255,25 @@ static inline int intent_add_predicate(struct intent_permit *permit,
                                        size_t value_count,
                                        const char **err_msg)
 {
+    struct intent_predicate predicate = {0};
+
+    if (!permit || !values)
+        return intent_fail(err_msg, "invalid permit");
     if (permit->predicate_count >= MAX_INTENT_PREDICATES ||
         value_count == 0 ||
         value_count > MAX_INTENT_SET_VALUES)
         return intent_fail(err_msg, "invalid permit");
 
-    struct intent_predicate *predicate = &permit->predicates[permit->predicate_count];
-    predicate->field = field;
-    predicate->op = op;
-    predicate->values.count = value_count;
+    predicate.field = field;
+    predicate.op = op;
+    predicate.values.count = value_count;
     for (size_t i = 0; i < value_count; i++)
-        predicate->values.values[i] = values[i];
+        predicate.values.values[i] = values[i];
+    intent_normalize_predicate_values(&predicate);
+    if (intent_validate_predicate_shape(&predicate, err_msg) != 0)
+        return -1;
 
+    permit->predicates[permit->predicate_count] = predicate;
     permit->predicate_count++;
     return 0;
 }
@@ -267,6 +323,11 @@ static inline int intent_append_permit(struct intent *intent,
 
     if (normalized.predicate_count == 0)
         return intent_fail(err_msg, "permit has no predicates");
+    for (size_t i = 0; i < normalized.predicate_count; i++)
+    {
+        if (intent_validate_predicate_shape(&normalized.predicates[i], err_msg) != 0)
+            return -1;
+    }
     if (intent_has_permit(intent, &normalized))
         return intent_fail(err_msg, "duplicate permit");
     if (intent->permit_count >= MAX_INTENT_PERMITS)
@@ -336,7 +397,11 @@ static inline int intent_add_permit(struct intent *intent,
     char *kind = NULL;
     char *target = NULL;
     char *port = NULL;
-    size_t arg_len = strlen(arg);
+    size_t arg_len = 0;
+
+    if (!arg)
+        return intent_fail(err_msg, "invalid permit");
+    arg_len = strlen(arg);
 
     if (arg_len >= sizeof(buf))
         return intent_fail(err_msg, "permit too long");

--- a/api/intent.h
+++ b/api/intent.h
@@ -8,6 +8,9 @@
 #include <string.h>
 
 #define MAX_INTENT_PERMITS 32
+/* Current permit grammar is IPv4-only. Revisit this bound with IPv6 support. */
+#define MAX_INTENT_PERMIT_INPUT_LEN 128
+/* Reserved for forbid lowering; permits are the only accepted CLI rule today. */
 #define MAX_INTENT_FORBIDS 32
 #define MAX_INTENT_PREDICATES 6
 #define MAX_INTENT_SET_VALUES 4
@@ -47,6 +50,7 @@ enum intent_predicate_op
 {
     INTENT_OP_EQ = 0,
     INTENT_OP_IN = 1,
+    /* Reserved for future CIDR predicates; unsupported until lowered explicitly. */
     INTENT_OP_CIDR_CONTAINS = 2,
 };
 
@@ -142,6 +146,37 @@ static inline bool intent_predicate_equal(const struct intent_predicate *left,
     return true;
 }
 
+static inline int intent_predicate_compare(const struct intent_predicate *left,
+                                           const struct intent_predicate *right)
+{
+    if (left->field != right->field)
+        return (int)left->field - (int)right->field;
+    if (left->op != right->op)
+        return (int)left->op - (int)right->op;
+    if (left->values.count != right->values.count)
+        return left->values.count < right->values.count ? -1 : 1;
+    for (size_t i = 0; i < left->values.count; i++)
+    {
+        if (left->values.values[i] != right->values.values[i])
+            return left->values.values[i] < right->values.values[i] ? -1 : 1;
+    }
+    return 0;
+}
+
+static inline int intent_predicate_qsort_compare(const void *left,
+                                                 const void *right)
+{
+    return intent_predicate_compare(left, right);
+}
+
+static inline void intent_normalize_permit(struct intent_permit *permit)
+{
+    qsort(permit->predicates,
+          permit->predicate_count,
+          sizeof(permit->predicates[0]),
+          intent_predicate_qsort_compare);
+}
+
 static inline bool intent_permit_equal(const struct intent_permit *left,
                                        const struct intent_permit *right)
 {
@@ -222,7 +257,10 @@ static inline int intent_append_permit(struct intent *intent,
                                        const struct intent_permit *permit,
                                        const char **err_msg)
 {
-    if (intent_has_permit(intent, permit))
+    struct intent_permit normalized = *permit;
+    intent_normalize_permit(&normalized);
+
+    if (intent_has_permit(intent, &normalized))
     {
         *err_msg = "duplicate permit";
         return -1;
@@ -232,7 +270,7 @@ static inline int intent_append_permit(struct intent *intent,
         *err_msg = "too many permits";
         return -1;
     }
-    intent->permits[intent->permit_count] = *permit;
+    intent->permits[intent->permit_count] = normalized;
     intent->permit_count++;
     return 0;
 }
@@ -299,12 +337,13 @@ static inline int intent_add_permit(struct intent *intent,
                                     const char *arg,
                                     const char **err_msg)
 {
-    char buf[128];
+    char buf[MAX_INTENT_PERMIT_INPUT_LEN];
     char *kind = NULL;
     char *target = NULL;
     char *port = NULL;
+    size_t arg_len = strlen(arg);
 
-    if (strlen(arg) >= sizeof(buf))
+    if (arg_len >= sizeof(buf))
     {
         *err_msg = "permit too long";
         return -1;
@@ -313,7 +352,7 @@ static inline int intent_add_permit(struct intent *intent,
     if (strcmp(arg, "arp") == 0)
         return intent_add_arp_permit(intent, err_msg);
 
-    memcpy(buf, arg, strlen(arg) + 1);
+    memcpy(buf, arg, arg_len + 1);
     kind = buf;
     target = strchr(kind, '/');
     if (!target)
@@ -359,23 +398,6 @@ static inline int intent_add_permit(struct intent *intent,
     return -1;
 }
 
-static inline int intent_predicate_compare(const struct intent_predicate *left,
-                                           const struct intent_predicate *right)
-{
-    if (left->field != right->field)
-        return (int)left->field - (int)right->field;
-    if (left->op != right->op)
-        return (int)left->op - (int)right->op;
-    if (left->values.count != right->values.count)
-        return left->values.count < right->values.count ? -1 : 1;
-    for (size_t i = 0; i < left->values.count; i++)
-    {
-        if (left->values.values[i] != right->values.values[i])
-            return left->values.values[i] < right->values.values[i] ? -1 : 1;
-    }
-    return 0;
-}
-
 static inline int intent_permit_compare(const void *left, const void *right)
 {
     const struct intent_permit *a = left;
@@ -395,6 +417,8 @@ static inline int intent_permit_compare(const void *left, const void *right)
 
 static inline void intent_normalize(struct intent *intent)
 {
+    for (size_t i = 0; i < intent->permit_count; i++)
+        intent_normalize_permit(&intent->permits[i]);
     qsort(intent->permits,
           intent->permit_count,
           sizeof(intent->permits[0]),

--- a/api/intent.h
+++ b/api/intent.h
@@ -8,9 +8,9 @@
 #include <string.h>
 
 #define MAX_INTENT_PERMITS 32
-/* Current permit grammar is IPv4-only. Revisit this bound with IPv6 support. */
+/* This bound only covers the IPv4 grammar accepted today. */
 #define MAX_INTENT_PERMIT_INPUT_LEN 128
-/* Reserved for forbid lowering; permits are the only accepted CLI rule today. */
+/* Forbid storage is reserved for the Intent model. */
 #define MAX_INTENT_FORBIDS 32
 #define MAX_INTENT_PREDICATES 6
 #define MAX_INTENT_SET_VALUES 4
@@ -50,7 +50,7 @@ enum intent_predicate_op
 {
     INTENT_OP_EQ = 0,
     INTENT_OP_IN = 1,
-    /* Reserved for future CIDR predicates; unsupported until lowered explicitly. */
+    /* CIDR predicates need explicit parser and backend lowering support. */
     INTENT_OP_CIDR_CONTAINS = 2,
 };
 
@@ -178,6 +178,7 @@ static inline int intent_predicate_qsort_compare(const void *left,
 
 static inline void intent_normalize_permit(struct intent_permit *permit)
 {
+    /* Canonical predicate order makes duplicate detection order independent. */
     qsort(permit->predicates,
           permit->predicate_count,
           sizeof(permit->predicates[0]),
@@ -343,6 +344,7 @@ static inline int intent_add_permit(struct intent *intent,
     if (strcmp(arg, "arp") == 0)
         return intent_add_arp_permit(intent, err_msg);
 
+    /* Parse a local copy because argp owns the input string. */
     memcpy(buf, arg, arg_len + 1);
     kind = buf;
     target = strchr(kind, '/');
@@ -354,8 +356,8 @@ static inline int intent_add_permit(struct intent *intent,
     {
         /*
          * dns/IP is a service shortcut for TCP+UDP destination port 53.
-         * Keep dns/IP:PORT rejected so custom ports must be spelled
-         * explicitly as tcp/IP:PORT and udp/IP:PORT.
+         * dns/IP:PORT stays rejected to avoid hidden custom-port semantics.
+         * Use tcp/IP:PORT plus udp/IP:PORT for custom DNS-like services.
          */
         if (strchr(target, ':'))
             return intent_fail(err_msg, "dns permits do not accept a port");

--- a/api/intent.h
+++ b/api/intent.h
@@ -1,0 +1,404 @@
+#ifndef TRAFFICO_INTENT_H
+#define TRAFFICO_INTENT_H
+
+#include <arpa/inet.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define MAX_INTENT_PERMITS 32
+#define MAX_INTENT_FORBIDS 32
+#define MAX_INTENT_PREDICATES 6
+#define MAX_INTENT_SET_VALUES 4
+
+#define INTENT_ETH_P_IP 0x0800
+#define INTENT_ETH_P_ARP 0x0806
+#define INTENT_IPPROTO_TCP 6
+#define INTENT_IPPROTO_UDP 17
+#define INTENT_DNS_PORT 53
+
+enum intent_direction
+{
+    INTENT_DIRECTION_EGRESS = 0,
+    INTENT_DIRECTION_INGRESS = 1,
+};
+
+enum intent_action
+{
+    INTENT_ACTION_DROP = 0,
+    INTENT_ACTION_ALLOW = 1,
+};
+
+enum intent_predicate_field
+{
+    INTENT_FIELD_ETH_TYPE = 0,
+    INTENT_FIELD_IP_SRC = 1,
+    INTENT_FIELD_IP_DST = 2,
+    INTENT_FIELD_IP_PROTO = 3,
+    INTENT_FIELD_L4_SRC_PORT = 4,
+    INTENT_FIELD_L4_DST_PORT = 5,
+    INTENT_FIELD_ARP_OP = 6,
+    INTENT_FIELD_ARP_SPA = 7,
+    INTENT_FIELD_ARP_TPA = 8,
+};
+
+enum intent_predicate_op
+{
+    INTENT_OP_EQ = 0,
+    INTENT_OP_IN = 1,
+    INTENT_OP_CIDR_CONTAINS = 2,
+};
+
+struct intent_value_set
+{
+    uint32_t values[MAX_INTENT_SET_VALUES];
+    size_t count;
+};
+
+struct intent_predicate
+{
+    enum intent_predicate_field field;
+    enum intent_predicate_op op;
+    struct intent_value_set values;
+};
+
+struct intent_permit
+{
+    struct intent_predicate predicates[MAX_INTENT_PREDICATES];
+    size_t predicate_count;
+};
+
+struct intent_forbid
+{
+    struct intent_predicate predicates[MAX_INTENT_PREDICATES];
+    size_t predicate_count;
+};
+
+struct intent
+{
+    enum intent_direction direction;
+    enum intent_action default_action;
+    struct intent_permit permits[MAX_INTENT_PERMITS];
+    size_t permit_count;
+    struct intent_forbid forbids[MAX_INTENT_FORBIDS];
+    size_t forbid_count;
+};
+
+static inline void intent_init(struct intent *intent,
+                               enum intent_direction direction)
+{
+    memset(intent, 0, sizeof(*intent));
+    intent->direction = direction;
+    intent->default_action = INTENT_ACTION_DROP;
+}
+
+static inline int intent_parse_ipv4(const char *value, uint32_t *out)
+{
+    struct in_addr addr;
+    if (inet_pton(AF_INET, value, &addr) != 1)
+        return -1;
+    /* Predicate values are stored in host byte order. */
+    *out = ntohl(addr.s_addr);
+    return 0;
+}
+
+static inline int intent_parse_port(const char *value, uint32_t *out)
+{
+    uint32_t port = 0;
+
+    if (*value == '\0')
+        return -1;
+
+    for (const char *p = value; *p != '\0'; p++)
+    {
+        if (*p < '0' || *p > '9')
+            return -1;
+        uint32_t digit = (uint32_t)(*p - '0');
+        if (port > 6553 || (port == 6553 && digit > 5))
+            return -1;
+        port = port * 10 + digit;
+    }
+    if (port == 0)
+        return -1;
+
+    *out = (uint32_t)port;
+    return 0;
+}
+
+static inline bool intent_predicate_equal(const struct intent_predicate *left,
+                                          const struct intent_predicate *right)
+{
+    if (left->field != right->field ||
+        left->op != right->op ||
+        left->values.count != right->values.count)
+        return false;
+
+    for (size_t i = 0; i < left->values.count; i++)
+    {
+        if (left->values.values[i] != right->values.values[i])
+            return false;
+    }
+    return true;
+}
+
+static inline bool intent_permit_equal(const struct intent_permit *left,
+                                       const struct intent_permit *right)
+{
+    if (left->predicate_count != right->predicate_count)
+        return false;
+
+    for (size_t i = 0; i < left->predicate_count; i++)
+    {
+        if (!intent_predicate_equal(&left->predicates[i], &right->predicates[i]))
+            return false;
+    }
+    return true;
+}
+
+static inline int intent_add_predicate(struct intent_permit *permit,
+                                       enum intent_predicate_field field,
+                                       enum intent_predicate_op op,
+                                       const uint32_t *values,
+                                       size_t value_count,
+                                       const char **err_msg)
+{
+    if (permit->predicate_count >= MAX_INTENT_PREDICATES ||
+        value_count == 0 ||
+        value_count > MAX_INTENT_SET_VALUES)
+    {
+        *err_msg = "invalid permit";
+        return -1;
+    }
+
+    struct intent_predicate *predicate = &permit->predicates[permit->predicate_count];
+    predicate->field = field;
+    predicate->op = op;
+    predicate->values.count = value_count;
+    for (size_t i = 0; i < value_count; i++)
+        predicate->values.values[i] = values[i];
+
+    permit->predicate_count++;
+    return 0;
+}
+
+static inline int intent_add_eq(struct intent_permit *permit,
+                                enum intent_predicate_field field,
+                                uint32_t value,
+                                const char **err_msg)
+{
+    return intent_add_predicate(permit, field, INTENT_OP_EQ, &value, 1, err_msg);
+}
+
+static inline int intent_add_proto_in_tcp_udp(struct intent_permit *permit,
+                                              const char **err_msg)
+{
+    const uint32_t protos[] = {INTENT_IPPROTO_TCP, INTENT_IPPROTO_UDP};
+    return intent_add_predicate(permit,
+                                INTENT_FIELD_IP_PROTO,
+                                INTENT_OP_IN,
+                                protos,
+                                2,
+                                err_msg);
+}
+
+static inline void intent_permit_init(struct intent_permit *permit)
+{
+    memset(permit, 0, sizeof(*permit));
+}
+
+static inline bool intent_has_permit(const struct intent *intent,
+                                     const struct intent_permit *candidate)
+{
+    for (size_t i = 0; i < intent->permit_count; i++)
+    {
+        if (intent_permit_equal(&intent->permits[i], candidate))
+            return true;
+    }
+    return false;
+}
+
+static inline int intent_append_permit(struct intent *intent,
+                                       const struct intent_permit *permit,
+                                       const char **err_msg)
+{
+    if (intent_has_permit(intent, permit))
+    {
+        *err_msg = "duplicate permit";
+        return -1;
+    }
+    if (intent->permit_count >= MAX_INTENT_PERMITS)
+    {
+        *err_msg = "too many permits";
+        return -1;
+    }
+    intent->permits[intent->permit_count] = *permit;
+    intent->permit_count++;
+    return 0;
+}
+
+static inline int intent_add_arp_permit(struct intent *intent,
+                                        const char **err_msg)
+{
+    struct intent_permit permit;
+    intent_permit_init(&permit);
+    if (intent_add_eq(&permit, INTENT_FIELD_ETH_TYPE, INTENT_ETH_P_ARP, err_msg) != 0)
+        return -1;
+    return intent_append_permit(intent, &permit, err_msg);
+}
+
+static inline int intent_add_dns_permit(struct intent *intent,
+                                        const char *ip,
+                                        const char **err_msg)
+{
+    uint32_t dst_ip = 0;
+    struct intent_permit permit;
+    intent_permit_init(&permit);
+
+    if (intent_parse_ipv4(ip, &dst_ip) != 0)
+    {
+        *err_msg = "invalid permit";
+        return -1;
+    }
+    if (intent_add_eq(&permit, INTENT_FIELD_ETH_TYPE, INTENT_ETH_P_IP, err_msg) != 0 ||
+        intent_add_eq(&permit, INTENT_FIELD_IP_DST, dst_ip, err_msg) != 0 ||
+        intent_add_proto_in_tcp_udp(&permit, err_msg) != 0 ||
+        intent_add_eq(&permit, INTENT_FIELD_L4_DST_PORT, INTENT_DNS_PORT, err_msg) != 0)
+        return -1;
+
+    return intent_append_permit(intent, &permit, err_msg);
+}
+
+static inline int intent_add_l4_permit(struct intent *intent,
+                                       uint32_t proto,
+                                       const char *ip,
+                                       const char *port,
+                                       const char **err_msg)
+{
+    uint32_t dst_ip = 0;
+    uint32_t dst_port = 0;
+    struct intent_permit permit;
+    intent_permit_init(&permit);
+
+    if (intent_parse_ipv4(ip, &dst_ip) != 0 ||
+        intent_parse_port(port, &dst_port) != 0)
+    {
+        *err_msg = "invalid permit";
+        return -1;
+    }
+    if (intent_add_eq(&permit, INTENT_FIELD_ETH_TYPE, INTENT_ETH_P_IP, err_msg) != 0 ||
+        intent_add_eq(&permit, INTENT_FIELD_IP_DST, dst_ip, err_msg) != 0 ||
+        intent_add_eq(&permit, INTENT_FIELD_IP_PROTO, proto, err_msg) != 0 ||
+        intent_add_eq(&permit, INTENT_FIELD_L4_DST_PORT, dst_port, err_msg) != 0)
+        return -1;
+
+    return intent_append_permit(intent, &permit, err_msg);
+}
+
+static inline int intent_add_permit(struct intent *intent,
+                                    const char *arg,
+                                    const char **err_msg)
+{
+    char buf[128];
+    char *kind = NULL;
+    char *target = NULL;
+    char *port = NULL;
+
+    if (strlen(arg) >= sizeof(buf))
+    {
+        *err_msg = "permit too long";
+        return -1;
+    }
+
+    if (strcmp(arg, "arp") == 0)
+        return intent_add_arp_permit(intent, err_msg);
+
+    memcpy(buf, arg, strlen(arg) + 1);
+    kind = buf;
+    target = strchr(kind, '/');
+    if (!target)
+    {
+        *err_msg = "unsupported permit";
+        return -1;
+    }
+    *target++ = '\0';
+
+    if (strcmp(kind, "dns") == 0)
+    {
+        if (strchr(target, ':'))
+        {
+            *err_msg = "invalid permit";
+            return -1;
+        }
+        return intent_add_dns_permit(intent, target, err_msg);
+    }
+    if (strcmp(kind, "tcp") == 0)
+    {
+        port = strrchr(target, ':');
+        if (!port)
+        {
+            *err_msg = "invalid permit";
+            return -1;
+        }
+        *port++ = '\0';
+        return intent_add_l4_permit(intent, INTENT_IPPROTO_TCP, target, port, err_msg);
+    }
+    if (strcmp(kind, "udp") == 0)
+    {
+        port = strrchr(target, ':');
+        if (!port)
+        {
+            *err_msg = "invalid permit";
+            return -1;
+        }
+        *port++ = '\0';
+        return intent_add_l4_permit(intent, INTENT_IPPROTO_UDP, target, port, err_msg);
+    }
+
+    *err_msg = "unsupported permit";
+    return -1;
+}
+
+static inline int intent_predicate_compare(const struct intent_predicate *left,
+                                           const struct intent_predicate *right)
+{
+    if (left->field != right->field)
+        return (int)left->field - (int)right->field;
+    if (left->op != right->op)
+        return (int)left->op - (int)right->op;
+    if (left->values.count != right->values.count)
+        return left->values.count < right->values.count ? -1 : 1;
+    for (size_t i = 0; i < left->values.count; i++)
+    {
+        if (left->values.values[i] != right->values.values[i])
+            return left->values.values[i] < right->values.values[i] ? -1 : 1;
+    }
+    return 0;
+}
+
+static inline int intent_permit_compare(const void *left, const void *right)
+{
+    const struct intent_permit *a = left;
+    const struct intent_permit *b = right;
+
+    if (a->predicate_count != b->predicate_count)
+        return a->predicate_count < b->predicate_count ? -1 : 1;
+
+    for (size_t i = 0; i < a->predicate_count; i++)
+    {
+        int cmp = intent_predicate_compare(&a->predicates[i], &b->predicates[i]);
+        if (cmp != 0)
+            return cmp;
+    }
+    return 0;
+}
+
+static inline void intent_normalize(struct intent *intent)
+{
+    qsort(intent->permits,
+          intent->permit_count,
+          sizeof(intent->permits[0]),
+          intent_permit_compare);
+}
+
+#endif

--- a/api/intent.h
+++ b/api/intent.h
@@ -97,6 +97,13 @@ static inline void intent_init(struct intent *intent,
     intent->default_action = INTENT_ACTION_DROP;
 }
 
+static inline int intent_fail(const char **err_msg, const char *msg)
+{
+    if (err_msg)
+        *err_msg = msg;
+    return -1;
+}
+
 static inline int intent_parse_ipv4(const char *value, uint32_t *out)
 {
     struct in_addr addr;
@@ -201,10 +208,7 @@ static inline int intent_add_predicate(struct intent_permit *permit,
     if (permit->predicate_count >= MAX_INTENT_PREDICATES ||
         value_count == 0 ||
         value_count > MAX_INTENT_SET_VALUES)
-    {
-        *err_msg = "invalid permit";
-        return -1;
-    }
+        return intent_fail(err_msg, "invalid permit");
 
     struct intent_predicate *predicate = &permit->predicates[permit->predicate_count];
     predicate->field = field;
@@ -260,16 +264,12 @@ static inline int intent_append_permit(struct intent *intent,
     struct intent_permit normalized = *permit;
     intent_normalize_permit(&normalized);
 
+    if (normalized.predicate_count == 0)
+        return intent_fail(err_msg, "permit has no predicates");
     if (intent_has_permit(intent, &normalized))
-    {
-        *err_msg = "duplicate permit";
-        return -1;
-    }
+        return intent_fail(err_msg, "duplicate permit");
     if (intent->permit_count >= MAX_INTENT_PERMITS)
-    {
-        *err_msg = "too many permits";
-        return -1;
-    }
+        return intent_fail(err_msg, "too many permits");
     intent->permits[intent->permit_count] = normalized;
     intent->permit_count++;
     return 0;
@@ -294,10 +294,7 @@ static inline int intent_add_dns_permit(struct intent *intent,
     intent_permit_init(&permit);
 
     if (intent_parse_ipv4(ip, &dst_ip) != 0)
-    {
-        *err_msg = "invalid permit";
-        return -1;
-    }
+        return intent_fail(err_msg, "invalid permit");
     if (intent_add_eq(&permit, INTENT_FIELD_ETH_TYPE, INTENT_ETH_P_IP, err_msg) != 0 ||
         intent_add_eq(&permit, INTENT_FIELD_IP_DST, dst_ip, err_msg) != 0 ||
         intent_add_proto_in_tcp_udp(&permit, err_msg) != 0 ||
@@ -320,10 +317,7 @@ static inline int intent_add_l4_permit(struct intent *intent,
 
     if (intent_parse_ipv4(ip, &dst_ip) != 0 ||
         intent_parse_port(port, &dst_port) != 0)
-    {
-        *err_msg = "invalid permit";
-        return -1;
-    }
+        return intent_fail(err_msg, "invalid permit");
     if (intent_add_eq(&permit, INTENT_FIELD_ETH_TYPE, INTENT_ETH_P_IP, err_msg) != 0 ||
         intent_add_eq(&permit, INTENT_FIELD_IP_DST, dst_ip, err_msg) != 0 ||
         intent_add_eq(&permit, INTENT_FIELD_IP_PROTO, proto, err_msg) != 0 ||
@@ -344,10 +338,7 @@ static inline int intent_add_permit(struct intent *intent,
     size_t arg_len = strlen(arg);
 
     if (arg_len >= sizeof(buf))
-    {
-        *err_msg = "permit too long";
-        return -1;
-    }
+        return intent_fail(err_msg, "permit too long");
 
     if (strcmp(arg, "arp") == 0)
         return intent_add_arp_permit(intent, err_msg);
@@ -356,29 +347,20 @@ static inline int intent_add_permit(struct intent *intent,
     kind = buf;
     target = strchr(kind, '/');
     if (!target)
-    {
-        *err_msg = "unsupported permit";
-        return -1;
-    }
+        return intent_fail(err_msg, "unsupported permit");
     *target++ = '\0';
 
     if (strcmp(kind, "dns") == 0)
     {
         if (strchr(target, ':'))
-        {
-            *err_msg = "invalid permit";
-            return -1;
-        }
+            return intent_fail(err_msg, "dns permits do not accept a port");
         return intent_add_dns_permit(intent, target, err_msg);
     }
     if (strcmp(kind, "tcp") == 0)
     {
         port = strrchr(target, ':');
         if (!port)
-        {
-            *err_msg = "invalid permit";
-            return -1;
-        }
+            return intent_fail(err_msg, "invalid permit");
         *port++ = '\0';
         return intent_add_l4_permit(intent, INTENT_IPPROTO_TCP, target, port, err_msg);
     }
@@ -386,16 +368,12 @@ static inline int intent_add_permit(struct intent *intent,
     {
         port = strrchr(target, ':');
         if (!port)
-        {
-            *err_msg = "invalid permit";
-            return -1;
-        }
+            return intent_fail(err_msg, "invalid permit");
         *port++ = '\0';
         return intent_add_l4_permit(intent, INTENT_IPPROTO_UDP, target, port, err_msg);
     }
 
-    *err_msg = "unsupported permit";
-    return -1;
+    return intent_fail(err_msg, "unsupported permit");
 }
 
 static inline int intent_permit_compare(const void *left, const void *right)

--- a/docs/README.md
+++ b/docs/README.md
@@ -219,7 +219,6 @@ xmake -b bpf
 To run the test suite you can do this:
 
 ```bash
-xmake -b test
 xmake run test
 ```
 

--- a/test/intent_unit.bats
+++ b/test/intent_unit.bats
@@ -1,0 +1,11 @@
+#!/usr/bin/env bats
+
+load helpers
+export BATS_TEST_NAME_PREFIX=$(setsuite)
+bats_require_minimum_version 1.7.0
+
+@test "intent header unit tests" {
+    run intent-ir-unit
+    [ $status -eq 0 ]
+    [ "${lines[0]}" == "intent unit tests: ok" ]
+}

--- a/test/intent_unit.c
+++ b/test/intent_unit.c
@@ -138,6 +138,19 @@ static int test_parse_first_permits(void)
     return 0;
 }
 
+static int test_parse_ipv4_addresses(void)
+{
+    uint32_t ip = 0;
+
+    CHECK(intent_parse_ipv4("10.0.0.53", &ip) == 0);
+    CHECK(ip == 0x0a000035);
+    CHECK(intent_parse_ipv4("", &ip) == -1);
+    CHECK(intent_parse_ipv4("999.999.999.999", &ip) == -1);
+    CHECK(intent_parse_ipv4("10.0.0.1x", &ip) == -1);
+
+    return 0;
+}
+
 static int test_rejects_invalid_and_duplicate_permits(void)
 {
     struct intent intent = {0};
@@ -192,7 +205,7 @@ static int test_rejects_duplicate_lowered_permits(void)
 static int test_rejects_permit_too_long(void)
 {
     struct intent intent = {0};
-    char permit[129];
+    char permit[MAX_INTENT_PERMIT_INPUT_LEN + 1];
     const char *err = NULL;
 
     intent_init(&intent, INTENT_DIRECTION_EGRESS);
@@ -202,6 +215,33 @@ static int test_rejects_permit_too_long(void)
 
     CHECK(intent_add_permit(&intent, permit, &err) == -1);
     CHECK(strcmp(err, "permit too long") == 0);
+
+    return 0;
+}
+
+static int test_append_normalizes_predicate_order(void)
+{
+    struct intent intent = {0};
+    struct intent_permit first;
+    struct intent_permit second;
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    intent_permit_init(&first);
+    intent_permit_init(&second);
+
+    CHECK(intent_add_eq(&first, INTENT_FIELD_ETH_TYPE, INTENT_ETH_P_IP, &err) == 0);
+    CHECK(intent_add_eq(&first, INTENT_FIELD_IP_PROTO, INTENT_IPPROTO_TCP, &err) == 0);
+
+    CHECK(intent_add_eq(&second, INTENT_FIELD_IP_PROTO, INTENT_IPPROTO_TCP, &err) == 0);
+    CHECK(intent_add_eq(&second, INTENT_FIELD_ETH_TYPE, INTENT_ETH_P_IP, &err) == 0);
+
+    CHECK(intent_append_permit(&intent, &second, &err) == 0);
+    CHECK(intent.permits[0].predicates[0].field == INTENT_FIELD_ETH_TYPE);
+    CHECK(intent.permits[0].predicates[1].field == INTENT_FIELD_IP_PROTO);
+
+    CHECK(intent_append_permit(&intent, &first, &err) == -1);
+    CHECK(strcmp(err, "duplicate permit") == 0);
 
     return 0;
 }
@@ -256,9 +296,11 @@ static int test_normalization_is_order_independent(void)
 int main(void)
 {
     RUN_TEST(test_parse_first_permits);
+    RUN_TEST(test_parse_ipv4_addresses);
     RUN_TEST(test_rejects_invalid_and_duplicate_permits);
     RUN_TEST(test_rejects_duplicate_lowered_permits);
     RUN_TEST(test_rejects_permit_too_long);
+    RUN_TEST(test_append_normalizes_predicate_order);
     RUN_TEST(test_rejects_too_many_permits);
     RUN_TEST(test_normalization_is_order_independent);
     puts("intent unit tests: ok");

--- a/test/intent_unit.c
+++ b/test/intent_unit.c
@@ -174,6 +174,8 @@ static int test_rejects_invalid_and_duplicate_permits(void)
     CHECK(intent_add_permit(&intent, "icmp/10.0.0.10", &err) == -1);
     CHECK(strcmp(err, "unsupported permit") == 0);
     CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", NULL) == -1);
+    CHECK(intent_add_permit(&intent, NULL, &err) == -1);
+    CHECK(strcmp(err, "invalid permit") == 0);
     CHECK(intent_add_permit(&intent, "arp", &err) == 0);
     CHECK(intent_add_permit(&intent, "arp", &err) == -1);
     CHECK(strcmp(err, "duplicate permit") == 0);
@@ -265,6 +267,66 @@ static int test_append_normalizes_predicate_order(void)
     return 0;
 }
 
+static int test_append_normalizes_value_set_order(void)
+{
+    struct intent intent = {0};
+    struct intent_permit first;
+    struct intent_permit second;
+    const uint32_t forward[] = {INTENT_IPPROTO_TCP, INTENT_IPPROTO_UDP};
+    const uint32_t reverse[] = {INTENT_IPPROTO_UDP, INTENT_IPPROTO_TCP};
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    intent_permit_init(&first);
+    intent_permit_init(&second);
+
+    CHECK(intent_add_predicate(&first,
+                               INTENT_FIELD_IP_PROTO,
+                               INTENT_OP_IN,
+                               forward,
+                               2,
+                               &err) == 0);
+    CHECK(intent_add_predicate(&second,
+                               INTENT_FIELD_IP_PROTO,
+                               INTENT_OP_IN,
+                               reverse,
+                               2,
+                               &err) == 0);
+    CHECK(second.predicates[0].values.values[0] == INTENT_IPPROTO_TCP);
+    CHECK(second.predicates[0].values.values[1] == INTENT_IPPROTO_UDP);
+
+    CHECK(intent_append_permit(&intent, &second, &err) == 0);
+    CHECK(intent_append_permit(&intent, &first, &err) == -1);
+    CHECK(strcmp(err, "duplicate permit") == 0);
+
+    return 0;
+}
+
+static int test_rejects_invalid_manual_predicates(void)
+{
+    struct intent_permit permit;
+    const uint32_t one[] = {INTENT_IPPROTO_TCP};
+    const uint32_t two[] = {INTENT_IPPROTO_TCP, INTENT_IPPROTO_UDP};
+    const uint32_t duplicate[] = {INTENT_IPPROTO_TCP, INTENT_IPPROTO_TCP};
+    const char *err = NULL;
+
+    intent_permit_init(&permit);
+
+    CHECK(intent_add_predicate(&permit, INTENT_FIELD_IP_PROTO, INTENT_OP_EQ, two, 2, &err) == -1);
+    CHECK(strcmp(err, "invalid permit") == 0);
+    CHECK(intent_add_predicate(&permit, INTENT_FIELD_IP_PROTO, INTENT_OP_IN, one, 1, &err) == -1);
+    CHECK(strcmp(err, "invalid permit") == 0);
+    CHECK(intent_add_predicate(&permit, INTENT_FIELD_IP_PROTO, INTENT_OP_IN, duplicate, 2, &err) == -1);
+    CHECK(strcmp(err, "invalid permit") == 0);
+    CHECK(intent_add_predicate(&permit, INTENT_FIELD_IP_DST, INTENT_OP_CIDR_CONTAINS, two, 2, &err) == -1);
+    CHECK(strcmp(err, "invalid permit") == 0);
+    CHECK(intent_add_predicate(&permit, INTENT_FIELD_IP_PROTO, INTENT_OP_EQ, NULL, 1, &err) == -1);
+    CHECK(strcmp(err, "invalid permit") == 0);
+    CHECK(permit.predicate_count == 0);
+
+    return 0;
+}
+
 static int test_rejects_too_many_permits(void)
 {
     struct intent intent = {0};
@@ -321,6 +383,8 @@ int main(void)
     RUN_TEST(test_rejects_empty_permits);
     RUN_TEST(test_rejects_permit_too_long);
     RUN_TEST(test_append_normalizes_predicate_order);
+    RUN_TEST(test_append_normalizes_value_set_order);
+    RUN_TEST(test_rejects_invalid_manual_predicates);
     RUN_TEST(test_rejects_too_many_permits);
     RUN_TEST(test_normalization_is_order_independent);
     puts("intent unit tests: ok");

--- a/test/intent_unit.c
+++ b/test/intent_unit.c
@@ -170,9 +170,10 @@ static int test_rejects_invalid_and_duplicate_permits(void)
     CHECK(intent_add_permit(&intent, "tcp/10.0.0.10: 443", &err) == -1);
     CHECK(strcmp(err, "invalid permit") == 0);
     CHECK(intent_add_permit(&intent, "dns/10.0.0.53:53", &err) == -1);
-    CHECK(strcmp(err, "invalid permit") == 0);
+    CHECK(strcmp(err, "dns permits do not accept a port") == 0);
     CHECK(intent_add_permit(&intent, "icmp/10.0.0.10", &err) == -1);
     CHECK(strcmp(err, "unsupported permit") == 0);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", NULL) == -1);
     CHECK(intent_add_permit(&intent, "arp", &err) == 0);
     CHECK(intent_add_permit(&intent, "arp", &err) == -1);
     CHECK(strcmp(err, "duplicate permit") == 0);
@@ -198,6 +199,24 @@ static int test_rejects_duplicate_lowered_permits(void)
     CHECK(intent_add_permit(&intent, "udp/10.0.0.20:123", &err) == 0);
     CHECK(intent_add_permit(&intent, "udp/10.0.0.20:123", &err) == -1);
     CHECK(strcmp(err, "duplicate permit") == 0);
+
+    return 0;
+}
+
+static int test_rejects_empty_permits(void)
+{
+    struct intent intent = {0};
+    struct intent_permit permit;
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    intent_permit_init(&permit);
+
+    CHECK(intent_append_permit(&intent, &permit, &err) == -1);
+    CHECK(strcmp(err, "permit has no predicates") == 0);
+    CHECK(intent.permit_count == 0);
+    CHECK(intent_append_permit(&intent, &permit, NULL) == -1);
+    CHECK(intent.permit_count == 0);
 
     return 0;
 }
@@ -299,6 +318,7 @@ int main(void)
     RUN_TEST(test_parse_ipv4_addresses);
     RUN_TEST(test_rejects_invalid_and_duplicate_permits);
     RUN_TEST(test_rejects_duplicate_lowered_permits);
+    RUN_TEST(test_rejects_empty_permits);
     RUN_TEST(test_rejects_permit_too_long);
     RUN_TEST(test_append_normalizes_predicate_order);
     RUN_TEST(test_rejects_too_many_permits);

--- a/test/intent_unit.c
+++ b/test/intent_unit.c
@@ -1,0 +1,266 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "api/intent.h"
+
+#define CHECK(condition)                                                       \
+    do                                                                         \
+    {                                                                          \
+        if (!(condition))                                                      \
+        {                                                                      \
+            fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, __LINE__,   \
+                    #condition);                                               \
+            return -1;                                                         \
+        }                                                                      \
+    } while (0)
+
+#define CHECK_PREDICATE(...)                                                   \
+    do                                                                         \
+    {                                                                          \
+        if (check_predicate(__VA_ARGS__) != 0)                                 \
+            return -1;                                                         \
+    } while (0)
+
+#define RUN_TEST(test)                                                         \
+    do                                                                         \
+    {                                                                          \
+        if ((test)() != 0)                                                     \
+            return 1;                                                          \
+    } while (0)
+
+static int check_predicate(const struct intent_predicate *predicate,
+                           enum intent_predicate_field field,
+                           enum intent_predicate_op op,
+                           size_t value_count,
+                           uint32_t first,
+                           uint32_t second)
+{
+    CHECK(predicate->field == field);
+    CHECK(predicate->op == op);
+    CHECK(predicate->values.count == value_count);
+    CHECK(predicate->values.values[0] == first);
+    if (value_count > 1)
+        CHECK(predicate->values.values[1] == second);
+    return 0;
+}
+
+static int test_parse_first_permits(void)
+{
+    struct intent intent = {0};
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+
+    CHECK(intent_add_permit(&intent, "arp", &err) == 0);
+    CHECK(intent_add_permit(&intent, "dns/10.0.0.53", &err) == 0);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10:443", &err) == 0);
+    CHECK(intent_add_permit(&intent, "udp/10.0.0.20:123", &err) == 0);
+
+    CHECK(intent.direction == INTENT_DIRECTION_EGRESS);
+    CHECK(intent.default_action == INTENT_ACTION_DROP);
+    CHECK(intent.permit_count == 4);
+    CHECK(intent.forbid_count == 0);
+
+    CHECK(intent.permits[0].predicate_count == 1);
+    CHECK_PREDICATE(&intent.permits[0].predicates[0],
+                    INTENT_FIELD_ETH_TYPE,
+                    INTENT_OP_EQ,
+                    1,
+                    INTENT_ETH_P_ARP,
+                    0);
+
+    CHECK(intent.permits[1].predicate_count == 4);
+    CHECK_PREDICATE(&intent.permits[1].predicates[0],
+                    INTENT_FIELD_ETH_TYPE,
+                    INTENT_OP_EQ,
+                    1,
+                    INTENT_ETH_P_IP,
+                    0);
+    CHECK_PREDICATE(&intent.permits[1].predicates[1],
+                    INTENT_FIELD_IP_DST,
+                    INTENT_OP_EQ,
+                    1,
+                    0x0a000035,
+                    0);
+    CHECK_PREDICATE(&intent.permits[1].predicates[2],
+                    INTENT_FIELD_IP_PROTO,
+                    INTENT_OP_IN,
+                    2,
+                    INTENT_IPPROTO_TCP,
+                    INTENT_IPPROTO_UDP);
+    CHECK_PREDICATE(&intent.permits[1].predicates[3],
+                    INTENT_FIELD_L4_DST_PORT,
+                    INTENT_OP_EQ,
+                    1,
+                    INTENT_DNS_PORT,
+                    0);
+
+    CHECK(intent.permits[2].predicate_count == 4);
+    CHECK_PREDICATE(&intent.permits[2].predicates[1],
+                    INTENT_FIELD_IP_DST,
+                    INTENT_OP_EQ,
+                    1,
+                    0x0a00000a,
+                    0);
+    CHECK_PREDICATE(&intent.permits[2].predicates[2],
+                    INTENT_FIELD_IP_PROTO,
+                    INTENT_OP_EQ,
+                    1,
+                    INTENT_IPPROTO_TCP,
+                    0);
+    CHECK_PREDICATE(&intent.permits[2].predicates[3],
+                    INTENT_FIELD_L4_DST_PORT,
+                    INTENT_OP_EQ,
+                    1,
+                    443,
+                    0);
+
+    CHECK(intent.permits[3].predicate_count == 4);
+    CHECK_PREDICATE(&intent.permits[3].predicates[1],
+                    INTENT_FIELD_IP_DST,
+                    INTENT_OP_EQ,
+                    1,
+                    0x0a000014,
+                    0);
+    CHECK_PREDICATE(&intent.permits[3].predicates[2],
+                    INTENT_FIELD_IP_PROTO,
+                    INTENT_OP_EQ,
+                    1,
+                    INTENT_IPPROTO_UDP,
+                    0);
+    CHECK_PREDICATE(&intent.permits[3].predicates[3],
+                    INTENT_FIELD_L4_DST_PORT,
+                    INTENT_OP_EQ,
+                    1,
+                    123,
+                    0);
+
+    return 0;
+}
+
+static int test_rejects_invalid_and_duplicate_permits(void)
+{
+    struct intent intent = {0};
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", &err) == -1);
+    CHECK(strcmp(err, "invalid permit") == 0);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10/443", &err) == -1);
+    CHECK(strcmp(err, "invalid permit") == 0);
+    CHECK(intent_add_permit(&intent, "udp/10.0.0.20:0", &err) == -1);
+    CHECK(strcmp(err, "invalid permit") == 0);
+    CHECK(intent_add_permit(&intent, "udp/10.0.0.20:65536", &err) == -1);
+    CHECK(strcmp(err, "invalid permit") == 0);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10:+443", &err) == -1);
+    CHECK(strcmp(err, "invalid permit") == 0);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10: 443", &err) == -1);
+    CHECK(strcmp(err, "invalid permit") == 0);
+    CHECK(intent_add_permit(&intent, "dns/10.0.0.53:53", &err) == -1);
+    CHECK(strcmp(err, "invalid permit") == 0);
+    CHECK(intent_add_permit(&intent, "icmp/10.0.0.10", &err) == -1);
+    CHECK(strcmp(err, "unsupported permit") == 0);
+    CHECK(intent_add_permit(&intent, "arp", &err) == 0);
+    CHECK(intent_add_permit(&intent, "arp", &err) == -1);
+    CHECK(strcmp(err, "duplicate permit") == 0);
+
+    return 0;
+}
+
+static int test_rejects_duplicate_lowered_permits(void)
+{
+    struct intent intent = {0};
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+
+    CHECK(intent_add_permit(&intent, "dns/10.0.0.53", &err) == 0);
+    CHECK(intent_add_permit(&intent, "dns/10.0.0.53", &err) == -1);
+    CHECK(strcmp(err, "duplicate permit") == 0);
+
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10:443", &err) == 0);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10:443", &err) == -1);
+    CHECK(strcmp(err, "duplicate permit") == 0);
+
+    CHECK(intent_add_permit(&intent, "udp/10.0.0.20:123", &err) == 0);
+    CHECK(intent_add_permit(&intent, "udp/10.0.0.20:123", &err) == -1);
+    CHECK(strcmp(err, "duplicate permit") == 0);
+
+    return 0;
+}
+
+static int test_rejects_permit_too_long(void)
+{
+    struct intent intent = {0};
+    char permit[129];
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+
+    memset(permit, 'a', sizeof(permit));
+    permit[sizeof(permit) - 1] = '\0';
+
+    CHECK(intent_add_permit(&intent, permit, &err) == -1);
+    CHECK(strcmp(err, "permit too long") == 0);
+
+    return 0;
+}
+
+static int test_rejects_too_many_permits(void)
+{
+    struct intent intent = {0};
+    char permit[64];
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    for (int i = 0; i < MAX_INTENT_PERMITS; i++)
+    {
+        snprintf(permit, sizeof(permit), "tcp/10.0.0.10:%d", 10000 + i);
+        CHECK(intent_add_permit(&intent, permit, &err) == 0);
+    }
+    CHECK(intent_add_permit(&intent, "udp/10.0.0.20:123", &err) == -1);
+    CHECK(strcmp(err, "too many permits") == 0);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10:10000", &err) == -1);
+    CHECK(strcmp(err, "duplicate permit") == 0);
+
+    return 0;
+}
+
+static int test_normalization_is_order_independent(void)
+{
+    struct intent a = {0};
+    struct intent b = {0};
+    const char *err = NULL;
+
+    intent_init(&a, INTENT_DIRECTION_EGRESS);
+    intent_init(&b, INTENT_DIRECTION_EGRESS);
+
+    CHECK(intent_add_permit(&a, "udp/10.0.0.20:123", &err) == 0);
+    CHECK(intent_add_permit(&a, "arp", &err) == 0);
+    CHECK(intent_add_permit(&a, "tcp/10.0.0.10:443", &err) == 0);
+
+    CHECK(intent_add_permit(&b, "tcp/10.0.0.10:443", &err) == 0);
+    CHECK(intent_add_permit(&b, "udp/10.0.0.20:123", &err) == 0);
+    CHECK(intent_add_permit(&b, "arp", &err) == 0);
+
+    intent_normalize(&a);
+    intent_normalize(&b);
+
+    CHECK(a.permit_count == b.permit_count);
+    for (size_t i = 0; i < a.permit_count; i++)
+        CHECK(intent_permit_equal(&a.permits[i], &b.permits[i]));
+
+    return 0;
+}
+
+int main(void)
+{
+    RUN_TEST(test_parse_first_permits);
+    RUN_TEST(test_rejects_invalid_and_duplicate_permits);
+    RUN_TEST(test_rejects_duplicate_lowered_permits);
+    RUN_TEST(test_rejects_permit_too_long);
+    RUN_TEST(test_rejects_too_many_permits);
+    RUN_TEST(test_normalization_is_order_independent);
+    puts("intent unit tests: ok");
+    return 0;
+}

--- a/xmake.lua
+++ b/xmake.lua
@@ -33,14 +33,22 @@ target_end()
 -- test
 add_requires("bats v1.11.1", { system = false })
 add_requires("mini_httpd", { system = false })
+target("intent-ir-unit")
+    set_kind("binary")
+    set_default(false)
+    add_includedirs(".")
+    add_files({ "test/intent_unit.c" }, { languages = { "c11" }})
+target_end()
+
 target("test")
     set_kind("phony")
-    add_deps("traffico", "traffico-cni")
+    add_deps("traffico", "traffico-cni", "intent-ir-unit")
     add_packages("bats", "mini_httpd")
     on_run(function (target)
         for _, name in ipairs(target:get("deps")) do
             os.addenv("PATH", path.absolute(target:dep(name):targetdir()))
         end
+        os.addenv("PATH", path.absolute("tools"))
         import("privilege.sudo")
         sudo.execv("bats", { "-t", "test/" })
     end)

--- a/xmake.lua
+++ b/xmake.lua
@@ -42,14 +42,51 @@ target_end()
 
 target("test")
     set_kind("phony")
-    add_deps("traffico", "traffico-cni", "intent-ir-unit")
     add_packages("bats", "mini_httpd")
     on_run(function (target)
-        for _, name in ipairs(target:get("deps")) do
-            os.addenv("PATH", path.absolute(target:dep(name):targetdir()))
+        import("core.base.option")
+        local bats_args = {"-t"}
+        local selected = table.wrap(option.get("arguments"))
+        local build_targets = {}
+        local selected_test_paths = 0
+        if #selected == 0 then
+            table.insert(bats_args, "test/")
+            build_targets = {"traffico", "traffico-cni", "intent-ir-unit"}
+        else
+            local needs_full_suite_targets = false
+            local needs_intent_ir_unit = false
+            for _, arg in ipairs(selected) do
+                table.insert(bats_args, arg)
+                if arg == "test" or arg == "test/" or arg:find("%.bats$") then
+                    selected_test_paths = selected_test_paths + 1
+                    if arg:find("intent_unit", 1, true) then
+                        needs_intent_ir_unit = true
+                    else
+                        needs_full_suite_targets = true
+                    end
+                end
+            end
+            if selected_test_paths == 0 then
+                table.insert(bats_args, "test/")
+                build_targets = {"traffico", "traffico-cni", "intent-ir-unit"}
+            elseif needs_full_suite_targets then
+                build_targets = {"traffico", "traffico-cni", "intent-ir-unit"}
+            elseif needs_intent_ir_unit then
+                build_targets = {"intent-ir-unit"}
+            end
+        end
+        for _, name in ipairs(build_targets) do
+            os.execv("xmake", {"build", "-y", name})
+        end
+        import("core.project.project")
+        for _, name in ipairs(build_targets) do
+            local built = project.target(name)
+            if built then
+                os.addenv("PATH", path.absolute(built:targetdir()))
+            end
         end
         os.addenv("PATH", path.absolute("tools"))
         import("privilege.sudo")
-        sudo.execv("bats", { "-t", "test/" })
+        sudo.execv("bats", bats_args)
     end)
 target_end()


### PR DESCRIPTION
## Summary

This is PR1 in the Intent compiler stack.

- Add the first `Intent` IR shape with typed predicates, top-level direction/default action, permit storage, reserved forbid storage, normalization, and duplicate detection.
- Add first permit lowering helpers for `arp`, `dns/IPv4`, `tcp/IPv4:PORT`, and `udp/IPv4:PORT` with plain user-facing errors like `invalid permit` and `duplicate permit`.
- Enforce predicate value invariants so malformed manual predicates, duplicate set values, invalid set shapes, and null permit input are rejected before later compiler layers see them.
- Add the `intent-ir-unit` xmake target and BATS wrapper, and update `xmake run test` so focused runs can build only the needed unit target while the full suite still builds and runs as before.

## Stack

- Base branch: `main`
- Head branch: `leox/managed-or-pr1-intent-ir`
- Head commit: `4ff640a99d819760b516a597dcaf2ac0620fb37b`

## Verification

- `git diff --check`
- stale terminology scans for old managed-policy / IntentPolicy / Policy IR wording outside local planning docs
- Focused Ubuntu Docker runner: `xmake f -c -y --generate-vmlinux=y --require-bpftool=y && xmake build -y intent-ir-unit && xmake run test test/intent_unit.bats`
- Also covered by the final top-of-stack privileged Ubuntu Docker run: `xmake f -c -y --generate-vmlinux=y --require-bpftool=y && xmake build -y && xmake run test` (`1..173`, exit 0)

## Notes

Private planning/spec notes under `docs/superpowers/` are intentionally not part of this PR.