### PR TITLE
docs(intent): document intent mode usage

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -73,11 +73,57 @@ USAGE
 
         These examples are alternative linear policies, not an additive
         multi-flow allowlist. Full policies such as "DNS to resolver OR HTTPS
-        to service" need explicit OR composition.
+        to service" need Intent mode.
 
         Chain order is validated before attach. If a chain contains any L3/L4
         program, slot 0 must be allow_ethertype, and the layer order must be
         L2 -> L3 -> L4.
+
+        Intent mode
+            Use Intent mode when the policy is an additive allowlist such as
+            "ARP OR DNS to this resolver OR HTTPS to this service". Intent
+            mode is selected by repeating --allow or --permit. --permit is an
+            alias for --allow.
+
+            Supported selectors:
+                arp
+                dns/IPv4
+                tcp/IPv4:PORT
+                udp/IPv4:PORT
+
+            dns/IPv4 permits DNS to that IPv4 resolver over TCP or UDP
+            destination port 53. TCP and UDP selectors match packets whose
+            destination endpoint is IPv4:PORT. Any traffic not matching a
+            permit is dropped, and packets that cannot be safely classified
+            are dropped.
+
+            traffico --ifname=eth0 --at=EGRESS \
+                --allow arp \
+                --allow dns/10.0.0.53 \
+                --allow tcp/10.0.0.10:443 \
+                --allow udp/10.0.0.20:123
+
+            Use --dry-run to compile and validate without attaching:
+
+            traffico --ifname=eth0 --at=EGRESS \
+                --allow arp \
+                --allow tcp/10.0.0.10:443 \
+                --dry-run
+
+            Use --explain to print the normalized Intent before validation
+            succeeds or fails:
+
+            traffico --ifname=eth0 --at=EGRESS \
+                --allow udp/10.0.0.20:123 \
+                --allow arp \
+                --allow tcp/10.0.0.10:443 \
+                --allow dns/10.0.0.53 \
+                --dry-run --explain
+
+            Intent mode is mutually exclusive with --chain and with positional
+            PROGRAM [INPUT]. The first Intent backend is the Linux BPF egress
+            adapter. --at=INGRESS is parsed and can be explained, but backend
+            validation rejects it until an ingress backend is implemented.
 
     traffico-cni
         traffico-cni is a meta CNI plugin that allows the traffico programs to be used in CNI.

--- a/docs/README.md
+++ b/docs/README.md
@@ -84,10 +84,62 @@ traffico --ifname=eth0 --at=EGRESS --chain \
 
 These examples are alternative linear policies, not an additive multi-flow
 allowlist. Full policies such as "DNS to resolver OR HTTPS to service" need
-explicit OR composition.
+Intent mode.
 
 Chain order is validated before attach. If a chain contains any L3/L4 program,
 slot 0 must be `allow_ethertype`, and the layer order must be `L2 -> L3 -> L4`.
+
+#### Intent mode
+
+Use Intent mode when the policy is an additive allowlist such as "ARP OR DNS to
+this resolver OR HTTPS to this service". Intent mode is selected by repeating
+`--allow` or `--permit`; `--permit` is an alias for `--allow`.
+
+Supported selectors:
+
+- `arp`
+- `dns/IPv4`
+- `tcp/IPv4:PORT`
+- `udp/IPv4:PORT`
+
+`dns/IPv4` permits DNS to that IPv4 resolver over TCP or UDP destination port
+53. TCP and UDP selectors match packets whose destination endpoint is
+`IPv4:PORT`. Any traffic not matching a permit is dropped, and packets that
+cannot be safely classified are dropped.
+
+```bash
+traffico --ifname=eth0 --at=EGRESS \
+  --allow arp \
+  --allow dns/10.0.0.53 \
+  --allow tcp/10.0.0.10:443 \
+  --allow udp/10.0.0.20:123
+```
+
+Use `--dry-run` to compile and validate without attaching:
+
+```bash
+traffico --ifname=eth0 --at=EGRESS \
+  --allow arp \
+  --allow tcp/10.0.0.10:443 \
+  --dry-run
+```
+
+Use `--explain` to print the normalized Intent before validation succeeds or
+fails:
+
+```bash
+traffico --ifname=eth0 --at=EGRESS \
+  --allow udp/10.0.0.20:123 \
+  --allow arp \
+  --allow tcp/10.0.0.10:443 \
+  --allow dns/10.0.0.53 \
+  --dry-run --explain
+```
+
+Intent mode is mutually exclusive with `--chain` and with positional
+`PROGRAM [INPUT]`. The first Intent backend is the Linux BPF egress adapter.
+`--at=INGRESS` is parsed and can be explained, but backend validation rejects
+it until an ingress backend is implemented.
 
 ### traffico-cni
 


### PR DESCRIPTION
## Summary

This follows merged PR #71 and documents Intent mode in the public README flow.

- Document Intent mode after the chain section.
- Show the tested selector forms: `arp`, `dns/IPv4`, `tcp/IPv4:PORT`, and `udp/IPv4:PORT`.
- Document `--dry-run`, `--explain`, and the `--permit` alias.
- Clarify that Intent mode is additive OR allowlist composition, while `--chain` is linear staged composition.
- State the current backend limitation: the first Intent backend is Linux BPF egress; ingress parses and explains, but backend validation rejects it.

## Stack

- Base branch: `main`
- Follows merged PR: #71 (`feat(intent): add live BPF attach backend`)
- Head branch: `leox/managed-or-pr6-readme-intent-docs`
- Head commit: `f2d22620793d7a0e6362cf292f7f0a2b8d341c73`
- This is PR6 in the Intent compiler arc.

## Verification

- `rg -n "--allow|--permit|--dry-run|--explain|Intent mode rejects ingress|Intent live ingress|dry-run --explain" traffico.c test/cli.flags.bats test/intent.bats test/intent_scapy.bats`
- `rg -n "explicit OR composition|managed OR|tcp:10\\.0\\.0\\.10:443" README.txt docs/README.md`
- `git diff --check`

Docs-only change; no code or test behavior changed.
