### PR TITLE
feat(intent): add dry-run explain CLI

### DIFF
--- a/api/intent.h
+++ b/api/intent.h
@@ -516,11 +516,12 @@ static inline void intent_format_ip(uint32_t ip, char *buf, size_t len)
     inet_ntop(AF_INET, &addr, buf, len);
 }
 
-static inline int intent_print_explain(FILE *out,
-                                       const char *ifname,
-                                       const struct intent *intent)
+static inline void intent_print_explain(FILE *out,
+                                        const char *ifname,
+                                        const struct intent *intent)
 {
     char ip[INET_ADDRSTRLEN];
+    bool has_l4_permits = false;
 
     fprintf(out, "traffico intent\n");
     fprintf(out, "interface: %s\n", ifname);
@@ -551,6 +552,7 @@ static inline int intent_print_explain(FILE *out,
             intent_permit_has_proto_in_tcp_udp(permit) &&
             port == INTENT_DNS_PORT)
         {
+            has_l4_permits = true;
             intent_format_ip(ip_dst, ip, sizeof(ip));
             fprintf(out, "  %zu. DNS to %s over TCP or UDP destination port 53\n",
                     i + 1,
@@ -565,6 +567,7 @@ static inline int intent_print_explain(FILE *out,
             intent_permit_get_eq(permit, INTENT_FIELD_L4_DST_PORT, &port) &&
             proto == INTENT_IPPROTO_TCP)
         {
+            has_l4_permits = true;
             intent_format_ip(ip_dst, ip, sizeof(ip));
             fprintf(out, "  %zu. TCP to %s destination port %u\n",
                     i + 1,
@@ -580,6 +583,7 @@ static inline int intent_print_explain(FILE *out,
             intent_permit_get_eq(permit, INTENT_FIELD_L4_DST_PORT, &port) &&
             proto == INTENT_IPPROTO_UDP)
         {
+            has_l4_permits = true;
             intent_format_ip(ip_dst, ip, sizeof(ip));
             fprintf(out, "  %zu. UDP to %s destination port %u\n",
                     i + 1,
@@ -593,9 +597,9 @@ static inline int intent_print_explain(FILE *out,
 
     fprintf(out, "\ndropped traffic:\n");
     fprintf(out, "  - malformed packets that cannot be safely classified\n");
-    fprintf(out, "  - TCP/UDP fragments whose destination port cannot be checked\n");
+    if (has_l4_permits)
+        fprintf(out, "  - TCP/UDP fragments whose destination port cannot be checked\n");
     fprintf(out, "  - any traffic not matching a permit\n");
-    return 0;
 }
 
 #endif

--- a/api/intent.h
+++ b/api/intent.h
@@ -501,10 +501,21 @@ static inline bool intent_permit_has_proto_in_tcp_udp(const struct intent_permit
         const struct intent_predicate *predicate = &permit->predicates[i];
         if (predicate->field == INTENT_FIELD_IP_PROTO &&
             predicate->op == INTENT_OP_IN &&
-            predicate->values.count == 2 &&
-            predicate->values.values[0] == INTENT_IPPROTO_TCP &&
-            predicate->values.values[1] == INTENT_IPPROTO_UDP)
-            return true;
+            predicate->values.count == 2)
+        {
+            bool has_tcp = false;
+            bool has_udp = false;
+
+            for (size_t j = 0; j < predicate->values.count; j++)
+            {
+                if (predicate->values.values[j] == INTENT_IPPROTO_TCP)
+                    has_tcp = true;
+                if (predicate->values.values[j] == INTENT_IPPROTO_UDP)
+                    has_udp = true;
+            }
+            if (has_tcp && has_udp)
+                return true;
+        }
     }
     return false;
 }

--- a/api/intent.h
+++ b/api/intent.h
@@ -4,6 +4,7 @@
 #include <arpa/inet.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -473,6 +474,128 @@ static inline void intent_normalize(struct intent *intent)
           intent->permit_count,
           sizeof(intent->permits[0]),
           intent_permit_compare);
+}
+
+static inline bool intent_permit_get_eq(const struct intent_permit *permit,
+                                        enum intent_predicate_field field,
+                                        uint32_t *out)
+{
+    for (size_t i = 0; i < permit->predicate_count; i++)
+    {
+        const struct intent_predicate *predicate = &permit->predicates[i];
+        if (predicate->field == field &&
+            predicate->op == INTENT_OP_EQ &&
+            predicate->values.count == 1)
+        {
+            *out = predicate->values.values[0];
+            return true;
+        }
+    }
+    return false;
+}
+
+static inline bool intent_permit_has_proto_in_tcp_udp(const struct intent_permit *permit)
+{
+    for (size_t i = 0; i < permit->predicate_count; i++)
+    {
+        const struct intent_predicate *predicate = &permit->predicates[i];
+        if (predicate->field == INTENT_FIELD_IP_PROTO &&
+            predicate->op == INTENT_OP_IN &&
+            predicate->values.count == 2 &&
+            predicate->values.values[0] == INTENT_IPPROTO_TCP &&
+            predicate->values.values[1] == INTENT_IPPROTO_UDP)
+            return true;
+    }
+    return false;
+}
+
+static inline void intent_format_ip(uint32_t ip, char *buf, size_t len)
+{
+    struct in_addr addr = {0};
+    addr.s_addr = htonl(ip);
+    inet_ntop(AF_INET, &addr, buf, len);
+}
+
+static inline int intent_print_explain(FILE *out,
+                                       const char *ifname,
+                                       const struct intent *intent)
+{
+    char ip[INET_ADDRSTRLEN];
+
+    fprintf(out, "traffico intent\n");
+    fprintf(out, "interface: %s\n", ifname);
+    fprintf(out, "direction: %s\n",
+            intent->direction == INTENT_DIRECTION_EGRESS ? "egress" : "ingress");
+    fprintf(out, "default: drop\n\n");
+    fprintf(out, "permitted traffic:\n");
+
+    for (size_t i = 0; i < intent->permit_count; i++)
+    {
+        const struct intent_permit *permit = &intent->permits[i];
+        uint32_t eth_type = 0;
+        uint32_t ip_dst = 0;
+        uint32_t proto = 0;
+        uint32_t port = 0;
+
+        if (intent_permit_get_eq(permit, INTENT_FIELD_ETH_TYPE, &eth_type) &&
+            eth_type == INTENT_ETH_P_ARP)
+        {
+            fprintf(out, "  %zu. ARP\n", i + 1);
+            continue;
+        }
+
+        if (intent_permit_get_eq(permit, INTENT_FIELD_ETH_TYPE, &eth_type) &&
+            eth_type == INTENT_ETH_P_IP &&
+            intent_permit_get_eq(permit, INTENT_FIELD_IP_DST, &ip_dst) &&
+            intent_permit_get_eq(permit, INTENT_FIELD_L4_DST_PORT, &port) &&
+            intent_permit_has_proto_in_tcp_udp(permit) &&
+            port == INTENT_DNS_PORT)
+        {
+            intent_format_ip(ip_dst, ip, sizeof(ip));
+            fprintf(out, "  %zu. DNS to %s over TCP or UDP destination port 53\n",
+                    i + 1,
+                    ip);
+            continue;
+        }
+
+        if (intent_permit_get_eq(permit, INTENT_FIELD_ETH_TYPE, &eth_type) &&
+            eth_type == INTENT_ETH_P_IP &&
+            intent_permit_get_eq(permit, INTENT_FIELD_IP_DST, &ip_dst) &&
+            intent_permit_get_eq(permit, INTENT_FIELD_IP_PROTO, &proto) &&
+            intent_permit_get_eq(permit, INTENT_FIELD_L4_DST_PORT, &port) &&
+            proto == INTENT_IPPROTO_TCP)
+        {
+            intent_format_ip(ip_dst, ip, sizeof(ip));
+            fprintf(out, "  %zu. TCP to %s destination port %u\n",
+                    i + 1,
+                    ip,
+                    port);
+            continue;
+        }
+
+        if (intent_permit_get_eq(permit, INTENT_FIELD_ETH_TYPE, &eth_type) &&
+            eth_type == INTENT_ETH_P_IP &&
+            intent_permit_get_eq(permit, INTENT_FIELD_IP_DST, &ip_dst) &&
+            intent_permit_get_eq(permit, INTENT_FIELD_IP_PROTO, &proto) &&
+            intent_permit_get_eq(permit, INTENT_FIELD_L4_DST_PORT, &port) &&
+            proto == INTENT_IPPROTO_UDP)
+        {
+            intent_format_ip(ip_dst, ip, sizeof(ip));
+            fprintf(out, "  %zu. UDP to %s destination port %u\n",
+                    i + 1,
+                    ip,
+                    port);
+            continue;
+        }
+
+        fprintf(out, "  %zu. unsupported normalized permit\n", i + 1);
+    }
+
+    fprintf(out, "\ndropped traffic:\n");
+    fprintf(out, "  - malformed packets that cannot be safely classified\n");
+    fprintf(out, "  - TCP/UDP fragments whose destination port cannot be checked\n");
+    fprintf(out, "  - any traffic not matching a permit\n");
+    return 0;
 }
 
 #endif

--- a/api/intent.h
+++ b/api/intent.h
@@ -588,7 +588,7 @@ static inline int intent_print_explain(FILE *out,
             continue;
         }
 
-        fprintf(out, "  %zu. unsupported normalized permit\n", i + 1);
+        fprintf(out, "  %zu. permit cannot be explained by this traffico version\n", i + 1);
     }
 
     fprintf(out, "\ndropped traffic:\n");

--- a/api/intent.h
+++ b/api/intent.h
@@ -523,6 +523,10 @@ static inline void intent_print_explain(FILE *out,
     char ip[INET_ADDRSTRLEN];
     bool has_l4_permits = false;
 
+    /*
+     * The caller passes a normalized Intent.
+     * That keeps explain output stable across CLI input order.
+     */
     fprintf(out, "traffico intent\n");
     fprintf(out, "interface: %s\n", ifname);
     fprintf(out, "direction: %s\n",
@@ -597,6 +601,7 @@ static inline void intent_print_explain(FILE *out,
 
     fprintf(out, "\ndropped traffic:\n");
     fprintf(out, "  - malformed packets that cannot be safely classified\n");
+    /* Only mention fragment policy when a permit depends on L4 ports. */
     if (has_l4_permits)
         fprintf(out, "  - TCP/UDP fragments whose destination port cannot be checked\n");
     fprintf(out, "  - any traffic not matching a permit\n");

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -65,6 +65,13 @@ bats_require_minimum_version 1.7.0
     [ "${lines[0]}" == "traffico: unsupported --explain mode: 'dag'" ]
 }
 
+@test "--explain=intent is the explicit Intent explain mode" {
+    run traffico -i lo --allow arp --dry-run --explain=intent
+    [ $status -eq 0 ]
+    [[ "$output" == *"traffico intent"* ]]
+    [[ "$output" == *"permitted traffic:"* ]]
+}
+
 @test "Intent mode rejects ingress until designed" {
     run traffico -i lo --at ingress --allow arp --dry-run
     [ $status -eq 1 ]

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -65,6 +65,12 @@ bats_require_minimum_version 1.7.0
     [ "${lines[0]}" == "traffico: unsupported --explain mode: 'dag'" ]
 }
 
+@test "Intent mode rejects ingress until designed" {
+    run traffico -i lo --at ingress --allow arp --dry-run
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: intent currently supports --at egress only" ]
+}
+
 @test "invalid option" {
     run traffico -x
     [ ! $status -eq 0 ]

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -28,6 +28,13 @@ bats_require_minimum_version 1.7.0
     [[ "$output" == *"intent backend: not implemented"* ]]
 }
 
+@test "--permit is an alias for --allow" {
+    run traffico -i lo --at egress --permit tcp/10.0.0.10:443 --dry-run
+    [ $status -eq 0 ]
+    [[ "$output" == *"intent dry-run: compiler ok"* ]]
+    [[ "$output" == *"intent backend: not implemented"* ]]
+}
+
 @test "invalid option" {
     run traffico -x
     [ ! $status -eq 0 ]

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -35,6 +35,24 @@ bats_require_minimum_version 1.7.0
     [[ "$output" == *"intent backend: not implemented"* ]]
 }
 
+@test "--allow and --chain are mutually exclusive" {
+    run traffico -i lo --allow arp --chain "allow_ethertype:arp" --dry-run
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: --allow/--permit and --chain are mutually exclusive" ]
+}
+
+@test "--allow and positional program are mutually exclusive" {
+    run traffico -i lo --allow arp nop --dry-run
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: --allow/--permit and positional PROGRAM arguments are mutually exclusive" ]
+}
+
+@test "--dry-run requires Intent mode" {
+    run traffico -i lo --dry-run nop
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: --dry-run currently requires --allow or --permit" ]
+}
+
 @test "invalid option" {
     run traffico -x
     [ ! $status -eq 0 ]

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -53,6 +53,18 @@ bats_require_minimum_version 1.7.0
     [ "${lines[0]}" == "traffico: --dry-run currently requires --allow or --permit" ]
 }
 
+@test "--explain requires Intent mode" {
+    run traffico -i lo --explain nop
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: --explain currently requires --allow or --permit" ]
+}
+
+@test "--explain=dag is reserved for future Intent debug output" {
+    run traffico -i lo --allow arp --dry-run --explain=dag
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: unsupported --explain mode: 'dag'" ]
+}
+
 @test "invalid option" {
     run traffico -x
     [ ! $status -eq 0 ]

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -7,13 +7,25 @@ bats_require_minimum_version 1.7.0
 @test "help" {
     run traffico --help
     [ $status -eq 0 ]
-    [ "${lines[0]}" == 'Usage: traffico [OPTION...] PROGRAM [INPUT]' ]
+    [ "${lines[0]}" == 'Usage: traffico [OPTION...] [PROGRAM [INPUT]]' ]
 }
 
 @test "usage" {
     run traffico --usage
     [ $status -eq 0 ]
     [ "${lines[0]%% *}" == 'Usage:' ]
+}
+
+@test "--allow accepts first Intent values in dry-run mode" {
+    run traffico -i lo --at egress \
+        --allow arp \
+        --allow dns/10.0.0.53 \
+        --allow tcp/10.0.0.10:443 \
+        --allow udp/10.0.0.20:123 \
+        --dry-run
+    [ $status -eq 0 ]
+    [[ "$output" == *"intent dry-run: compiler ok"* ]]
+    [[ "$output" == *"intent backend: not implemented"* ]]
 }
 
 @test "invalid option" {

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -71,6 +71,35 @@ bats_require_minimum_version 1.7.0
     [ "${lines[0]}" == "traffico: intent currently supports --at egress only" ]
 }
 
+@test "--allow rejects malformed values" {
+    run traffico -i lo --allow tcp/10.0.0.10 --dry-run
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: invalid permit: 'tcp/10.0.0.10'" ]
+}
+
+@test "--allow rejects unsupported Intent value" {
+    run traffico -i lo --allow icmp/10.0.0.10 --dry-run
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: unsupported permit: 'icmp/10.0.0.10'" ]
+}
+
+@test "--allow rejects duplicate permits" {
+    run traffico -i lo --allow arp --allow arp --dry-run
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: duplicate permit: 'arp'" ]
+}
+
+@test "--allow rejects too many permits" {
+    args=(-i lo --dry-run)
+    for port in {10000..10032}; do
+        args+=(--allow "tcp/10.0.0.10:${port}")
+    done
+
+    run traffico "${args[@]}"
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: too many permits: 'tcp/10.0.0.10:10032'" ]
+}
+
 @test "invalid option" {
     run traffico -x
     [ ! $status -eq 0 ]

--- a/test/intent.bats
+++ b/test/intent.bats
@@ -1,0 +1,11 @@
+#!/usr/bin/env bats
+
+load helpers
+export BATS_TEST_NAME_PREFIX=$(setsuite)
+bats_require_minimum_version 1.7.0
+
+@test "Intent live attach is rejected until backend is implemented" {
+    run traffico -i lo --at egress --allow arp
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: intent attach backend is not implemented; use --dry-run" ]
+}

--- a/test/intent.bats
+++ b/test/intent.bats
@@ -44,6 +44,7 @@ teardown() {
         --allow udp/10.0.0.20:123 \
         --allow arp \
         --allow tcp/10.0.0.10:443 \
+        --allow dns/10.0.0.53 \
         --dry-run --explain
     [ $status -eq 0 ]
     [ "${lines[0]}" == "traffico intent" ]
@@ -53,13 +54,17 @@ teardown() {
     [[ "$output" == *"  1. ARP"* ]]
     [[ "$output" == *"  2. TCP to 10.0.0.10 destination port 443"* ]]
     [[ "$output" == *"  3. UDP to 10.0.0.20 destination port 123"* ]]
+    [[ "$output" == *"  4. DNS to 10.0.0.53 over TCP or UDP destination port 53"* ]]
+    [[ "$output" == *"TCP/UDP fragments whose destination port cannot be checked"* ]]
 }
 
 @test "--explain prints deterministic intent before live attach rejection" {
-    run traffico -i lo --at egress --allow arp --explain
+    run --separate-stderr traffico -i lo --at egress --allow arp --explain
     [ $status -eq 1 ]
-    [ "${lines[0]}" == "traffico intent" ]
-    [[ "$output" == *"permitted traffic:"* ]]
-    [[ "$output" == *"  1. ARP"* ]]
-    [[ "$output" == *"traffico: intent attach backend is not implemented; use --dry-run"* ]]
+    [ "$output" = "" ]
+    [[ "$stderr" == *"traffico intent"* ]]
+    [[ "$stderr" == *"permitted traffic:"* ]]
+    [[ "$stderr" == *"  1. ARP"* ]]
+    [[ "$stderr" != *"TCP/UDP fragments whose destination port cannot be checked"* ]]
+    [[ "$stderr" == *"traffico: intent attach backend is not implemented; use --dry-run"* ]]
 }

--- a/test/intent.bats
+++ b/test/intent.bats
@@ -39,6 +39,21 @@ teardown() {
     [ "$output" = "" ]
 }
 
+@test "--dry-run does not require an attach interface" {
+    run ip netns exec "${NETNS}" ip route del default
+    [ $status -eq 0 ]
+
+    run ip netns exec "${NETNS}" traffico --at egress \
+        --allow arp \
+        --dry-run --explain
+    [ $status -eq 0 ]
+    [ "${lines[1]}" == "interface: not attached" ]
+    [[ "$output" == *"intent dry-run: compiler ok"* ]]
+
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$output" = "" ]
+}
+
 @test "--dry-run --explain prints deterministic intent" {
     run traffico -i lo --at egress \
         --allow udp/10.0.0.20:123 \

--- a/test/intent.bats
+++ b/test/intent.bats
@@ -9,3 +9,19 @@ bats_require_minimum_version 1.7.0
     [ $status -eq 1 ]
     [ "${lines[0]}" == "traffico: intent attach backend is not implemented; use --dry-run" ]
 }
+
+@test "--dry-run --explain prints deterministic intent" {
+    run traffico -i lo --at egress \
+        --allow udp/10.0.0.20:123 \
+        --allow arp \
+        --allow tcp/10.0.0.10:443 \
+        --dry-run --explain
+    [ $status -eq 0 ]
+    [ "${lines[0]}" == "traffico intent" ]
+    [ "${lines[1]}" == "interface: lo" ]
+    [ "${lines[2]}" == "direction: egress" ]
+    [ "${lines[3]}" == "default: drop" ]
+    [[ "$output" == *"  1. ARP"* ]]
+    [[ "$output" == *"  2. TCP to 10.0.0.10 destination port 443"* ]]
+    [[ "$output" == *"  3. UDP to 10.0.0.20 destination port 123"* ]]
+}

--- a/test/intent.bats
+++ b/test/intent.bats
@@ -4,10 +4,36 @@ load helpers
 export BATS_TEST_NAME_PREFIX=$(setsuite)
 bats_require_minimum_version 1.7.0
 
+setup() {
+    load net
+    NETNS="ns$((RANDOM % 10))"
+    new_netns "${NETNS}"
+    setup_net "${NETNS}"
+}
+
+teardown() {
+    killall traffico &>/dev/null || true
+    del_netdev
+    del_netns "${NETNS}"
+}
+
 @test "Intent live attach is rejected until backend is implemented" {
     run traffico -i lo --at egress --allow arp
     [ $status -eq 1 ]
     [ "${lines[0]}" == "traffico: intent attach backend is not implemented; use --dry-run" ]
+}
+
+@test "--dry-run validates Intent without attaching" {
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress \
+        --allow arp \
+        --allow "tcp/${VETH_ADDR}:443" \
+        --dry-run
+    [ $status -eq 0 ]
+    [[ "$output" == *"intent dry-run: compiler ok"* ]]
+    [[ "$output" == *"intent backend: not implemented"* ]]
+
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$output" = "" ]
 }
 
 @test "--dry-run --explain prints deterministic intent" {

--- a/test/intent.bats
+++ b/test/intent.bats
@@ -18,9 +18,12 @@ teardown() {
 }
 
 @test "Intent live attach is rejected until backend is implemented" {
-    run traffico -i lo --at egress --allow arp
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress --allow arp
     [ $status -eq 1 ]
     [ "${lines[0]}" == "traffico: intent attach backend is not implemented; use --dry-run" ]
+
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$output" = "" ]
 }
 
 @test "--dry-run validates Intent without attaching" {
@@ -50,4 +53,13 @@ teardown() {
     [[ "$output" == *"  1. ARP"* ]]
     [[ "$output" == *"  2. TCP to 10.0.0.10 destination port 443"* ]]
     [[ "$output" == *"  3. UDP to 10.0.0.20 destination port 123"* ]]
+}
+
+@test "--explain prints deterministic intent before live attach rejection" {
+    run traffico -i lo --at egress --allow arp --explain
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico intent" ]
+    [[ "$output" == *"permitted traffic:"* ]]
+    [[ "$output" == *"  1. ARP"* ]]
+    [[ "$output" == *"traffico: intent attach backend is not implemented; use --dry-run"* ]]
 }

--- a/traffico.c
+++ b/traffico.c
@@ -49,6 +49,9 @@ const char OPT_PERMIT_LONG[] = "permit";
 const char OPT_PERMIT_ARG[] = "PERMIT";
 #define OPT_DRY_RUN_KEY 0x85
 const char OPT_DRY_RUN_LONG[] = "dry-run";
+#define OPT_EXPLAIN_KEY 0x86
+const char OPT_EXPLAIN_LONG[] = "explain";
+const char OPT_EXPLAIN_ARG[] = "intent|dag";
 
 const struct argp_option argp_opts[] = {
 
@@ -61,6 +64,7 @@ const struct argp_option argp_opts[] = {
     {OPT_ALLOW_LONG, OPT_ALLOW_KEY, OPT_ALLOW_ARG, 0, "Add an Intent permit", 1},
     {OPT_PERMIT_LONG, OPT_PERMIT_KEY, OPT_PERMIT_ARG, 0, "Alias for --allow", 1},
     {OPT_DRY_RUN_LONG, OPT_DRY_RUN_KEY, NULL, 0, "Validate Intent without attaching", 1},
+    {OPT_EXPLAIN_LONG, OPT_EXPLAIN_KEY, OPT_EXPLAIN_ARG, OPTION_ARG_OPTIONAL, "Print normalized Intent", 1},
     {"", 0, 0, OPTION_DOC, 0, 0},
     {0} // .
 
@@ -73,6 +77,7 @@ static char *g_chain_arg = NULL;
 static struct intent g_intent;
 static bool g_intent_mode = false;
 static bool g_intent_dry_run = false;
+static bool g_intent_explain = false;
 
 #define log_erro(fmt, ...) \
     log_err(&g_config, fmt, ##__VA_ARGS__);
@@ -138,6 +143,7 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
         intent_init(&g_intent, INTENT_DIRECTION_EGRESS);
         g_intent_mode = false;
         g_intent_dry_run = false;
+        g_intent_explain = false;
         break;
 
     // Options
@@ -184,6 +190,13 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
     case OPT_DRY_RUN_KEY:
         g_intent_dry_run = true;
         break;
+    case OPT_EXPLAIN_KEY:
+        g_intent_explain = true;
+        if (arg && strcmp(arg, "intent") != 0)
+        {
+            argp_error(state, "unsupported --explain mode: '%s'", arg);
+        }
+        break;
 
     // Arguments
     case ARGP_KEY_ARG:
@@ -224,6 +237,10 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
         if (g_intent_dry_run && !g_intent_mode)
         {
             argp_error(state, "--dry-run currently requires --allow or --permit");
+        }
+        if (g_intent_explain && !g_intent_mode)
+        {
+            argp_error(state, "--explain currently requires --allow or --permit");
         }
 
         // In chain or Intent mode, positional args are not required

--- a/traffico.c
+++ b/traffico.c
@@ -12,6 +12,7 @@
 #include <bpf/libbpf.h>
 
 #include "api.h"
+#include "api/dag.h"
 #include "api/input_parse.h"
 #include "chain.h"
 
@@ -40,6 +41,11 @@ const char OPT_NO_CLEANUP_LONG[] = "no-cleanup";
 #define OPT_CHAIN_KEY 0x82
 const char OPT_CHAIN_LONG[] = "chain";
 const char OPT_CHAIN_ARG[] = "PROG:INPUT,...";
+#define OPT_ALLOW_KEY 0x83
+const char OPT_ALLOW_LONG[] = "allow";
+const char OPT_ALLOW_ARG[] = "PERMIT";
+#define OPT_DRY_RUN_KEY 0x84
+const char OPT_DRY_RUN_LONG[] = "dry-run";
 
 const struct argp_option argp_opts[] = {
 
@@ -49,6 +55,8 @@ const struct argp_option argp_opts[] = {
     {OPT_ATTACH_LONG, OPT_ATTACH_KEY, OPT_ATTACH_ARG, 0, "Where to attach the filter (defaults to egress)", 1},
     {OPT_NO_CLEANUP_LONG, OPT_NO_CLEANUP_KEY, NULL, 0, "Do not detach the TC hook and filter at the exit", 1},
     {OPT_CHAIN_LONG, OPT_CHAIN_KEY, OPT_CHAIN_ARG, 0, "Attach a chain of programs (e.g., allow_ipv4:10.0.0.1,allow_port:8080)", 1},
+    {OPT_ALLOW_LONG, OPT_ALLOW_KEY, OPT_ALLOW_ARG, 0, "Add an Intent permit", 1},
+    {OPT_DRY_RUN_LONG, OPT_DRY_RUN_KEY, NULL, 0, "Validate Intent without attaching", 1},
     {"", 0, 0, OPTION_DOC, 0, 0},
     {0} // .
 
@@ -58,6 +66,9 @@ static struct config g_config;
 static struct chain_entry g_chain[MAX_CHAIN_LEN];
 static int g_chain_len = 0;
 static char *g_chain_arg = NULL;
+static struct intent g_intent;
+static bool g_intent_mode = false;
+static bool g_intent_dry_run = false;
 
 #define log_erro(fmt, ...) \
     log_err(&g_config, fmt, ##__VA_ARGS__);
@@ -108,6 +119,7 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
 {
     int ifindex;
     int p;
+    const char *err_msg = NULL;
     switch (key)
     {
 
@@ -119,6 +131,9 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
         g_config.verbose = false;
         g_config.err_stream = state->err_stream = stderr;
         g_config.out_stream = state->out_stream = stdout;
+        intent_init(&g_intent, INTENT_DIRECTION_EGRESS);
+        g_intent_mode = false;
+        g_intent_dry_run = false;
         break;
 
     // Options
@@ -154,6 +169,16 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
     case OPT_CHAIN_KEY:
         g_chain_arg = arg;
         break;
+    case OPT_ALLOW_KEY:
+        g_intent_mode = true;
+        if (intent_add_permit(&g_intent, arg, &err_msg) != 0)
+        {
+            argp_error(state, "%s: '%s'", err_msg, arg);
+        }
+        break;
+    case OPT_DRY_RUN_KEY:
+        g_intent_dry_run = true;
+        break;
 
     // Arguments
     case ARGP_KEY_ARG:
@@ -183,8 +208,21 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
         break;
 
     case ARGP_KEY_END:
-        // In chain mode, positional args are not required
-        if (!g_chain_arg)
+        if (g_intent_mode && g_chain_arg)
+        {
+            argp_error(state, "--allow and --chain are mutually exclusive");
+        }
+        if (g_intent_mode && state->arg_num > 0)
+        {
+            argp_error(state, "--allow and positional PROGRAM arguments are mutually exclusive");
+        }
+        if (g_intent_dry_run && !g_intent_mode)
+        {
+            argp_error(state, "--dry-run currently requires --allow");
+        }
+
+        // In chain or Intent mode, positional args are not required
+        if (!g_chain_arg && !g_intent_mode)
         {
             if (state->arg_num == 0)
             {
@@ -307,6 +345,13 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
                     argp_error(state, "%s", validation_err);
             }
         }
+        else if (g_intent_mode)
+        {
+            if (g_config.attach_point == BPF_TC_INGRESS)
+                g_intent.direction = INTENT_DIRECTION_INGRESS;
+            else
+                g_intent.direction = INTENT_DIRECTION_EGRESS;
+        }
         else
         {
             // Single program mode: parse input value
@@ -334,7 +379,7 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
 static const struct argp argp = {
     .options = argp_opts,
     .parser = parse_cli,
-    .args_doc = "PROGRAM [INPUT]",
+    .args_doc = "[PROGRAM [INPUT]]",
     .doc = argp_program_doc,
 };
 
@@ -369,6 +414,24 @@ int await(struct bpf_tc_hook hook, struct bpf_tc_opts opts)
     return 0;
 }
 
+static int intent_dry_run(void)
+{
+    struct decision_dag dag = {0};
+    const char *err_msg = NULL;
+
+    intent_normalize(&g_intent);
+    if (intent_build_dag(&g_intent, &dag, &err_msg) != 0 ||
+        intent_validate_supported_subset(&dag, &err_msg) != 0)
+    {
+        fprintf(g_config.err_stream, TOOL_NAME ": intent dry-run: %s\n", err_msg);
+        return 1;
+    }
+
+    fprintf(g_config.out_stream, "intent dry-run: compiler ok\n");
+    fprintf(g_config.out_stream, "intent backend: not implemented\n");
+    return 0;
+}
+
 int main(int argc, char **argv)
 {
     int err;
@@ -380,6 +443,11 @@ int main(int argc, char **argv)
     if (err)
     {
         return 1;
+    }
+
+    if (g_intent_mode && g_intent_dry_run)
+    {
+        return intent_dry_run();
     }
 
     // Setup signal handling

--- a/traffico.c
+++ b/traffico.c
@@ -242,6 +242,10 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
         {
             argp_error(state, "--explain currently requires --allow or --permit");
         }
+        if (g_intent_mode && g_config.attach_point != BPF_TC_EGRESS)
+        {
+            argp_error(state, "intent currently supports --at egress only");
+        }
 
         // In chain or Intent mode, positional args are not required
         if (!g_chain_arg && !g_intent_mode)

--- a/traffico.c
+++ b/traffico.c
@@ -475,6 +475,11 @@ int main(int argc, char **argv)
     {
         return intent_dry_run();
     }
+    if (g_intent_mode)
+    {
+        fprintf(g_config.err_stream, TOOL_NAME ": intent attach backend is not implemented; use --dry-run\n");
+        return 1;
+    }
 
     // Setup signal handling
     if (signal(SIGINT, sig_handler) == SIG_ERR || signal(SIGTERM, sig_handler) == SIG_ERR)

--- a/traffico.c
+++ b/traffico.c
@@ -44,7 +44,10 @@ const char OPT_CHAIN_ARG[] = "PROG:INPUT,...";
 #define OPT_ALLOW_KEY 0x83
 const char OPT_ALLOW_LONG[] = "allow";
 const char OPT_ALLOW_ARG[] = "PERMIT";
-#define OPT_DRY_RUN_KEY 0x84
+#define OPT_PERMIT_KEY 0x84
+const char OPT_PERMIT_LONG[] = "permit";
+const char OPT_PERMIT_ARG[] = "PERMIT";
+#define OPT_DRY_RUN_KEY 0x85
 const char OPT_DRY_RUN_LONG[] = "dry-run";
 
 const struct argp_option argp_opts[] = {
@@ -56,6 +59,7 @@ const struct argp_option argp_opts[] = {
     {OPT_NO_CLEANUP_LONG, OPT_NO_CLEANUP_KEY, NULL, 0, "Do not detach the TC hook and filter at the exit", 1},
     {OPT_CHAIN_LONG, OPT_CHAIN_KEY, OPT_CHAIN_ARG, 0, "Attach a chain of programs (e.g., allow_ipv4:10.0.0.1,allow_port:8080)", 1},
     {OPT_ALLOW_LONG, OPT_ALLOW_KEY, OPT_ALLOW_ARG, 0, "Add an Intent permit", 1},
+    {OPT_PERMIT_LONG, OPT_PERMIT_KEY, OPT_PERMIT_ARG, 0, "Alias for --allow", 1},
     {OPT_DRY_RUN_LONG, OPT_DRY_RUN_KEY, NULL, 0, "Validate Intent without attaching", 1},
     {"", 0, 0, OPTION_DOC, 0, 0},
     {0} // .
@@ -170,6 +174,7 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
         g_chain_arg = arg;
         break;
     case OPT_ALLOW_KEY:
+    case OPT_PERMIT_KEY:
         g_intent_mode = true;
         if (intent_add_permit(&g_intent, arg, &err_msg) != 0)
         {

--- a/traffico.c
+++ b/traffico.c
@@ -242,6 +242,14 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
         {
             argp_error(state, "--explain currently requires --allow or --permit");
         }
+        if (g_intent_mode)
+        {
+            if (g_config.attach_point == BPF_TC_INGRESS)
+                g_intent.direction = INTENT_DIRECTION_INGRESS;
+            else
+                g_intent.direction = INTENT_DIRECTION_EGRESS;
+            intent_normalize(&g_intent);
+        }
         if (g_intent_mode && g_config.attach_point != BPF_TC_EGRESS)
         {
             argp_error(state, "intent currently supports --at egress only");
@@ -371,14 +379,7 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
                     argp_error(state, "%s", validation_err);
             }
         }
-        else if (g_intent_mode)
-        {
-            if (g_config.attach_point == BPF_TC_INGRESS)
-                g_intent.direction = INTENT_DIRECTION_INGRESS;
-            else
-                g_intent.direction = INTENT_DIRECTION_EGRESS;
-        }
-        else
+        else if (!g_intent_mode)
         {
             // Single program mode: parse input value
             if (g_config.input_arg)
@@ -445,7 +446,6 @@ static int intent_validate(const char *context)
     struct decision_dag dag = {0};
     const char *err_msg = NULL;
 
-    intent_normalize(&g_intent);
     if (intent_build_dag(&g_intent, &dag, &err_msg) != 0 ||
         intent_validate_supported_subset(&dag, &err_msg) != 0)
     {

--- a/traffico.c
+++ b/traffico.c
@@ -51,7 +51,7 @@ const char OPT_PERMIT_ARG[] = "PERMIT";
 const char OPT_DRY_RUN_LONG[] = "dry-run";
 #define OPT_EXPLAIN_KEY 0x86
 const char OPT_EXPLAIN_LONG[] = "explain";
-const char OPT_EXPLAIN_ARG[] = "intent|dag";
+const char OPT_EXPLAIN_ARG[] = "intent";
 
 const struct argp_option argp_opts[] = {
 
@@ -440,7 +440,7 @@ int await(struct bpf_tc_hook hook, struct bpf_tc_opts opts)
     return 0;
 }
 
-static int intent_dry_run(void)
+static int intent_validate(const char *context)
 {
     struct decision_dag dag = {0};
     const char *err_msg = NULL;
@@ -449,18 +449,45 @@ static int intent_dry_run(void)
     if (intent_build_dag(&g_intent, &dag, &err_msg) != 0 ||
         intent_validate_supported_subset(&dag, &err_msg) != 0)
     {
-        fprintf(g_config.err_stream, TOOL_NAME ": intent dry-run: %s\n", err_msg);
+        fprintf(g_config.err_stream, TOOL_NAME ": %s: %s\n", context, err_msg);
         return 1;
     }
 
+    return 0;
+}
+
+static void intent_explain(void)
+{
     if (g_intent_explain)
     {
         intent_print_explain(g_config.out_stream, g_config.ifname, &g_intent);
+        fflush(g_config.out_stream);
+    }
+}
+
+static int intent_dry_run(void)
+{
+    if (intent_validate("intent dry-run") != 0)
+    {
+        return 1;
     }
 
+    intent_explain();
     fprintf(g_config.out_stream, "intent dry-run: compiler ok\n");
     fprintf(g_config.out_stream, "intent backend: not implemented\n");
     return 0;
+}
+
+static int intent_reject_live_attach(void)
+{
+    if (intent_validate("intent attach") != 0)
+    {
+        return 1;
+    }
+
+    intent_explain();
+    fprintf(g_config.err_stream, TOOL_NAME ": intent attach backend is not implemented; use --dry-run\n");
+    return 1;
 }
 
 int main(int argc, char **argv)
@@ -482,8 +509,7 @@ int main(int argc, char **argv)
     }
     if (g_intent_mode)
     {
-        fprintf(g_config.err_stream, TOOL_NAME ": intent attach backend is not implemented; use --dry-run\n");
-        return 1;
+        return intent_reject_live_attach();
     }
 
     // Setup signal handling

--- a/traffico.c
+++ b/traffico.c
@@ -453,6 +453,11 @@ static int intent_dry_run(void)
         return 1;
     }
 
+    if (g_intent_explain)
+    {
+        intent_print_explain(g_config.out_stream, g_config.ifname, &g_intent);
+    }
+
     fprintf(g_config.out_stream, "intent dry-run: compiler ok\n");
     fprintf(g_config.out_stream, "intent backend: not implemented\n");
     return 0;

--- a/traffico.c
+++ b/traffico.c
@@ -136,6 +136,7 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
     case ARGP_KEY_INIT:
         g_config.attach_point = BPF_TC_EGRESS;
         g_config.ifindex = 0;
+        g_config.ifname[0] = '\0';
         g_config.cleanup_on_exit = true;
         g_config.verbose = false;
         g_config.err_stream = state->err_stream = stderr;
@@ -276,8 +277,11 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
 
     // Final settings, validations
     case ARGP_KEY_FINI:
-        // Fallback to the default gateway interface by default
-        if (g_config.ifindex == 0)
+        /*
+         * Dry-run compiles Intent only.
+         * Live attach and legacy modes still need a concrete interface.
+         */
+        if (g_config.ifindex == 0 && !(g_intent_mode && g_intent_dry_run))
         {
             if (get_gateway_iface(g_config.ifname))
             {
@@ -463,10 +467,12 @@ static int intent_validate(const char *context)
 
 static void intent_explain(FILE *out)
 {
+    const char *ifname = g_config.ifname[0] ? g_config.ifname : "not attached";
+
     /* The caller chooses stdout or stderr based on the command result. */
     if (g_intent_explain)
     {
-        intent_print_explain(out, g_config.ifname, &g_intent);
+        intent_print_explain(out, ifname, &g_intent);
         fflush(out);
     }
 }

--- a/traffico.c
+++ b/traffico.c
@@ -244,6 +244,7 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
         }
         if (g_intent_mode)
         {
+            /* Normalize here so dry-run, explain, and attach share one order. */
             if (g_config.attach_point == BPF_TC_INGRESS)
                 g_intent.direction = INTENT_DIRECTION_INGRESS;
             else
@@ -446,6 +447,10 @@ static int intent_validate(const char *context)
     struct decision_dag dag = {0};
     const char *err_msg = NULL;
 
+    /*
+     * Dry-run and live rejection validate through the same DDAG path.
+     * This keeps dry-run aligned with the attach preconditions.
+     */
     if (intent_build_dag(&g_intent, &dag, &err_msg) != 0 ||
         intent_validate_supported_subset(&dag, &err_msg) != 0)
     {
@@ -458,6 +463,7 @@ static int intent_validate(const char *context)
 
 static void intent_explain(FILE *out)
 {
+    /* The caller chooses stdout or stderr based on the command result. */
     if (g_intent_explain)
     {
         intent_print_explain(out, g_config.ifname, &g_intent);

--- a/traffico.c
+++ b/traffico.c
@@ -456,12 +456,12 @@ static int intent_validate(const char *context)
     return 0;
 }
 
-static void intent_explain(void)
+static void intent_explain(FILE *out)
 {
     if (g_intent_explain)
     {
-        intent_print_explain(g_config.out_stream, g_config.ifname, &g_intent);
-        fflush(g_config.out_stream);
+        intent_print_explain(out, g_config.ifname, &g_intent);
+        fflush(out);
     }
 }
 
@@ -472,7 +472,7 @@ static int intent_dry_run(void)
         return 1;
     }
 
-    intent_explain();
+    intent_explain(g_config.out_stream);
     fprintf(g_config.out_stream, "intent dry-run: compiler ok\n");
     fprintf(g_config.out_stream, "intent backend: not implemented\n");
     return 0;
@@ -485,7 +485,7 @@ static int intent_reject_live_attach(void)
         return 1;
     }
 
-    intent_explain();
+    intent_explain(g_config.err_stream);
     fprintf(g_config.err_stream, TOOL_NAME ": intent attach backend is not implemented; use --dry-run\n");
     return 1;
 }

--- a/traffico.c
+++ b/traffico.c
@@ -215,15 +215,15 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
     case ARGP_KEY_END:
         if (g_intent_mode && g_chain_arg)
         {
-            argp_error(state, "--allow and --chain are mutually exclusive");
+            argp_error(state, "--allow/--permit and --chain are mutually exclusive");
         }
         if (g_intent_mode && state->arg_num > 0)
         {
-            argp_error(state, "--allow and positional PROGRAM arguments are mutually exclusive");
+            argp_error(state, "--allow/--permit and positional PROGRAM arguments are mutually exclusive");
         }
         if (g_intent_dry_run && !g_intent_mode)
         {
-            argp_error(state, "--dry-run currently requires --allow");
+            argp_error(state, "--dry-run currently requires --allow or --permit");
         }
 
         // In chain or Intent mode, positional args are not required


### PR DESCRIPTION
## Summary

This follows merged PR #69 and adds the first safe user-visible Intent workflow.

- Add repeated `--allow` and `--permit` as aliases for first Intent permit selectors.
- Add compiler-only `--dry-run` validation for parsing, normalization, DDAG construction, and supported-subset validation.
- Add normalized `--explain` / `--explain=intent` output as the human audit artifact.
- Keep `--dry-run` side-effect free, including the no-interface case where no default route exists.
- Reject live Intent attach clearly until the backend PR lands, and prove dry-run and live rejection do not attach TC state.
- Keep explain output deterministic across input order, including DNS TCP/UDP set normalization.

## Stack

- Base branch: `main`
- Follows merged PR: #69 (`feat(ddag): add Decision DAG builder`)
- Head branch: `leox/managed-or-pr3-cli-dry-run-explain`
- Head commit: `823124e3f83055f8b8d07471f1d22ce778ef1759`
- This is PR3 in the Intent compiler arc.

## Verification

- `git diff --check origin/main..HEAD`
- Focused Ubuntu Docker runner after the review fixes: `xmake f -c -y --generate-vmlinux=y --require-bpftool=y && xmake build -y traffico && xmake run test test/cli.flags.bats test/intent.bats`
- PR3 full Ubuntu Docker suite previously passed at `1..161` before the live backend PR.
- Also covered by the final top-of-stack privileged Ubuntu Docker run: `xmake f -c -y --generate-vmlinux=y --require-bpftool=y && xmake build -y && xmake run test` (`1..173`, exit 0)

## Notes

At this PR boundary, `--dry-run` is still compiler-core validation only and reports that the backend is not implemented. PR #71 upgrades dry-run to include selected-backend BPF admissibility.
