### PR TITLE
test(scapy): wait for sniffer readiness

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -43,15 +43,35 @@ scapy_needs_marker_match() {
 start_sniffer() {
   local iface="$1" ip_id="$2" src_ip="${3:-}" dst_ip="${4:-}" match_marker="${5:-}"
   local sniff_args=(--iface "$iface" --ip-id "$ip_id" --timeout "$SCAPY_SNIFF_TIMEOUT")
+  local i
   [ -n "$src_ip" ] && sniff_args+=(--src-ip "$src_ip")
   [ -n "$dst_ip" ] && sniff_args+=(--dst-ip "$dst_ip")
   [ "$match_marker" = "1" ] && sniff_args+=(--match-marker)
 
+  SNIFFER_READY_FILE="$BATS_TEST_TMPDIR/sniffer_ready"
+  SNIFFER_STATUS_FILE="$BATS_TEST_TMPDIR/sniffer_status"
+  rm -f "$SNIFFER_READY_FILE" "$SNIFFER_STATUS_FILE"
+  sniff_args+=(--ready-file "$SNIFFER_READY_FILE")
+
   python3 "$SCAPY_HELPER" sniff "${sniff_args[@]}" &
   SNIFFER_PID=$!
-  SNIFFER_STATUS_FILE="$BATS_TEST_TMPDIR/sniffer_status"
-  # Brief settle time for the sniffer to attach
-  sleep 0.3
+
+  # Scapy opens the raw socket asynchronously.
+  # Wait for its started callback before sending the packet.
+  for i in {1..50}; do
+    [ -f "$SNIFFER_READY_FILE" ] && return 0
+    if ! kill -0 "$SNIFFER_PID" 2>/dev/null; then
+      wait "$SNIFFER_PID" || true
+      echo "# FAIL: sniffer exited before it was ready on $iface" >&3
+      return 1
+    fi
+    sleep 0.1
+  done
+
+  echo "# FAIL: sniffer did not become ready on $iface" >&3
+  kill "$SNIFFER_PID" 2>/dev/null || true
+  wait "$SNIFFER_PID" 2>/dev/null || true
+  return 1
 }
 
 # Wait for the background sniffer and capture its exit code.
@@ -88,7 +108,7 @@ assert_packet_seen() {
   local match_marker=0
   scapy_needs_marker_match "$@" && match_marker=1
 
-  start_sniffer "$VETH" "$ip_id" "" "" "$match_marker"
+  start_sniffer "$VETH" "$ip_id" "" "" "$match_marker" || return 1
   scapy_send "$netns" "$PEER" --ip-id "$ip_id" "$@"
   wait_sniffer
   local rc=$?
@@ -106,7 +126,7 @@ assert_packet_blocked() {
   local match_marker=0
   scapy_needs_marker_match "$@" && match_marker=1
 
-  start_sniffer "$VETH" "$ip_id" "" "" "$match_marker"
+  start_sniffer "$VETH" "$ip_id" "" "" "$match_marker" || return 1
   scapy_send "$netns" "$PEER" --ip-id "$ip_id" "$@"
   local rc=0
   wait "$SNIFFER_PID" || rc=$?

--- a/test/intent_scapy.bats
+++ b/test/intent_scapy.bats
@@ -188,7 +188,7 @@ assert_l4_prefix_blocked() {
     local dst_port="$6"
     local rc=0
 
-    start_sniffer "$VETH" "$ip_id"
+    start_sniffer "$VETH" "$ip_id" || return 1
     send_ipv4_l4_prefix "${netns}" "${ip_id}" "${proto}" "${total_length}" "${src_port}" "${dst_port}"
     wait "$SNIFFER_PID" || rc=$?
     if [ $rc -eq 0 ]; then

--- a/test/scapy_helper.bats
+++ b/test/scapy_helper.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+
+load helpers
+export BATS_TEST_NAME_PREFIX=$(setsuite)
+bats_require_minimum_version 1.7.0
+
+@test "Scapy sniffer reports readiness before timeout" {
+    ready_file="$BATS_TEST_TMPDIR/sniffer.ready"
+
+    run python3 "$SCAPY_HELPER" sniff \
+        --iface lo \
+        --ip-id 65000 \
+        --timeout 0.1 \
+        --ready-file "$ready_file"
+
+    [ "$status" -eq 1 ]
+    [ -f "$ready_file" ]
+}

--- a/test/scapy_packets.py
+++ b/test/scapy_packets.py
@@ -33,6 +33,15 @@ def marker_for(ip_id):
     return b"TRAFFICO" + struct.pack("!H", ip_id & 0xFFFF)
 
 
+def write_ready_file(path):
+    """Signal that sniff() has opened its socket and started listening."""
+    if not path:
+        return
+
+    with open(path, "w", encoding="utf-8") as ready:
+        ready.write("ready\n")
+
+
 def ether(eth_type):
     """Build a broadcast Ethernet header for raw L2 test packets."""
     return Ether(dst="ff:ff:ff:ff:ff:ff", type=eth_type)
@@ -241,6 +250,7 @@ def cmd_sniff(args):
         count=1,
         lfilter=match_filter,
         store=True,
+        started_callback=lambda: write_ready_file(args.ready_file),
     )
 
     if len(result) > 0:
@@ -288,6 +298,8 @@ def main():
     p_sniff.add_argument("--dst-ip", default=None)
     p_sniff.add_argument("--match-marker", action="store_true",
                          help="Also match the raw payload marker for packets without a reliable IPv4 ID")
+    p_sniff.add_argument("--ready-file", default=None,
+                         help="Write this file once the sniffer is listening")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary
- replace the fixed Scapy sniffer settle sleep with Scapy's started callback
- fail early if the sniffer exits or never reports readiness
- add a BATS regression test for readiness signaling

## Verification
- docker Ubuntu runner: xmake f -c -y --generate-vmlinux=y --require-bpftool=y && xmake build -y && xmake run test
- targeted loop: 5 consecutive xmake run test test/intent_scapy.bats passes
- git diff --check