### PR TITLE
feat(intent): allow host-wide tcp udp permits

### DIFF
--- a/api/dag.h
+++ b/api/dag.h
@@ -374,8 +374,7 @@ static inline bool intent_subset_context_allows_terminal(struct intent_subset_co
 {
     bool has_l4_service = context.has_ipv4 &&
                           context.has_ip_dst &&
-                          context.has_l4_proto &&
-                          context.has_l4_dst_port;
+                          context.has_l4_proto;
 
     return context.has_arp || has_l4_service;
 }

--- a/api/enforcement.h
+++ b/api/enforcement.h
@@ -6,8 +6,9 @@
 #include <string.h>
 
 #include "dag.h"
+#include "intent_l4.h"
 
-#define MAX_INTENT_ENFORCEMENT_RULES MAX_INTENT_PERMITS
+#define MAX_INTENT_ENFORCEMENT_RULES (MAX_INTENT_PERMITS + MAX_INTENT_FORBIDS)
 #define MAX_INTENT_ENFORCEMENT_PROTOS 2
 
 enum intent_enforcement_rule_kind
@@ -20,6 +21,7 @@ struct intent_enforcement_rule
 {
     enum intent_enforcement_rule_kind kind;
     uint32_t ip_dst;
+    enum intent_l4_dst_port_mode l4_dst_port_mode;
     uint16_t l4_dst_port;
     uint8_t ip_protos[MAX_INTENT_ENFORCEMENT_PROTOS];
     size_t ip_proto_count;
@@ -253,6 +255,7 @@ static inline int intent_enforcement_append_rule(struct intent_enforcement_plan 
         const struct intent_enforcement_rule *existing = &plan->rules[i];
         if (existing->kind == rule->kind &&
             existing->ip_dst == rule->ip_dst &&
+            existing->l4_dst_port_mode == rule->l4_dst_port_mode &&
             existing->l4_dst_port == rule->l4_dst_port &&
             existing->ip_proto_count == rule->ip_proto_count &&
             existing->ip_protos[0] == rule->ip_protos[0] &&
@@ -357,10 +360,11 @@ static inline int intent_enforcement_emit_path(const struct intent_enforcement_p
 
     if (eth_type == INTENT_ETH_P_IP &&
         has_ip_dst &&
-        has_ip_proto &&
-        has_l4_dst_port)
+        has_ip_proto)
     {
         rule.kind = INTENT_ENFORCEMENT_RULE_IPV4_L4;
+        rule.l4_dst_port_mode = has_l4_dst_port ? INTENT_L4_DST_PORT_EXACT
+                                                : INTENT_L4_DST_PORT_ANY;
         return intent_enforcement_append_rule(plan, &rule, err_msg);
     }
 

--- a/api/intent.h
+++ b/api/intent.h
@@ -378,12 +378,16 @@ static inline int intent_add_l4_permit(struct intent *intent,
     struct intent_permit permit;
     intent_permit_init(&permit);
 
-    if (intent_parse_ipv4(ip, &dst_ip) != 0 ||
-        intent_parse_port(port, &dst_port) != 0)
+    if (intent_parse_ipv4(ip, &dst_ip) != 0)
+        return intent_fail(err_msg, "invalid permit");
+    if (port && intent_parse_port(port, &dst_port) != 0)
         return intent_fail(err_msg, "invalid permit");
     if (intent_add_eq(&permit, INTENT_FIELD_ETH_TYPE, INTENT_ETH_P_IP, err_msg) != 0 ||
         intent_add_eq(&permit, INTENT_FIELD_IP_DST, dst_ip, err_msg) != 0 ||
-        intent_add_eq(&permit, INTENT_FIELD_IP_PROTO, proto, err_msg) != 0 ||
+        intent_add_eq(&permit, INTENT_FIELD_IP_PROTO, proto, err_msg) != 0)
+        return -1;
+
+    if (port &&
         intent_add_eq(&permit, INTENT_FIELD_L4_DST_PORT, dst_port, err_msg) != 0)
         return -1;
 
@@ -432,17 +436,15 @@ static inline int intent_add_permit(struct intent *intent,
     if (strcmp(kind, "tcp") == 0)
     {
         port = strrchr(target, ':');
-        if (!port)
-            return intent_fail(err_msg, "invalid permit");
-        *port++ = '\0';
+        if (port)
+            *port++ = '\0';
         return intent_add_l4_permit(intent, INTENT_IPPROTO_TCP, target, port, err_msg);
     }
     if (strcmp(kind, "udp") == 0)
     {
         port = strrchr(target, ':');
-        if (!port)
-            return intent_fail(err_msg, "invalid permit");
-        *port++ = '\0';
+        if (port)
+            *port++ = '\0';
         return intent_add_l4_permit(intent, INTENT_IPPROTO_UDP, target, port, err_msg);
     }
 
@@ -552,6 +554,7 @@ static inline void intent_print_explain(FILE *out,
         uint32_t ip_dst = 0;
         uint32_t proto = 0;
         uint32_t port = 0;
+        bool has_port = intent_permit_get_eq(permit, INTENT_FIELD_L4_DST_PORT, &port);
 
         if (intent_permit_get_eq(permit, INTENT_FIELD_ETH_TYPE, &eth_type) &&
             eth_type == INTENT_ETH_P_ARP)
@@ -563,7 +566,7 @@ static inline void intent_print_explain(FILE *out,
         if (intent_permit_get_eq(permit, INTENT_FIELD_ETH_TYPE, &eth_type) &&
             eth_type == INTENT_ETH_P_IP &&
             intent_permit_get_eq(permit, INTENT_FIELD_IP_DST, &ip_dst) &&
-            intent_permit_get_eq(permit, INTENT_FIELD_L4_DST_PORT, &port) &&
+            has_port &&
             intent_permit_has_proto_in_tcp_udp(permit) &&
             port == INTENT_DNS_PORT)
         {
@@ -579,15 +582,23 @@ static inline void intent_print_explain(FILE *out,
             eth_type == INTENT_ETH_P_IP &&
             intent_permit_get_eq(permit, INTENT_FIELD_IP_DST, &ip_dst) &&
             intent_permit_get_eq(permit, INTENT_FIELD_IP_PROTO, &proto) &&
-            intent_permit_get_eq(permit, INTENT_FIELD_L4_DST_PORT, &port) &&
             proto == INTENT_IPPROTO_TCP)
         {
             has_l4_permits = true;
             intent_format_ip(ip_dst, ip, sizeof(ip));
-            fprintf(out, "  %zu. TCP to %s destination port %u\n",
-                    i + 1,
-                    ip,
-                    port);
+            if (has_port)
+            {
+                fprintf(out, "  %zu. TCP to %s destination port %u\n",
+                        i + 1,
+                        ip,
+                        port);
+            }
+            else
+            {
+                fprintf(out, "  %zu. TCP to %s any destination port\n",
+                        i + 1,
+                        ip);
+            }
             continue;
         }
 
@@ -595,15 +606,23 @@ static inline void intent_print_explain(FILE *out,
             eth_type == INTENT_ETH_P_IP &&
             intent_permit_get_eq(permit, INTENT_FIELD_IP_DST, &ip_dst) &&
             intent_permit_get_eq(permit, INTENT_FIELD_IP_PROTO, &proto) &&
-            intent_permit_get_eq(permit, INTENT_FIELD_L4_DST_PORT, &port) &&
             proto == INTENT_IPPROTO_UDP)
         {
             has_l4_permits = true;
             intent_format_ip(ip_dst, ip, sizeof(ip));
-            fprintf(out, "  %zu. UDP to %s destination port %u\n",
-                    i + 1,
-                    ip,
-                    port);
+            if (has_port)
+            {
+                fprintf(out, "  %zu. UDP to %s destination port %u\n",
+                        i + 1,
+                        ip,
+                        port);
+            }
+            else
+            {
+                fprintf(out, "  %zu. UDP to %s any destination port\n",
+                        i + 1,
+                        ip);
+            }
             continue;
         }
 
@@ -612,9 +631,9 @@ static inline void intent_print_explain(FILE *out,
 
     fprintf(out, "\ndropped traffic:\n");
     fprintf(out, "  - malformed packets that cannot be safely classified\n");
-    /* Only mention fragment policy when a permit depends on L4 ports. */
+    /* Only mention fragment policy when a permit needs L4 classification. */
     if (has_l4_permits)
-        fprintf(out, "  - TCP/UDP fragments whose destination port cannot be checked\n");
+        fprintf(out, "  - TCP/UDP fragments that cannot be fully classified\n");
     fprintf(out, "  - any traffic not matching a permit\n");
 }
 

--- a/api/intent_bpf.h
+++ b/api/intent_bpf.h
@@ -6,21 +6,19 @@
 #include <string.h>
 
 #include "enforcement.h"
+#include "intent_bpf_uapi.h"
 
-#define INTENT_BPF_MAX_RULES MAX_INTENT_ENFORCEMENT_RULES
-#define INTENT_BPF_MAX_PROTOS MAX_INTENT_ENFORCEMENT_PROTOS
-
-enum intent_bpf_rule_kind
-{
-    INTENT_BPF_RULE_ARP = 1,
-    INTENT_BPF_RULE_IPV4_L4 = 2,
-};
+_Static_assert(MAX_INTENT_ENFORCEMENT_RULES == INTENT_BPF_MAX_RULES,
+               "enforcement and BPF rule limits must match");
+_Static_assert(MAX_INTENT_ENFORCEMENT_PROTOS == INTENT_BPF_MAX_PROTOS,
+               "enforcement and BPF proto limits must match");
 
 struct intent_bpf_rule
 {
     uint8_t kind;
     uint8_t ip_proto_count;
     uint8_t ip_protos[INTENT_BPF_MAX_PROTOS];
+    uint8_t l4_dst_port_mode;
     uint16_t l4_dst_port;
     uint32_t ip_dst;
 };
@@ -52,14 +50,29 @@ static inline bool intent_bpf_rule_supported(const struct intent_enforcement_rul
 {
     if (rule->kind == INTENT_ENFORCEMENT_RULE_ARP)
         return rule->ip_dst == 0 &&
+               rule->l4_dst_port_mode == INTENT_L4_DST_PORT_EXACT &&
                rule->l4_dst_port == 0 &&
                rule->ip_proto_count == 0;
 
     if (rule->kind != INTENT_ENFORCEMENT_RULE_IPV4_L4 ||
-        rule->l4_dst_port == 0 ||
         rule->ip_proto_count == 0 ||
         rule->ip_proto_count > INTENT_BPF_MAX_PROTOS)
         return false;
+
+    if (rule->l4_dst_port_mode == INTENT_L4_DST_PORT_EXACT)
+    {
+        if (rule->l4_dst_port == 0)
+            return false;
+    }
+    else if (rule->l4_dst_port_mode == INTENT_L4_DST_PORT_ANY)
+    {
+        if (rule->l4_dst_port != 0)
+            return false;
+    }
+    else
+    {
+        return false;
+    }
 
     for (size_t i = 0; i < rule->ip_proto_count; i++)
     {
@@ -106,7 +119,10 @@ static inline int intent_bpf_plan_from_enforcement(const struct intent_enforceme
 
         dst->kind = INTENT_BPF_RULE_IPV4_L4;
         dst->ip_dst = src->ip_dst;
-        dst->l4_dst_port = src->l4_dst_port;
+        dst->l4_dst_port_mode = (uint8_t)src->l4_dst_port_mode;
+        dst->l4_dst_port = src->l4_dst_port_mode == INTENT_L4_DST_PORT_ANY
+                               ? 0
+                               : src->l4_dst_port;
         dst->ip_proto_count = (uint8_t)src->ip_proto_count;
         for (size_t j = 0; j < src->ip_proto_count; j++)
             dst->ip_protos[j] = src->ip_protos[j];

--- a/api/intent_bpf_loader.h.in
+++ b/api/intent_bpf_loader.h.in
@@ -45,6 +45,7 @@ static int attach_intent_bpf(struct config *conf,
         obj->rodata->intent_rules[i].ip_proto_count = plan->rules[i].ip_proto_count;
         obj->rodata->intent_rules[i].ip_protos[0] = plan->rules[i].ip_protos[0];
         obj->rodata->intent_rules[i].ip_protos[1] = plan->rules[i].ip_protos[1];
+        obj->rodata->intent_rules[i].l4_dst_port_mode = plan->rules[i].l4_dst_port_mode;
         obj->rodata->intent_rules[i].l4_dst_port = plan->rules[i].l4_dst_port;
         obj->rodata->intent_rules[i].ip_dst = plan->rules[i].ip_dst;
     }

--- a/api/intent_bpf_uapi.h
+++ b/api/intent_bpf_uapi.h
@@ -1,0 +1,18 @@
+#ifndef TRAFFICO_INTENT_BPF_UAPI_H
+#define TRAFFICO_INTENT_BPF_UAPI_H
+
+#include "intent_l4.h"
+
+enum
+{
+    INTENT_BPF_MAX_RULES = 64,
+    INTENT_BPF_MAX_PROTOS = 2,
+};
+
+enum intent_bpf_rule_kind
+{
+    INTENT_BPF_RULE_ARP = 1,
+    INTENT_BPF_RULE_IPV4_L4 = 2,
+};
+
+#endif

--- a/api/intent_l4.h
+++ b/api/intent_l4.h
@@ -1,0 +1,10 @@
+#ifndef TRAFFICO_INTENT_L4_H
+#define TRAFFICO_INTENT_L4_H
+
+enum intent_l4_dst_port_mode
+{
+    INTENT_L4_DST_PORT_EXACT = 0,
+    INTENT_L4_DST_PORT_ANY = 1,
+};
+
+#endif

--- a/bpf/intent.bpf.c
+++ b/bpf/intent.bpf.c
@@ -1,5 +1,6 @@
 #include "vmlinux.h"
 #include "commons.bpf.h"
+#include "../api/intent_bpf_uapi.h"
 
 #include <bpf/bpf_endian.h>
 
@@ -9,18 +10,19 @@ struct intent_bpf_rule
 {
     __u8 kind;
     __u8 ip_proto_count;
-    __u8 ip_protos[2];
+    __u8 ip_protos[INTENT_BPF_MAX_PROTOS];
+    __u8 l4_dst_port_mode;
     __u16 l4_dst_port;
     __u32 ip_dst;
 };
 
 /* libbpf writes these read-only values before loading the program. */
 const volatile __u32 intent_rule_count = 0;
-const volatile struct intent_bpf_rule intent_rules[32] = {};
+const volatile struct intent_bpf_rule intent_rules[INTENT_BPF_MAX_RULES] = {};
 
 static __always_inline int proto_allowed(const volatile struct intent_bpf_rule *rule, __u8 proto)
 {
-    for (__u32 i = 0; i < 2; i++)
+    for (__u32 i = 0; i < INTENT_BPF_MAX_PROTOS; i++)
     {
         if (i >= rule->ip_proto_count)
             break;
@@ -37,6 +39,9 @@ int intent(struct __sk_buff *skb)
     void *data = (void *)(unsigned long long)skb->data;
     struct ethhdr *eth = data;
     const int l3_offset = sizeof(*eth);
+
+    if (intent_rule_count > INTENT_BPF_MAX_RULES)
+        return TC_ACT_SHOT;
 
     /* Intent allowlists fail closed on packets that cannot be classified. */
     if (data + l3_offset > data_end)
@@ -55,11 +60,11 @@ int intent(struct __sk_buff *skb)
         if (data + l3_offset + arp_len > data_end)
             return TC_ACT_SHOT;
 
-        for (__u32 i = 0; i < 32; i++)
+        for (__u32 i = 0; i < INTENT_BPF_MAX_RULES; i++)
         {
             if (i >= intent_rule_count)
                 break;
-            if (intent_rules[i].kind == 1)
+            if (intent_rules[i].kind == INTENT_BPF_RULE_ARP)
                 return TC_ACT_OK;
         }
         return TC_ACT_SHOT;
@@ -106,17 +111,20 @@ int intent(struct __sk_buff *skb)
     __u32 dst_ip = bpf_ntohl(ip->daddr);
 
     /* Rules are correlated tuples, not independent allow sets. */
-    for (__u32 i = 0; i < 32; i++)
+    for (__u32 i = 0; i < INTENT_BPF_MAX_RULES; i++)
     {
         if (i >= intent_rule_count)
             break;
 
         const volatile struct intent_bpf_rule *rule = &intent_rules[i];
-        if (rule->kind != 2)
+        if (rule->kind != INTENT_BPF_RULE_IPV4_L4)
             continue;
-        if (rule->ip_dst == dst_ip &&
-            rule->l4_dst_port == dst_port &&
-            proto_allowed(rule, ip->protocol))
+        if (rule->ip_dst != dst_ip || !proto_allowed(rule, ip->protocol))
+            continue;
+        if (rule->l4_dst_port_mode == INTENT_L4_DST_PORT_ANY)
+            return TC_ACT_OK;
+        if (rule->l4_dst_port_mode == INTENT_L4_DST_PORT_EXACT &&
+            rule->l4_dst_port == dst_port)
             return TC_ACT_OK;
     }
 

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -72,16 +72,33 @@ bats_require_minimum_version 1.7.0
     [[ "$output" == *"permitted traffic:"* ]]
 }
 
+@test "--dry-run --explain prints host-wide TCP and UDP permits" {
+    run traffico -i lo --at egress \
+        --allow udp/10.0.0.20 \
+        --allow tcp/10.0.0.10 \
+        --dry-run --explain
+    [ $status -eq 0 ]
+    [[ "$output" == *"  1. TCP to 10.0.0.10 any destination port"* ]]
+    [[ "$output" == *"  2. UDP to 10.0.0.20 any destination port"* ]]
+    [[ "$output" == *"TCP/UDP fragments that cannot be fully classified"* ]]
+    [[ "$output" != *"permit cannot be explained"* ]]
+}
+
 @test "Intent mode rejects ingress until designed" {
     run traffico -i lo --at ingress --allow arp --dry-run
     [ $status -eq 1 ]
     [ "${lines[0]}" == "traffico: intent dry-run: Intent BPF backend supports egress only" ]
 }
 
-@test "--allow rejects malformed values" {
-    run traffico -i lo --allow tcp/10.0.0.10 --dry-run
+@test "--allow accepts host-wide TCP and still rejects malformed values" {
+    run traffico -i lo --at egress --allow tcp/10.0.0.10 --dry-run
+    [ $status -eq 0 ]
+    [[ "$output" == *"intent dry-run: compiler ok"* ]]
+    [[ "$output" == *"intent backend: bpf admissible"* ]]
+
+    run traffico -i lo --allow tcp/10.0.0.10/443 --dry-run
     [ $status -eq 1 ]
-    [ "${lines[0]}" == "traffico: invalid permit: 'tcp/10.0.0.10'" ]
+    [ "${lines[0]}" == "traffico: invalid permit: 'tcp/10.0.0.10/443'" ]
 }
 
 @test "--allow rejects unsupported Intent value" {

--- a/test/ddag_unit.c
+++ b/test/ddag_unit.c
@@ -103,6 +103,29 @@ static int test_decision_dag_chains_three_permit_false_edges(void)
     return 0;
 }
 
+static int test_decision_dag_accepts_host_wide_l4_permit_path(void)
+{
+    struct intent intent = {0};
+    struct decision_dag dag = {0};
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", &err) == 0);
+    intent_normalize(&intent);
+
+    CHECK(intent_build_dag(&intent, &dag, &err) == 0);
+    CHECK(dag.node_count == 3);
+    CHECK(dag.nodes[0].predicate.field == INTENT_FIELD_ETH_TYPE);
+    CHECK(dag.nodes[1].predicate.field == INTENT_FIELD_IP_DST);
+    CHECK(dag.nodes[2].predicate.field == INTENT_FIELD_IP_PROTO);
+    CHECK(dag.nodes[2].on_true.terminal == DECISION_TERMINAL_ALLOW);
+
+    CHECK(intent_validate_dag(&dag, &err) == 0);
+    CHECK(intent_validate_supported_subset(&dag, &err) == 0);
+
+    return 0;
+}
+
 static int test_decision_dag_rejects_future_forbids(void)
 {
     struct intent intent = {0};
@@ -452,6 +475,7 @@ int main(void)
 {
     RUN_TEST(test_decision_dag_builds_predicate_chain);
     RUN_TEST(test_decision_dag_chains_three_permit_false_edges);
+    RUN_TEST(test_decision_dag_accepts_host_wide_l4_permit_path);
     RUN_TEST(test_decision_dag_rejects_future_forbids);
     RUN_TEST(test_decision_dag_rejects_non_drop_default_action);
     RUN_TEST(test_decision_dag_rejects_invalid_public_counts);

--- a/test/enforcement_unit.c
+++ b/test/enforcement_unit.c
@@ -91,6 +91,27 @@ static int test_enforcement_extracts_tcp_ipv4_l4_rule(void)
     return 0;
 }
 
+static int test_enforcement_extracts_host_wide_tcp_any_port_rule(void)
+{
+    struct intent intent = {0};
+    struct intent_enforcement_plan plan = {0};
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", &err) == 0);
+
+    CHECK(build_plan(&intent, &plan, &err) == 0);
+    CHECK(plan.direction == INTENT_DIRECTION_EGRESS);
+    CHECK(plan.rule_count == 1);
+    CHECK(plan.rules[0].kind == INTENT_ENFORCEMENT_RULE_IPV4_L4);
+    CHECK(plan.rules[0].ip_dst == 0x0a00000a);
+    CHECK(plan.rules[0].l4_dst_port_mode == INTENT_L4_DST_PORT_ANY);
+    CHECK(plan.rules[0].l4_dst_port == 0);
+    CHECK(plan.rules[0].ip_proto_count == 1);
+    CHECK(plan.rules[0].ip_protos[0] == INTENT_IPPROTO_TCP);
+    return 0;
+}
+
 static int test_enforcement_extracts_dns_ipv4_l4_rule(void)
 {
     struct intent intent = {0};
@@ -423,6 +444,7 @@ int main(void)
 {
     RUN_TEST(test_enforcement_extracts_arp_rule);
     RUN_TEST(test_enforcement_extracts_tcp_ipv4_l4_rule);
+    RUN_TEST(test_enforcement_extracts_host_wide_tcp_any_port_rule);
     RUN_TEST(test_enforcement_extracts_dns_ipv4_l4_rule);
     RUN_TEST(test_enforcement_extracts_primary_scenario_rows);
     RUN_TEST(test_enforcement_preserves_prior_true_predicates_on_false_edges);

--- a/test/intent.bats
+++ b/test/intent.bats
@@ -131,10 +131,19 @@ assert_intent_tc_cleanup() {
 }
 
 @test "Intent live invalid permit rejection leaves TC untouched" {
-    run ip netns exec "${NETNS}" traffico -i "${PEER}" --allow tcp/10.0.0.10
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --allow tcp/10.0.0.10/443
     [ $status -eq 1 ]
-    [ "${lines[0]}" == "traffico: invalid permit: 'tcp/10.0.0.10'" ]
+    [ "${lines[0]}" == "traffico: invalid permit: 'tcp/10.0.0.10/443'" ]
 
+    assert_intent_tc_cleanup
+}
+
+@test "Intent live host-wide TCP permit creates and cleans TC state" {
+    start_intent_attach "${BATS_TEST_TMPDIR}/intent-host-wide-live.out" \
+        -i "${PEER}" --at egress --allow arp --allow "tcp/${VETH_ADDR}"
+
+    wait_for_intent_tc_state
+    stop_intent_attach
     assert_intent_tc_cleanup
 }
 
@@ -154,7 +163,7 @@ assert_intent_tc_cleanup() {
     [[ "$output" == *"  2. TCP to 10.0.0.10 destination port 443"* ]]
     [[ "$output" == *"  3. UDP to 10.0.0.20 destination port 123"* ]]
     [[ "$output" == *"  4. DNS to 10.0.0.53 over TCP or UDP destination port 53"* ]]
-    [[ "$output" == *"TCP/UDP fragments whose destination port cannot be checked"* ]]
+    [[ "$output" == *"TCP/UDP fragments that cannot be fully classified"* ]]
 }
 
 @test "--explain prints deterministic intent before live attach" {

--- a/test/intent_bpf_unit.c
+++ b/test/intent_bpf_unit.c
@@ -71,6 +71,31 @@ static int test_bpf_lowering_preserves_correlated_rows(void)
     return 0;
 }
 
+static int test_bpf_lowering_accepts_any_destination_port(void)
+{
+    struct intent_enforcement_plan plan = {0};
+    struct intent_bpf_plan bpf_plan = {0};
+    const char *err = NULL;
+
+    plan.direction = INTENT_DIRECTION_EGRESS;
+    plan.rule_count = 1;
+    plan.rules[0].kind = INTENT_ENFORCEMENT_RULE_IPV4_L4;
+    plan.rules[0].ip_dst = 0x0a00000a;
+    plan.rules[0].l4_dst_port_mode = INTENT_L4_DST_PORT_ANY;
+    plan.rules[0].ip_proto_count = 1;
+    plan.rules[0].ip_protos[0] = INTENT_IPPROTO_TCP;
+
+    CHECK(intent_bpf_plan_from_enforcement(&plan, &bpf_plan, &err) == 0);
+    CHECK(bpf_plan.rule_count == 1);
+    CHECK(bpf_plan.rules[0].kind == INTENT_BPF_RULE_IPV4_L4);
+    CHECK(bpf_plan.rules[0].ip_dst == 0x0a00000a);
+    CHECK(bpf_plan.rules[0].l4_dst_port_mode == INTENT_L4_DST_PORT_ANY);
+    CHECK(bpf_plan.rules[0].l4_dst_port == 0);
+    CHECK(bpf_plan.rules[0].ip_proto_count == 1);
+    CHECK(bpf_plan.rules[0].ip_protos[0] == INTENT_IPPROTO_TCP);
+    return 0;
+}
+
 static int expect_unsupported_rule_rejected(const struct intent_enforcement_rule *rule)
 {
     struct intent_enforcement_plan plan = {0};
@@ -207,6 +232,7 @@ static int test_bpf_hook_cleanup_policy(void)
 int main(void)
 {
     RUN_TEST(test_bpf_lowering_preserves_correlated_rows);
+    RUN_TEST(test_bpf_lowering_accepts_any_destination_port);
     RUN_TEST(test_bpf_lowering_rejects_malformed_arp_row);
     RUN_TEST(test_bpf_lowering_rejects_unsupported_proto_value);
     RUN_TEST(test_bpf_lowering_rejects_duplicate_two_entry_proto_set);

--- a/test/intent_host_scapy.bats
+++ b/test/intent_host_scapy.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+
+load helpers
+export BATS_TEST_NAME_PREFIX=$(setsuite)
+bats_require_minimum_version 1.7.0
+
+setup_file() {
+    if ! command -v python3 &>/dev/null; then
+        skip "python3 not found: scapy tests require python3"
+    fi
+    if ! python3 -c "import scapy" &>/dev/null; then
+        skip "scapy not installed: install python-scapy (Arch) or python3-scapy (Ubuntu)"
+    fi
+}
+
+setup() {
+    load net
+    NETNS="ns$((RANDOM % 10))"
+    new_netns "${NETNS}"
+    setup_net "${NETNS}"
+    arp_prewarm "${NETNS}"
+}
+
+teardown() {
+    killall traffico &>/dev/null || true
+    [ -n "${SNIFFER_PID:-}" ] && kill "$SNIFFER_PID" &>/dev/null || true
+    del_netdev
+    del_netns "${NETNS}"
+}
+
+intent_tc_state_exists() {
+    local qdisc
+    local filter
+
+    qdisc="$(ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact)"
+    filter="$(ip netns exec "${NETNS}" tc filter show dev "${PEER}" egress)"
+
+    [[ "${qdisc}" == *"clsact"* && "${filter}" != "" ]]
+}
+
+wait_for_intent_tc_state() {
+    local i
+
+    for i in {1..50}; do
+        if intent_tc_state_exists; then
+            return 0
+        fi
+        sleep 0.1
+    done
+
+    return 1
+}
+
+@test "Intent host-wide TCP permit allows multiple destination ports" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress \
+        --allow arp \
+        --allow "tcp/${VETH_ADDR}" >/dev/null 3>&- &
+    wait_for_intent_tc_state
+
+    assert_packet_seen "${NETNS}" 21001 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 443
+    assert_packet_seen "${NETNS}" 21002 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 8443
+    assert_packet_blocked "${NETNS}" 21003 \
+        --type udp --dst-ip "${VETH_ADDR}" --dst-port 443
+    assert_packet_blocked "${NETNS}" 21004 \
+        --type tcp --dst-ip "${PEER_ADDR}" --dst-port 443
+}
+
+@test "Intent host-wide UDP permit allows multiple destination ports" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress \
+        --allow arp \
+        --allow "udp/${VETH_ADDR}" >/dev/null 3>&- &
+    wait_for_intent_tc_state
+
+    assert_packet_seen "${NETNS}" 22001 \
+        --type udp --dst-ip "${VETH_ADDR}" --dst-port 123
+    assert_packet_seen "${NETNS}" 22002 \
+        --type udp --dst-ip "${VETH_ADDR}" --dst-port 9999
+    assert_packet_blocked "${NETNS}" 22003 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 123
+    assert_packet_blocked "${NETNS}" 22004 \
+        --type udp --dst-ip "${PEER_ADDR}" --dst-port 123
+}

--- a/test/intent_unit.c
+++ b/test/intent_unit.c
@@ -151,14 +151,74 @@ static int test_parse_ipv4_addresses(void)
     return 0;
 }
 
+static int test_parse_host_wide_l4_permits(void)
+{
+    struct intent intent = {0};
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", &err) == 0);
+    CHECK(intent_add_permit(&intent, "udp/10.0.0.20", &err) == 0);
+
+    CHECK(intent.permit_count == 2);
+    CHECK(intent.permits[0].predicate_count == 3);
+    CHECK_PREDICATE(&intent.permits[0].predicates[0],
+                    INTENT_FIELD_ETH_TYPE,
+                    INTENT_OP_EQ,
+                    1,
+                    INTENT_ETH_P_IP,
+                    0);
+    CHECK_PREDICATE(&intent.permits[0].predicates[1],
+                    INTENT_FIELD_IP_DST,
+                    INTENT_OP_EQ,
+                    1,
+                    0x0a00000a,
+                    0);
+    CHECK_PREDICATE(&intent.permits[0].predicates[2],
+                    INTENT_FIELD_IP_PROTO,
+                    INTENT_OP_EQ,
+                    1,
+                    INTENT_IPPROTO_TCP,
+                    0);
+
+    CHECK(intent.permits[1].predicate_count == 3);
+    CHECK_PREDICATE(&intent.permits[1].predicates[1],
+                    INTENT_FIELD_IP_DST,
+                    INTENT_OP_EQ,
+                    1,
+                    0x0a000014,
+                    0);
+    CHECK_PREDICATE(&intent.permits[1].predicates[2],
+                    INTENT_FIELD_IP_PROTO,
+                    INTENT_OP_EQ,
+                    1,
+                    INTENT_IPPROTO_UDP,
+                    0);
+
+    return 0;
+}
+
+static int test_rejects_duplicate_host_wide_l4_permits(void)
+{
+    struct intent intent = {0};
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", &err) == 0);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", &err) == -1);
+    CHECK(strcmp(err, "duplicate permit") == 0);
+
+    return 0;
+}
+
 static int test_rejects_invalid_and_duplicate_permits(void)
 {
     struct intent intent = {0};
     const char *err = NULL;
 
     intent_init(&intent, INTENT_DIRECTION_EGRESS);
-    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", &err) == -1);
-    CHECK(strcmp(err, "invalid permit") == 0);
     CHECK(intent_add_permit(&intent, "tcp/10.0.0.10/443", &err) == -1);
     CHECK(strcmp(err, "invalid permit") == 0);
     CHECK(intent_add_permit(&intent, "udp/10.0.0.20:0", &err) == -1);
@@ -173,7 +233,7 @@ static int test_rejects_invalid_and_duplicate_permits(void)
     CHECK(strcmp(err, "dns permits do not accept a port") == 0);
     CHECK(intent_add_permit(&intent, "icmp/10.0.0.10", &err) == -1);
     CHECK(strcmp(err, "unsupported permit") == 0);
-    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", NULL) == -1);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10/443", NULL) == -1);
     CHECK(intent_add_permit(&intent, NULL, &err) == -1);
     CHECK(strcmp(err, "invalid permit") == 0);
     CHECK(intent_add_permit(&intent, "arp", &err) == 0);
@@ -378,6 +438,8 @@ int main(void)
 {
     RUN_TEST(test_parse_first_permits);
     RUN_TEST(test_parse_ipv4_addresses);
+    RUN_TEST(test_parse_host_wide_l4_permits);
+    RUN_TEST(test_rejects_duplicate_host_wide_l4_permits);
     RUN_TEST(test_rejects_invalid_and_duplicate_permits);
     RUN_TEST(test_rejects_duplicate_lowered_permits);
     RUN_TEST(test_rejects_empty_permits);


### PR DESCRIPTION
## Summary

- Accept tcp/IPv4 and udp/IPv4 Intent selectors as host-wide permits for any destination port.
- Carry exact-port vs any-port mode through DDAG validation, enforcement rows, BPF rodata, loader copy, and TC BPF matching.
- Add parser, DDAG, enforcement, BPF lowering, CLI explain, live attach, and Scapy coverage for host-wide TCP and UDP permits.

## Verification

- Docker focused PR1 gate: xmake run test test/intent_unit.bats test/ddag_unit.bats test/enforcement_unit.bats test/intent_bpf_unit.bats test/intent_host_scapy.bats test/cli.flags.bats test/intent.bats
  - Passed: 91 tests.
- Docker post-cleanup BPF/live gate: xmake run test test/intent_bpf_unit.bats test/intent_host_scapy.bats
  - Passed: 3 tests.

## Notes

This is PR 1 of the local v0.6 Intent egress quarantine stack. todo.txt and docs/superpowers/** remain local/private and are not included.