### PR TITLE
feat(intent): add forbid cli and ir

### DIFF
--- a/api/dag.h
+++ b/api/dag.h
@@ -374,8 +374,7 @@ static inline bool intent_subset_context_allows_terminal(struct intent_subset_co
 {
     bool has_l4_service = context.has_ipv4 &&
                           context.has_ip_dst &&
-                          context.has_l4_proto &&
-                          context.has_l4_dst_port;
+                          context.has_l4_proto;
 
     return context.has_arp || has_l4_service;
 }

--- a/api/enforcement.h
+++ b/api/enforcement.h
@@ -6,8 +6,9 @@
 #include <string.h>
 
 #include "dag.h"
+#include "intent_l4.h"
 
-#define MAX_INTENT_ENFORCEMENT_RULES MAX_INTENT_PERMITS
+#define MAX_INTENT_ENFORCEMENT_RULES (MAX_INTENT_PERMITS + MAX_INTENT_FORBIDS)
 #define MAX_INTENT_ENFORCEMENT_PROTOS 2
 
 enum intent_enforcement_rule_kind
@@ -20,6 +21,7 @@ struct intent_enforcement_rule
 {
     enum intent_enforcement_rule_kind kind;
     uint32_t ip_dst;
+    enum intent_l4_dst_port_mode l4_dst_port_mode;
     uint16_t l4_dst_port;
     uint8_t ip_protos[MAX_INTENT_ENFORCEMENT_PROTOS];
     size_t ip_proto_count;
@@ -253,6 +255,7 @@ static inline int intent_enforcement_append_rule(struct intent_enforcement_plan 
         const struct intent_enforcement_rule *existing = &plan->rules[i];
         if (existing->kind == rule->kind &&
             existing->ip_dst == rule->ip_dst &&
+            existing->l4_dst_port_mode == rule->l4_dst_port_mode &&
             existing->l4_dst_port == rule->l4_dst_port &&
             existing->ip_proto_count == rule->ip_proto_count &&
             existing->ip_protos[0] == rule->ip_protos[0] &&
@@ -357,10 +360,11 @@ static inline int intent_enforcement_emit_path(const struct intent_enforcement_p
 
     if (eth_type == INTENT_ETH_P_IP &&
         has_ip_dst &&
-        has_ip_proto &&
-        has_l4_dst_port)
+        has_ip_proto)
     {
         rule.kind = INTENT_ENFORCEMENT_RULE_IPV4_L4;
+        rule.l4_dst_port_mode = has_l4_dst_port ? INTENT_L4_DST_PORT_EXACT
+                                                : INTENT_L4_DST_PORT_ANY;
         return intent_enforcement_append_rule(plan, &rule, err_msg);
     }
 

--- a/api/intent.h
+++ b/api/intent.h
@@ -9,9 +9,8 @@
 #include <string.h>
 
 #define MAX_INTENT_PERMITS 32
-/* This bound only covers the IPv4 grammar accepted today. */
-#define MAX_INTENT_PERMIT_INPUT_LEN 128
-/* Forbid storage is reserved for the Intent model. */
+/* This bound only covers the IPv4 selector grammar accepted today. */
+#define MAX_INTENT_SELECTOR_INPUT_LEN 128
 #define MAX_INTENT_FORBIDS 32
 #define MAX_INTENT_PREDICATES 6
 #define MAX_INTENT_SET_VALUES 4
@@ -196,57 +195,127 @@ static inline void intent_normalize_predicate_values(struct intent_predicate *pr
           intent_value_qsort_compare);
 }
 
-static inline int intent_validate_predicate_shape(const struct intent_predicate *predicate,
-                                                  const char **err_msg)
+static inline int intent_validate_predicate_shape_msg(const struct intent_predicate *predicate,
+                                                      const char *invalid_msg,
+                                                      const char **err_msg)
 {
     if (predicate->values.count == 0 ||
         predicate->values.count > MAX_INTENT_SET_VALUES)
-        return intent_fail(err_msg, "invalid permit");
+        return intent_fail(err_msg, invalid_msg);
 
     if (predicate->op == INTENT_OP_EQ)
     {
         if (predicate->values.count != 1)
-            return intent_fail(err_msg, "invalid permit");
+            return intent_fail(err_msg, invalid_msg);
         return 0;
     }
 
     if (predicate->op != INTENT_OP_IN)
-        return intent_fail(err_msg, "invalid permit");
+        return intent_fail(err_msg, invalid_msg);
 
     if (predicate->values.count < 2)
-        return intent_fail(err_msg, "invalid permit");
+        return intent_fail(err_msg, invalid_msg);
     for (size_t i = 1; i < predicate->values.count; i++)
     {
         if (predicate->values.values[i - 1] == predicate->values.values[i])
-            return intent_fail(err_msg, "invalid permit");
+            return intent_fail(err_msg, invalid_msg);
     }
     return 0;
 }
 
-static inline void intent_normalize_permit(struct intent_permit *permit)
+static inline int intent_validate_predicate_shape(const struct intent_predicate *predicate,
+                                                  const char **err_msg)
 {
-    for (size_t i = 0; i < permit->predicate_count; i++)
-        intent_normalize_predicate_values(&permit->predicates[i]);
+    return intent_validate_predicate_shape_msg(predicate, "invalid permit", err_msg);
+}
+
+static inline void intent_normalize_predicates(struct intent_predicate *predicates,
+                                               size_t predicate_count)
+{
+    for (size_t i = 0; i < predicate_count; i++)
+        intent_normalize_predicate_values(&predicates[i]);
 
     /* Canonical predicate order makes duplicate detection order independent. */
-    qsort(permit->predicates,
-          permit->predicate_count,
-          sizeof(permit->predicates[0]),
+    qsort(predicates,
+          predicate_count,
+          sizeof(predicates[0]),
           intent_predicate_qsort_compare);
+}
+
+static inline void intent_normalize_permit(struct intent_permit *permit)
+{
+    intent_normalize_predicates(permit->predicates, permit->predicate_count);
+}
+
+static inline void intent_normalize_forbid(struct intent_forbid *forbid)
+{
+    intent_normalize_predicates(forbid->predicates, forbid->predicate_count);
+}
+
+static inline bool intent_predicate_list_equal(const struct intent_predicate *left,
+                                               size_t left_count,
+                                               const struct intent_predicate *right,
+                                               size_t right_count)
+{
+    if (left_count != right_count)
+        return false;
+
+    for (size_t i = 0; i < left_count; i++)
+    {
+        if (!intent_predicate_equal(&left[i], &right[i]))
+            return false;
+    }
+    return true;
 }
 
 static inline bool intent_permit_equal(const struct intent_permit *left,
                                        const struct intent_permit *right)
 {
-    if (left->predicate_count != right->predicate_count)
-        return false;
+    return intent_predicate_list_equal(left->predicates,
+                                       left->predicate_count,
+                                       right->predicates,
+                                       right->predicate_count);
+}
 
-    for (size_t i = 0; i < left->predicate_count; i++)
-    {
-        if (!intent_predicate_equal(&left->predicates[i], &right->predicates[i]))
-            return false;
-    }
-    return true;
+static inline bool intent_forbid_equal(const struct intent_forbid *left,
+                                       const struct intent_forbid *right)
+{
+    return intent_predicate_list_equal(left->predicates,
+                                       left->predicate_count,
+                                       right->predicates,
+                                       right->predicate_count);
+}
+
+static inline int intent_rule_add_predicate(struct intent_predicate *predicates,
+                                            size_t *predicate_count,
+                                            enum intent_predicate_field field,
+                                            enum intent_predicate_op op,
+                                            const uint32_t *values,
+                                            size_t value_count,
+                                            const char *invalid_msg,
+                                            const char **err_msg)
+{
+    struct intent_predicate predicate = {0};
+
+    if (!predicates || !predicate_count || !values)
+        return intent_fail(err_msg, invalid_msg);
+    if (*predicate_count >= MAX_INTENT_PREDICATES ||
+        value_count == 0 ||
+        value_count > MAX_INTENT_SET_VALUES)
+        return intent_fail(err_msg, invalid_msg);
+
+    predicate.field = field;
+    predicate.op = op;
+    predicate.values.count = value_count;
+    for (size_t i = 0; i < value_count; i++)
+        predicate.values.values[i] = values[i];
+    intent_normalize_predicate_values(&predicate);
+    if (intent_validate_predicate_shape_msg(&predicate, invalid_msg, err_msg) != 0)
+        return -1;
+
+    predicates[*predicate_count] = predicate;
+    (*predicate_count)++;
+    return 0;
 }
 
 static inline int intent_add_predicate(struct intent_permit *permit,
@@ -256,26 +325,95 @@ static inline int intent_add_predicate(struct intent_permit *permit,
                                        size_t value_count,
                                        const char **err_msg)
 {
-    struct intent_predicate predicate = {0};
-
-    if (!permit || !values)
+    if (!permit)
         return intent_fail(err_msg, "invalid permit");
-    if (permit->predicate_count >= MAX_INTENT_PREDICATES ||
-        value_count == 0 ||
-        value_count > MAX_INTENT_SET_VALUES)
-        return intent_fail(err_msg, "invalid permit");
+    return intent_rule_add_predicate(permit->predicates,
+                                     &permit->predicate_count,
+                                     field,
+                                     op,
+                                     values,
+                                     value_count,
+                                     "invalid permit",
+                                     err_msg);
+}
 
-    predicate.field = field;
-    predicate.op = op;
-    predicate.values.count = value_count;
-    for (size_t i = 0; i < value_count; i++)
-        predicate.values.values[i] = values[i];
-    intent_normalize_predicate_values(&predicate);
-    if (intent_validate_predicate_shape(&predicate, err_msg) != 0)
-        return -1;
+static inline int intent_add_forbid_predicate(struct intent_forbid *forbid,
+                                              enum intent_predicate_field field,
+                                              enum intent_predicate_op op,
+                                              const uint32_t *values,
+                                              size_t value_count,
+                                              const char **err_msg)
+{
+    if (!forbid)
+        return intent_fail(err_msg, "invalid forbid");
+    return intent_rule_add_predicate(forbid->predicates,
+                                     &forbid->predicate_count,
+                                     field,
+                                     op,
+                                     values,
+                                     value_count,
+                                     "invalid forbid",
+                                     err_msg);
+}
 
-    permit->predicates[permit->predicate_count] = predicate;
-    permit->predicate_count++;
+static inline int intent_add_forbid_eq(struct intent_forbid *forbid,
+                                       enum intent_predicate_field field,
+                                       uint32_t value,
+                                       const char **err_msg)
+{
+    return intent_add_forbid_predicate(forbid, field, INTENT_OP_EQ, &value, 1, err_msg);
+}
+
+static inline int intent_add_forbid_proto_in_tcp_udp(struct intent_forbid *forbid,
+                                                     const char **err_msg)
+{
+    const uint32_t protos[] = {INTENT_IPPROTO_TCP, INTENT_IPPROTO_UDP};
+    return intent_add_forbid_predicate(forbid,
+                                       INTENT_FIELD_IP_PROTO,
+                                       INTENT_OP_IN,
+                                       protos,
+                                       2,
+                                       err_msg);
+}
+
+static inline void intent_forbid_init(struct intent_forbid *forbid)
+{
+    memset(forbid, 0, sizeof(*forbid));
+}
+
+static inline bool intent_has_forbid(const struct intent *intent,
+                                     const struct intent_forbid *candidate)
+{
+    for (size_t i = 0; i < intent->forbid_count; i++)
+    {
+        if (intent_forbid_equal(&intent->forbids[i], candidate))
+            return true;
+    }
+    return false;
+}
+
+static inline int intent_append_forbid(struct intent *intent,
+                                       const struct intent_forbid *forbid,
+                                       const char **err_msg)
+{
+    struct intent_forbid normalized = *forbid;
+    intent_normalize_forbid(&normalized);
+
+    if (normalized.predicate_count == 0)
+        return intent_fail(err_msg, "forbid has no predicates");
+    for (size_t i = 0; i < normalized.predicate_count; i++)
+    {
+        if (intent_validate_predicate_shape_msg(&normalized.predicates[i],
+                                                "invalid forbid",
+                                                err_msg) != 0)
+            return -1;
+    }
+    if (intent_has_forbid(intent, &normalized))
+        return intent_fail(err_msg, "duplicate forbid");
+    if (intent->forbid_count >= MAX_INTENT_FORBIDS)
+        return intent_fail(err_msg, "too many forbids");
+    intent->forbids[intent->forbid_count] = normalized;
+    intent->forbid_count++;
     return 0;
 }
 
@@ -394,11 +532,64 @@ static inline int intent_add_l4_permit(struct intent *intent,
     return intent_append_permit(intent, &permit, err_msg);
 }
 
+static inline int intent_add_arp_forbid(struct intent *intent,
+                                        const char **err_msg)
+{
+    struct intent_forbid forbid;
+    intent_forbid_init(&forbid);
+    if (intent_add_forbid_eq(&forbid, INTENT_FIELD_ETH_TYPE, INTENT_ETH_P_ARP, err_msg) != 0)
+        return -1;
+    return intent_append_forbid(intent, &forbid, err_msg);
+}
+
+static inline int intent_add_dns_forbid(struct intent *intent,
+                                        const char *ip,
+                                        const char **err_msg)
+{
+    uint32_t dst_ip = 0;
+    struct intent_forbid forbid;
+    intent_forbid_init(&forbid);
+
+    if (intent_parse_ipv4(ip, &dst_ip) != 0)
+        return intent_fail(err_msg, "invalid forbid");
+    if (intent_add_forbid_eq(&forbid, INTENT_FIELD_ETH_TYPE, INTENT_ETH_P_IP, err_msg) != 0 ||
+        intent_add_forbid_eq(&forbid, INTENT_FIELD_IP_DST, dst_ip, err_msg) != 0 ||
+        intent_add_forbid_proto_in_tcp_udp(&forbid, err_msg) != 0 ||
+        intent_add_forbid_eq(&forbid, INTENT_FIELD_L4_DST_PORT, INTENT_DNS_PORT, err_msg) != 0)
+        return -1;
+
+    return intent_append_forbid(intent, &forbid, err_msg);
+}
+
+static inline int intent_add_l4_forbid(struct intent *intent,
+                                       uint32_t proto,
+                                       const char *ip,
+                                       const char *port,
+                                       const char **err_msg)
+{
+    uint32_t dst_ip = 0;
+    uint32_t dst_port = 0;
+    struct intent_forbid forbid;
+    intent_forbid_init(&forbid);
+
+    if (!port ||
+        intent_parse_ipv4(ip, &dst_ip) != 0 ||
+        intent_parse_port(port, &dst_port) != 0)
+        return intent_fail(err_msg, "invalid forbid");
+    if (intent_add_forbid_eq(&forbid, INTENT_FIELD_ETH_TYPE, INTENT_ETH_P_IP, err_msg) != 0 ||
+        intent_add_forbid_eq(&forbid, INTENT_FIELD_IP_DST, dst_ip, err_msg) != 0 ||
+        intent_add_forbid_eq(&forbid, INTENT_FIELD_IP_PROTO, proto, err_msg) != 0 ||
+        intent_add_forbid_eq(&forbid, INTENT_FIELD_L4_DST_PORT, dst_port, err_msg) != 0)
+        return -1;
+
+    return intent_append_forbid(intent, &forbid, err_msg);
+}
+
 static inline int intent_add_permit(struct intent *intent,
                                     const char *arg,
                                     const char **err_msg)
 {
-    char buf[MAX_INTENT_PERMIT_INPUT_LEN];
+    char buf[MAX_INTENT_SELECTOR_INPUT_LEN];
     char *kind = NULL;
     char *target = NULL;
     char *port = NULL;
@@ -451,21 +642,92 @@ static inline int intent_add_permit(struct intent *intent,
     return intent_fail(err_msg, "unsupported permit");
 }
 
-static inline int intent_permit_compare(const void *left, const void *right)
+static inline int intent_add_forbid(struct intent *intent,
+                                    const char *arg,
+                                    const char **err_msg)
 {
-    const struct intent_permit *a = left;
-    const struct intent_permit *b = right;
+    char buf[MAX_INTENT_SELECTOR_INPUT_LEN];
+    char *kind = NULL;
+    char *target = NULL;
+    char *port = NULL;
+    size_t arg_len = 0;
 
-    if (a->predicate_count != b->predicate_count)
-        return a->predicate_count < b->predicate_count ? -1 : 1;
+    if (!arg)
+        return intent_fail(err_msg, "invalid forbid");
+    arg_len = strlen(arg);
 
-    for (size_t i = 0; i < a->predicate_count; i++)
+    if (arg_len >= sizeof(buf))
+        return intent_fail(err_msg, "forbid too long");
+
+    if (strcmp(arg, "arp") == 0)
+        return intent_add_arp_forbid(intent, err_msg);
+
+    memcpy(buf, arg, arg_len + 1);
+    kind = buf;
+    target = strchr(kind, '/');
+    if (!target)
+        return intent_fail(err_msg, "unsupported forbid");
+    *target++ = '\0';
+
+    if (strcmp(kind, "dns") == 0)
     {
-        int cmp = intent_predicate_compare(&a->predicates[i], &b->predicates[i]);
+        if (strchr(target, ':'))
+            return intent_fail(err_msg, "dns forbids do not accept a port");
+        return intent_add_dns_forbid(intent, target, err_msg);
+    }
+    if (strcmp(kind, "tcp") == 0)
+    {
+        port = strrchr(target, ':');
+        if (port)
+            *port++ = '\0';
+        return intent_add_l4_forbid(intent, INTENT_IPPROTO_TCP, target, port, err_msg);
+    }
+    if (strcmp(kind, "udp") == 0)
+    {
+        port = strrchr(target, ':');
+        if (port)
+            *port++ = '\0';
+        return intent_add_l4_forbid(intent, INTENT_IPPROTO_UDP, target, port, err_msg);
+    }
+
+    return intent_fail(err_msg, "unsupported forbid");
+}
+
+static inline int intent_rule_compare(const struct intent_predicate *left,
+                                      size_t left_count,
+                                      const struct intent_predicate *right,
+                                      size_t right_count)
+{
+    if (left_count != right_count)
+        return left_count < right_count ? -1 : 1;
+
+    for (size_t i = 0; i < left_count; i++)
+    {
+        int cmp = intent_predicate_compare(&left[i], &right[i]);
         if (cmp != 0)
             return cmp;
     }
     return 0;
+}
+
+static inline int intent_permit_compare(const void *left, const void *right)
+{
+    const struct intent_permit *a = left;
+    const struct intent_permit *b = right;
+    return intent_rule_compare(a->predicates,
+                               a->predicate_count,
+                               b->predicates,
+                               b->predicate_count);
+}
+
+static inline int intent_forbid_compare(const void *left, const void *right)
+{
+    const struct intent_forbid *a = left;
+    const struct intent_forbid *b = right;
+    return intent_rule_compare(a->predicates,
+                               a->predicate_count,
+                               b->predicates,
+                               b->predicate_count);
 }
 
 static inline void intent_normalize(struct intent *intent)
@@ -476,15 +738,23 @@ static inline void intent_normalize(struct intent *intent)
           intent->permit_count,
           sizeof(intent->permits[0]),
           intent_permit_compare);
+
+    for (size_t i = 0; i < intent->forbid_count; i++)
+        intent_normalize_forbid(&intent->forbids[i]);
+    qsort(intent->forbids,
+          intent->forbid_count,
+          sizeof(intent->forbids[0]),
+          intent_forbid_compare);
 }
 
-static inline bool intent_permit_get_eq(const struct intent_permit *permit,
-                                        enum intent_predicate_field field,
-                                        uint32_t *out)
+static inline bool intent_rule_get_eq(const struct intent_predicate *predicates,
+                                      size_t predicate_count,
+                                      enum intent_predicate_field field,
+                                      uint32_t *out)
 {
-    for (size_t i = 0; i < permit->predicate_count; i++)
+    for (size_t i = 0; i < predicate_count; i++)
     {
-        const struct intent_predicate *predicate = &permit->predicates[i];
+        const struct intent_predicate *predicate = &predicates[i];
         if (predicate->field == field &&
             predicate->op == INTENT_OP_EQ &&
             predicate->values.count == 1)
@@ -496,11 +766,26 @@ static inline bool intent_permit_get_eq(const struct intent_permit *permit,
     return false;
 }
 
-static inline bool intent_permit_has_proto_in_tcp_udp(const struct intent_permit *permit)
+static inline bool intent_permit_get_eq(const struct intent_permit *permit,
+                                        enum intent_predicate_field field,
+                                        uint32_t *out)
 {
-    for (size_t i = 0; i < permit->predicate_count; i++)
+    return intent_rule_get_eq(permit->predicates, permit->predicate_count, field, out);
+}
+
+static inline bool intent_forbid_get_eq(const struct intent_forbid *forbid,
+                                        enum intent_predicate_field field,
+                                        uint32_t *out)
+{
+    return intent_rule_get_eq(forbid->predicates, forbid->predicate_count, field, out);
+}
+
+static inline bool intent_rule_has_proto_in_tcp_udp(const struct intent_predicate *predicates,
+                                                    size_t predicate_count)
+{
+    for (size_t i = 0; i < predicate_count; i++)
     {
-        const struct intent_predicate *predicate = &permit->predicates[i];
+        const struct intent_predicate *predicate = &predicates[i];
         if (predicate->field == INTENT_FIELD_IP_PROTO &&
             predicate->op == INTENT_OP_IN &&
             predicate->values.count == 2)
@@ -522,6 +807,16 @@ static inline bool intent_permit_has_proto_in_tcp_udp(const struct intent_permit
     return false;
 }
 
+static inline bool intent_permit_has_proto_in_tcp_udp(const struct intent_permit *permit)
+{
+    return intent_rule_has_proto_in_tcp_udp(permit->predicates, permit->predicate_count);
+}
+
+static inline bool intent_forbid_has_proto_in_tcp_udp(const struct intent_forbid *forbid)
+{
+    return intent_rule_has_proto_in_tcp_udp(forbid->predicates, forbid->predicate_count);
+}
+
 static inline void intent_format_ip(uint32_t ip, char *buf, size_t len)
 {
     struct in_addr addr = {0};
@@ -529,12 +824,159 @@ static inline void intent_format_ip(uint32_t ip, char *buf, size_t len)
     inet_ntop(AF_INET, &addr, buf, len);
 }
 
+static inline bool intent_print_permit_explain(FILE *out,
+                                               size_t index,
+                                               const struct intent_permit *permit)
+{
+    char ip[INET_ADDRSTRLEN];
+    uint32_t eth_type = 0;
+    uint32_t ip_dst = 0;
+    uint32_t proto = 0;
+    uint32_t port = 0;
+    bool has_port = intent_permit_get_eq(permit, INTENT_FIELD_L4_DST_PORT, &port);
+
+    if (intent_permit_get_eq(permit, INTENT_FIELD_ETH_TYPE, &eth_type) &&
+        eth_type == INTENT_ETH_P_ARP)
+    {
+        fprintf(out, "  %zu. ARP\n", index);
+        return false;
+    }
+
+    if (intent_permit_get_eq(permit, INTENT_FIELD_ETH_TYPE, &eth_type) &&
+        eth_type == INTENT_ETH_P_IP &&
+        intent_permit_get_eq(permit, INTENT_FIELD_IP_DST, &ip_dst) &&
+        has_port &&
+        intent_permit_has_proto_in_tcp_udp(permit) &&
+        port == INTENT_DNS_PORT)
+    {
+        intent_format_ip(ip_dst, ip, sizeof(ip));
+        fprintf(out, "  %zu. DNS to %s over TCP or UDP destination port 53\n",
+                index,
+                ip);
+        return true;
+    }
+
+    if (intent_permit_get_eq(permit, INTENT_FIELD_ETH_TYPE, &eth_type) &&
+        eth_type == INTENT_ETH_P_IP &&
+        intent_permit_get_eq(permit, INTENT_FIELD_IP_DST, &ip_dst) &&
+        intent_permit_get_eq(permit, INTENT_FIELD_IP_PROTO, &proto) &&
+        proto == INTENT_IPPROTO_TCP)
+    {
+        intent_format_ip(ip_dst, ip, sizeof(ip));
+        if (has_port)
+        {
+            fprintf(out, "  %zu. TCP to %s destination port %u\n",
+                    index,
+                    ip,
+                    port);
+        }
+        else
+        {
+            fprintf(out, "  %zu. TCP to %s any destination port\n",
+                    index,
+                    ip);
+        }
+        return true;
+    }
+
+    if (intent_permit_get_eq(permit, INTENT_FIELD_ETH_TYPE, &eth_type) &&
+        eth_type == INTENT_ETH_P_IP &&
+        intent_permit_get_eq(permit, INTENT_FIELD_IP_DST, &ip_dst) &&
+        intent_permit_get_eq(permit, INTENT_FIELD_IP_PROTO, &proto) &&
+        proto == INTENT_IPPROTO_UDP)
+    {
+        intent_format_ip(ip_dst, ip, sizeof(ip));
+        if (has_port)
+        {
+            fprintf(out, "  %zu. UDP to %s destination port %u\n",
+                    index,
+                    ip,
+                    port);
+        }
+        else
+        {
+            fprintf(out, "  %zu. UDP to %s any destination port\n",
+                    index,
+                    ip);
+        }
+        return true;
+    }
+
+    fprintf(out, "  %zu. permit cannot be explained by this traffico version\n", index);
+    return false;
+}
+
+static inline bool intent_print_forbid_explain(FILE *out,
+                                               size_t index,
+                                               const struct intent_forbid *forbid)
+{
+    char ip[INET_ADDRSTRLEN];
+    uint32_t eth_type = 0;
+    uint32_t ip_dst = 0;
+    uint32_t proto = 0;
+    uint32_t port = 0;
+    bool has_port = intent_forbid_get_eq(forbid, INTENT_FIELD_L4_DST_PORT, &port);
+
+    if (intent_forbid_get_eq(forbid, INTENT_FIELD_ETH_TYPE, &eth_type) &&
+        eth_type == INTENT_ETH_P_ARP)
+    {
+        fprintf(out, "  %zu. ARP\n", index);
+        return false;
+    }
+
+    if (intent_forbid_get_eq(forbid, INTENT_FIELD_ETH_TYPE, &eth_type) &&
+        eth_type == INTENT_ETH_P_IP &&
+        intent_forbid_get_eq(forbid, INTENT_FIELD_IP_DST, &ip_dst) &&
+        has_port &&
+        intent_forbid_has_proto_in_tcp_udp(forbid) &&
+        port == INTENT_DNS_PORT)
+    {
+        intent_format_ip(ip_dst, ip, sizeof(ip));
+        fprintf(out, "  %zu. DNS to %s over TCP or UDP destination port 53\n",
+                index,
+                ip);
+        return true;
+    }
+
+    if (intent_forbid_get_eq(forbid, INTENT_FIELD_ETH_TYPE, &eth_type) &&
+        eth_type == INTENT_ETH_P_IP &&
+        intent_forbid_get_eq(forbid, INTENT_FIELD_IP_DST, &ip_dst) &&
+        has_port &&
+        intent_forbid_get_eq(forbid, INTENT_FIELD_IP_PROTO, &proto) &&
+        proto == INTENT_IPPROTO_TCP)
+    {
+        intent_format_ip(ip_dst, ip, sizeof(ip));
+        fprintf(out, "  %zu. TCP to %s destination port %u\n",
+                index,
+                ip,
+                port);
+        return true;
+    }
+
+    if (intent_forbid_get_eq(forbid, INTENT_FIELD_ETH_TYPE, &eth_type) &&
+        eth_type == INTENT_ETH_P_IP &&
+        intent_forbid_get_eq(forbid, INTENT_FIELD_IP_DST, &ip_dst) &&
+        has_port &&
+        intent_forbid_get_eq(forbid, INTENT_FIELD_IP_PROTO, &proto) &&
+        proto == INTENT_IPPROTO_UDP)
+    {
+        intent_format_ip(ip_dst, ip, sizeof(ip));
+        fprintf(out, "  %zu. UDP to %s destination port %u\n",
+                index,
+                ip,
+                port);
+        return true;
+    }
+
+    fprintf(out, "  %zu. forbid cannot be explained by this traffico version\n", index);
+    return false;
+}
+
 static inline void intent_print_explain(FILE *out,
                                         const char *ifname,
                                         const struct intent *intent)
 {
-    char ip[INET_ADDRSTRLEN];
-    bool has_l4_permits = false;
+    bool has_l4_rules = false;
 
     /*
      * The caller passes a normalized Intent.
@@ -549,91 +991,27 @@ static inline void intent_print_explain(FILE *out,
 
     for (size_t i = 0; i < intent->permit_count; i++)
     {
-        const struct intent_permit *permit = &intent->permits[i];
-        uint32_t eth_type = 0;
-        uint32_t ip_dst = 0;
-        uint32_t proto = 0;
-        uint32_t port = 0;
-        bool has_port = intent_permit_get_eq(permit, INTENT_FIELD_L4_DST_PORT, &port);
+        if (intent_print_permit_explain(out, i + 1, &intent->permits[i]))
+            has_l4_rules = true;
+    }
 
-        if (intent_permit_get_eq(permit, INTENT_FIELD_ETH_TYPE, &eth_type) &&
-            eth_type == INTENT_ETH_P_ARP)
+    if (intent->forbid_count > 0)
+    {
+        fprintf(out, "\nforbidden traffic:\n");
+        for (size_t i = 0; i < intent->forbid_count; i++)
         {
-            fprintf(out, "  %zu. ARP\n", i + 1);
-            continue;
+            if (intent_print_forbid_explain(out, i + 1, &intent->forbids[i]))
+                has_l4_rules = true;
         }
-
-        if (intent_permit_get_eq(permit, INTENT_FIELD_ETH_TYPE, &eth_type) &&
-            eth_type == INTENT_ETH_P_IP &&
-            intent_permit_get_eq(permit, INTENT_FIELD_IP_DST, &ip_dst) &&
-            has_port &&
-            intent_permit_has_proto_in_tcp_udp(permit) &&
-            port == INTENT_DNS_PORT)
-        {
-            has_l4_permits = true;
-            intent_format_ip(ip_dst, ip, sizeof(ip));
-            fprintf(out, "  %zu. DNS to %s over TCP or UDP destination port 53\n",
-                    i + 1,
-                    ip);
-            continue;
-        }
-
-        if (intent_permit_get_eq(permit, INTENT_FIELD_ETH_TYPE, &eth_type) &&
-            eth_type == INTENT_ETH_P_IP &&
-            intent_permit_get_eq(permit, INTENT_FIELD_IP_DST, &ip_dst) &&
-            intent_permit_get_eq(permit, INTENT_FIELD_IP_PROTO, &proto) &&
-            proto == INTENT_IPPROTO_TCP)
-        {
-            has_l4_permits = true;
-            intent_format_ip(ip_dst, ip, sizeof(ip));
-            if (has_port)
-            {
-                fprintf(out, "  %zu. TCP to %s destination port %u\n",
-                        i + 1,
-                        ip,
-                        port);
-            }
-            else
-            {
-                fprintf(out, "  %zu. TCP to %s any destination port\n",
-                        i + 1,
-                        ip);
-            }
-            continue;
-        }
-
-        if (intent_permit_get_eq(permit, INTENT_FIELD_ETH_TYPE, &eth_type) &&
-            eth_type == INTENT_ETH_P_IP &&
-            intent_permit_get_eq(permit, INTENT_FIELD_IP_DST, &ip_dst) &&
-            intent_permit_get_eq(permit, INTENT_FIELD_IP_PROTO, &proto) &&
-            proto == INTENT_IPPROTO_UDP)
-        {
-            has_l4_permits = true;
-            intent_format_ip(ip_dst, ip, sizeof(ip));
-            if (has_port)
-            {
-                fprintf(out, "  %zu. UDP to %s destination port %u\n",
-                        i + 1,
-                        ip,
-                        port);
-            }
-            else
-            {
-                fprintf(out, "  %zu. UDP to %s any destination port\n",
-                        i + 1,
-                        ip);
-            }
-            continue;
-        }
-
-        fprintf(out, "  %zu. permit cannot be explained by this traffico version\n", i + 1);
     }
 
     fprintf(out, "\ndropped traffic:\n");
     fprintf(out, "  - malformed packets that cannot be safely classified\n");
-    /* Only mention fragment policy when a permit needs L4 classification. */
-    if (has_l4_permits)
+    /* Only mention fragment policy when a rule needs L4 classification. */
+    if (has_l4_rules)
         fprintf(out, "  - TCP/UDP fragments that cannot be fully classified\n");
+    if (intent->forbid_count > 0)
+        fprintf(out, "  - traffic matching a forbid\n");
     fprintf(out, "  - any traffic not matching a permit\n");
 }
 

--- a/api/intent.h
+++ b/api/intent.h
@@ -378,12 +378,16 @@ static inline int intent_add_l4_permit(struct intent *intent,
     struct intent_permit permit;
     intent_permit_init(&permit);
 
-    if (intent_parse_ipv4(ip, &dst_ip) != 0 ||
-        intent_parse_port(port, &dst_port) != 0)
+    if (intent_parse_ipv4(ip, &dst_ip) != 0)
+        return intent_fail(err_msg, "invalid permit");
+    if (port && intent_parse_port(port, &dst_port) != 0)
         return intent_fail(err_msg, "invalid permit");
     if (intent_add_eq(&permit, INTENT_FIELD_ETH_TYPE, INTENT_ETH_P_IP, err_msg) != 0 ||
         intent_add_eq(&permit, INTENT_FIELD_IP_DST, dst_ip, err_msg) != 0 ||
-        intent_add_eq(&permit, INTENT_FIELD_IP_PROTO, proto, err_msg) != 0 ||
+        intent_add_eq(&permit, INTENT_FIELD_IP_PROTO, proto, err_msg) != 0)
+        return -1;
+
+    if (port &&
         intent_add_eq(&permit, INTENT_FIELD_L4_DST_PORT, dst_port, err_msg) != 0)
         return -1;
 
@@ -432,17 +436,15 @@ static inline int intent_add_permit(struct intent *intent,
     if (strcmp(kind, "tcp") == 0)
     {
         port = strrchr(target, ':');
-        if (!port)
-            return intent_fail(err_msg, "invalid permit");
-        *port++ = '\0';
+        if (port)
+            *port++ = '\0';
         return intent_add_l4_permit(intent, INTENT_IPPROTO_TCP, target, port, err_msg);
     }
     if (strcmp(kind, "udp") == 0)
     {
         port = strrchr(target, ':');
-        if (!port)
-            return intent_fail(err_msg, "invalid permit");
-        *port++ = '\0';
+        if (port)
+            *port++ = '\0';
         return intent_add_l4_permit(intent, INTENT_IPPROTO_UDP, target, port, err_msg);
     }
 
@@ -552,6 +554,7 @@ static inline void intent_print_explain(FILE *out,
         uint32_t ip_dst = 0;
         uint32_t proto = 0;
         uint32_t port = 0;
+        bool has_port = intent_permit_get_eq(permit, INTENT_FIELD_L4_DST_PORT, &port);
 
         if (intent_permit_get_eq(permit, INTENT_FIELD_ETH_TYPE, &eth_type) &&
             eth_type == INTENT_ETH_P_ARP)
@@ -563,7 +566,7 @@ static inline void intent_print_explain(FILE *out,
         if (intent_permit_get_eq(permit, INTENT_FIELD_ETH_TYPE, &eth_type) &&
             eth_type == INTENT_ETH_P_IP &&
             intent_permit_get_eq(permit, INTENT_FIELD_IP_DST, &ip_dst) &&
-            intent_permit_get_eq(permit, INTENT_FIELD_L4_DST_PORT, &port) &&
+            has_port &&
             intent_permit_has_proto_in_tcp_udp(permit) &&
             port == INTENT_DNS_PORT)
         {
@@ -579,15 +582,23 @@ static inline void intent_print_explain(FILE *out,
             eth_type == INTENT_ETH_P_IP &&
             intent_permit_get_eq(permit, INTENT_FIELD_IP_DST, &ip_dst) &&
             intent_permit_get_eq(permit, INTENT_FIELD_IP_PROTO, &proto) &&
-            intent_permit_get_eq(permit, INTENT_FIELD_L4_DST_PORT, &port) &&
             proto == INTENT_IPPROTO_TCP)
         {
             has_l4_permits = true;
             intent_format_ip(ip_dst, ip, sizeof(ip));
-            fprintf(out, "  %zu. TCP to %s destination port %u\n",
-                    i + 1,
-                    ip,
-                    port);
+            if (has_port)
+            {
+                fprintf(out, "  %zu. TCP to %s destination port %u\n",
+                        i + 1,
+                        ip,
+                        port);
+            }
+            else
+            {
+                fprintf(out, "  %zu. TCP to %s any destination port\n",
+                        i + 1,
+                        ip);
+            }
             continue;
         }
 
@@ -595,15 +606,23 @@ static inline void intent_print_explain(FILE *out,
             eth_type == INTENT_ETH_P_IP &&
             intent_permit_get_eq(permit, INTENT_FIELD_IP_DST, &ip_dst) &&
             intent_permit_get_eq(permit, INTENT_FIELD_IP_PROTO, &proto) &&
-            intent_permit_get_eq(permit, INTENT_FIELD_L4_DST_PORT, &port) &&
             proto == INTENT_IPPROTO_UDP)
         {
             has_l4_permits = true;
             intent_format_ip(ip_dst, ip, sizeof(ip));
-            fprintf(out, "  %zu. UDP to %s destination port %u\n",
-                    i + 1,
-                    ip,
-                    port);
+            if (has_port)
+            {
+                fprintf(out, "  %zu. UDP to %s destination port %u\n",
+                        i + 1,
+                        ip,
+                        port);
+            }
+            else
+            {
+                fprintf(out, "  %zu. UDP to %s any destination port\n",
+                        i + 1,
+                        ip);
+            }
             continue;
         }
 
@@ -612,9 +631,9 @@ static inline void intent_print_explain(FILE *out,
 
     fprintf(out, "\ndropped traffic:\n");
     fprintf(out, "  - malformed packets that cannot be safely classified\n");
-    /* Only mention fragment policy when a permit depends on L4 ports. */
+    /* Only mention fragment policy when a permit needs L4 classification. */
     if (has_l4_permits)
-        fprintf(out, "  - TCP/UDP fragments whose destination port cannot be checked\n");
+        fprintf(out, "  - TCP/UDP fragments that cannot be fully classified\n");
     fprintf(out, "  - any traffic not matching a permit\n");
 }
 

--- a/api/intent_bpf.h
+++ b/api/intent_bpf.h
@@ -6,21 +6,19 @@
 #include <string.h>
 
 #include "enforcement.h"
+#include "intent_bpf_uapi.h"
 
-#define INTENT_BPF_MAX_RULES MAX_INTENT_ENFORCEMENT_RULES
-#define INTENT_BPF_MAX_PROTOS MAX_INTENT_ENFORCEMENT_PROTOS
-
-enum intent_bpf_rule_kind
-{
-    INTENT_BPF_RULE_ARP = 1,
-    INTENT_BPF_RULE_IPV4_L4 = 2,
-};
+_Static_assert(MAX_INTENT_ENFORCEMENT_RULES == INTENT_BPF_MAX_RULES,
+               "enforcement and BPF rule limits must match");
+_Static_assert(MAX_INTENT_ENFORCEMENT_PROTOS == INTENT_BPF_MAX_PROTOS,
+               "enforcement and BPF proto limits must match");
 
 struct intent_bpf_rule
 {
     uint8_t kind;
     uint8_t ip_proto_count;
     uint8_t ip_protos[INTENT_BPF_MAX_PROTOS];
+    uint8_t l4_dst_port_mode;
     uint16_t l4_dst_port;
     uint32_t ip_dst;
 };
@@ -52,14 +50,29 @@ static inline bool intent_bpf_rule_supported(const struct intent_enforcement_rul
 {
     if (rule->kind == INTENT_ENFORCEMENT_RULE_ARP)
         return rule->ip_dst == 0 &&
+               rule->l4_dst_port_mode == INTENT_L4_DST_PORT_EXACT &&
                rule->l4_dst_port == 0 &&
                rule->ip_proto_count == 0;
 
     if (rule->kind != INTENT_ENFORCEMENT_RULE_IPV4_L4 ||
-        rule->l4_dst_port == 0 ||
         rule->ip_proto_count == 0 ||
         rule->ip_proto_count > INTENT_BPF_MAX_PROTOS)
         return false;
+
+    if (rule->l4_dst_port_mode == INTENT_L4_DST_PORT_EXACT)
+    {
+        if (rule->l4_dst_port == 0)
+            return false;
+    }
+    else if (rule->l4_dst_port_mode == INTENT_L4_DST_PORT_ANY)
+    {
+        if (rule->l4_dst_port != 0)
+            return false;
+    }
+    else
+    {
+        return false;
+    }
 
     for (size_t i = 0; i < rule->ip_proto_count; i++)
     {
@@ -106,7 +119,10 @@ static inline int intent_bpf_plan_from_enforcement(const struct intent_enforceme
 
         dst->kind = INTENT_BPF_RULE_IPV4_L4;
         dst->ip_dst = src->ip_dst;
-        dst->l4_dst_port = src->l4_dst_port;
+        dst->l4_dst_port_mode = (uint8_t)src->l4_dst_port_mode;
+        dst->l4_dst_port = src->l4_dst_port_mode == INTENT_L4_DST_PORT_ANY
+                               ? 0
+                               : src->l4_dst_port;
         dst->ip_proto_count = (uint8_t)src->ip_proto_count;
         for (size_t j = 0; j < src->ip_proto_count; j++)
             dst->ip_protos[j] = src->ip_protos[j];

--- a/api/intent_bpf_loader.h.in
+++ b/api/intent_bpf_loader.h.in
@@ -45,6 +45,7 @@ static int attach_intent_bpf(struct config *conf,
         obj->rodata->intent_rules[i].ip_proto_count = plan->rules[i].ip_proto_count;
         obj->rodata->intent_rules[i].ip_protos[0] = plan->rules[i].ip_protos[0];
         obj->rodata->intent_rules[i].ip_protos[1] = plan->rules[i].ip_protos[1];
+        obj->rodata->intent_rules[i].l4_dst_port_mode = plan->rules[i].l4_dst_port_mode;
         obj->rodata->intent_rules[i].l4_dst_port = plan->rules[i].l4_dst_port;
         obj->rodata->intent_rules[i].ip_dst = plan->rules[i].ip_dst;
     }

--- a/api/intent_bpf_uapi.h
+++ b/api/intent_bpf_uapi.h
@@ -1,0 +1,18 @@
+#ifndef TRAFFICO_INTENT_BPF_UAPI_H
+#define TRAFFICO_INTENT_BPF_UAPI_H
+
+#include "intent_l4.h"
+
+enum
+{
+    INTENT_BPF_MAX_RULES = 64,
+    INTENT_BPF_MAX_PROTOS = 2,
+};
+
+enum intent_bpf_rule_kind
+{
+    INTENT_BPF_RULE_ARP = 1,
+    INTENT_BPF_RULE_IPV4_L4 = 2,
+};
+
+#endif

--- a/api/intent_l4.h
+++ b/api/intent_l4.h
@@ -1,0 +1,10 @@
+#ifndef TRAFFICO_INTENT_L4_H
+#define TRAFFICO_INTENT_L4_H
+
+enum intent_l4_dst_port_mode
+{
+    INTENT_L4_DST_PORT_EXACT = 0,
+    INTENT_L4_DST_PORT_ANY = 1,
+};
+
+#endif

--- a/bpf/intent.bpf.c
+++ b/bpf/intent.bpf.c
@@ -1,5 +1,6 @@
 #include "vmlinux.h"
 #include "commons.bpf.h"
+#include "../api/intent_bpf_uapi.h"
 
 #include <bpf/bpf_endian.h>
 
@@ -9,18 +10,19 @@ struct intent_bpf_rule
 {
     __u8 kind;
     __u8 ip_proto_count;
-    __u8 ip_protos[2];
+    __u8 ip_protos[INTENT_BPF_MAX_PROTOS];
+    __u8 l4_dst_port_mode;
     __u16 l4_dst_port;
     __u32 ip_dst;
 };
 
 /* libbpf writes these read-only values before loading the program. */
 const volatile __u32 intent_rule_count = 0;
-const volatile struct intent_bpf_rule intent_rules[32] = {};
+const volatile struct intent_bpf_rule intent_rules[INTENT_BPF_MAX_RULES] = {};
 
 static __always_inline int proto_allowed(const volatile struct intent_bpf_rule *rule, __u8 proto)
 {
-    for (__u32 i = 0; i < 2; i++)
+    for (__u32 i = 0; i < INTENT_BPF_MAX_PROTOS; i++)
     {
         if (i >= rule->ip_proto_count)
             break;
@@ -37,6 +39,9 @@ int intent(struct __sk_buff *skb)
     void *data = (void *)(unsigned long long)skb->data;
     struct ethhdr *eth = data;
     const int l3_offset = sizeof(*eth);
+
+    if (intent_rule_count > INTENT_BPF_MAX_RULES)
+        return TC_ACT_SHOT;
 
     /* Intent allowlists fail closed on packets that cannot be classified. */
     if (data + l3_offset > data_end)
@@ -55,11 +60,11 @@ int intent(struct __sk_buff *skb)
         if (data + l3_offset + arp_len > data_end)
             return TC_ACT_SHOT;
 
-        for (__u32 i = 0; i < 32; i++)
+        for (__u32 i = 0; i < INTENT_BPF_MAX_RULES; i++)
         {
             if (i >= intent_rule_count)
                 break;
-            if (intent_rules[i].kind == 1)
+            if (intent_rules[i].kind == INTENT_BPF_RULE_ARP)
                 return TC_ACT_OK;
         }
         return TC_ACT_SHOT;
@@ -106,17 +111,20 @@ int intent(struct __sk_buff *skb)
     __u32 dst_ip = bpf_ntohl(ip->daddr);
 
     /* Rules are correlated tuples, not independent allow sets. */
-    for (__u32 i = 0; i < 32; i++)
+    for (__u32 i = 0; i < INTENT_BPF_MAX_RULES; i++)
     {
         if (i >= intent_rule_count)
             break;
 
         const volatile struct intent_bpf_rule *rule = &intent_rules[i];
-        if (rule->kind != 2)
+        if (rule->kind != INTENT_BPF_RULE_IPV4_L4)
             continue;
-        if (rule->ip_dst == dst_ip &&
-            rule->l4_dst_port == dst_port &&
-            proto_allowed(rule, ip->protocol))
+        if (rule->ip_dst != dst_ip || !proto_allowed(rule, ip->protocol))
+            continue;
+        if (rule->l4_dst_port_mode == INTENT_L4_DST_PORT_ANY)
+            return TC_ACT_OK;
+        if (rule->l4_dst_port_mode == INTENT_L4_DST_PORT_EXACT &&
+            rule->l4_dst_port == dst_port)
             return TC_ACT_OK;
     }
 

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -38,25 +38,25 @@ bats_require_minimum_version 1.7.0
 @test "--allow and --chain are mutually exclusive" {
     run traffico -i lo --allow arp --chain "allow_ethertype:arp" --dry-run
     [ $status -eq 1 ]
-    [ "${lines[0]}" == "traffico: --allow/--permit and --chain are mutually exclusive" ]
+    [ "${lines[0]}" == "traffico: --allow/--permit/--forbid/--block and --chain are mutually exclusive" ]
 }
 
 @test "--allow and positional program are mutually exclusive" {
     run traffico -i lo --allow arp nop --dry-run
     [ $status -eq 1 ]
-    [ "${lines[0]}" == "traffico: --allow/--permit and positional PROGRAM arguments are mutually exclusive" ]
+    [ "${lines[0]}" == "traffico: --allow/--permit/--forbid/--block and positional PROGRAM arguments are mutually exclusive" ]
 }
 
 @test "--dry-run requires Intent mode" {
     run traffico -i lo --dry-run nop
     [ $status -eq 1 ]
-    [ "${lines[0]}" == "traffico: --dry-run currently requires --allow or --permit" ]
+    [ "${lines[0]}" == "traffico: --dry-run currently requires --allow, --permit, --forbid, or --block" ]
 }
 
 @test "--explain requires Intent mode" {
     run traffico -i lo --explain nop
     [ $status -eq 1 ]
-    [ "${lines[0]}" == "traffico: --explain currently requires --allow or --permit" ]
+    [ "${lines[0]}" == "traffico: --explain currently requires --allow, --permit, --forbid, or --block" ]
 }
 
 @test "--explain=dag is reserved for future Intent debug output" {

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -72,16 +72,33 @@ bats_require_minimum_version 1.7.0
     [[ "$output" == *"permitted traffic:"* ]]
 }
 
+@test "--dry-run --explain prints host-wide TCP and UDP permits" {
+    run traffico -i lo --at egress \
+        --allow udp/10.0.0.20 \
+        --allow tcp/10.0.0.10 \
+        --dry-run --explain
+    [ $status -eq 0 ]
+    [[ "$output" == *"  1. TCP to 10.0.0.10 any destination port"* ]]
+    [[ "$output" == *"  2. UDP to 10.0.0.20 any destination port"* ]]
+    [[ "$output" == *"TCP/UDP fragments that cannot be fully classified"* ]]
+    [[ "$output" != *"permit cannot be explained"* ]]
+}
+
 @test "Intent mode rejects ingress until designed" {
     run traffico -i lo --at ingress --allow arp --dry-run
     [ $status -eq 1 ]
     [ "${lines[0]}" == "traffico: intent dry-run: Intent BPF backend supports egress only" ]
 }
 
-@test "--allow rejects malformed values" {
-    run traffico -i lo --allow tcp/10.0.0.10 --dry-run
+@test "--allow accepts host-wide TCP and still rejects malformed values" {
+    run traffico -i lo --at egress --allow tcp/10.0.0.10 --dry-run
+    [ $status -eq 0 ]
+    [[ "$output" == *"intent dry-run: compiler ok"* ]]
+    [[ "$output" == *"intent backend: bpf admissible"* ]]
+
+    run traffico -i lo --allow tcp/10.0.0.10/443 --dry-run
     [ $status -eq 1 ]
-    [ "${lines[0]}" == "traffico: invalid permit: 'tcp/10.0.0.10'" ]
+    [ "${lines[0]}" == "traffico: invalid permit: 'tcp/10.0.0.10/443'" ]
 }
 
 @test "--allow rejects unsupported Intent value" {

--- a/test/ddag_unit.c
+++ b/test/ddag_unit.c
@@ -103,6 +103,29 @@ static int test_decision_dag_chains_three_permit_false_edges(void)
     return 0;
 }
 
+static int test_decision_dag_accepts_host_wide_l4_permit_path(void)
+{
+    struct intent intent = {0};
+    struct decision_dag dag = {0};
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", &err) == 0);
+    intent_normalize(&intent);
+
+    CHECK(intent_build_dag(&intent, &dag, &err) == 0);
+    CHECK(dag.node_count == 3);
+    CHECK(dag.nodes[0].predicate.field == INTENT_FIELD_ETH_TYPE);
+    CHECK(dag.nodes[1].predicate.field == INTENT_FIELD_IP_DST);
+    CHECK(dag.nodes[2].predicate.field == INTENT_FIELD_IP_PROTO);
+    CHECK(dag.nodes[2].on_true.terminal == DECISION_TERMINAL_ALLOW);
+
+    CHECK(intent_validate_dag(&dag, &err) == 0);
+    CHECK(intent_validate_supported_subset(&dag, &err) == 0);
+
+    return 0;
+}
+
 static int test_decision_dag_rejects_future_forbids(void)
 {
     struct intent intent = {0};
@@ -452,6 +475,7 @@ int main(void)
 {
     RUN_TEST(test_decision_dag_builds_predicate_chain);
     RUN_TEST(test_decision_dag_chains_three_permit_false_edges);
+    RUN_TEST(test_decision_dag_accepts_host_wide_l4_permit_path);
     RUN_TEST(test_decision_dag_rejects_future_forbids);
     RUN_TEST(test_decision_dag_rejects_non_drop_default_action);
     RUN_TEST(test_decision_dag_rejects_invalid_public_counts);

--- a/test/enforcement_unit.c
+++ b/test/enforcement_unit.c
@@ -91,6 +91,27 @@ static int test_enforcement_extracts_tcp_ipv4_l4_rule(void)
     return 0;
 }
 
+static int test_enforcement_extracts_host_wide_tcp_any_port_rule(void)
+{
+    struct intent intent = {0};
+    struct intent_enforcement_plan plan = {0};
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", &err) == 0);
+
+    CHECK(build_plan(&intent, &plan, &err) == 0);
+    CHECK(plan.direction == INTENT_DIRECTION_EGRESS);
+    CHECK(plan.rule_count == 1);
+    CHECK(plan.rules[0].kind == INTENT_ENFORCEMENT_RULE_IPV4_L4);
+    CHECK(plan.rules[0].ip_dst == 0x0a00000a);
+    CHECK(plan.rules[0].l4_dst_port_mode == INTENT_L4_DST_PORT_ANY);
+    CHECK(plan.rules[0].l4_dst_port == 0);
+    CHECK(plan.rules[0].ip_proto_count == 1);
+    CHECK(plan.rules[0].ip_protos[0] == INTENT_IPPROTO_TCP);
+    return 0;
+}
+
 static int test_enforcement_extracts_dns_ipv4_l4_rule(void)
 {
     struct intent intent = {0};
@@ -423,6 +444,7 @@ int main(void)
 {
     RUN_TEST(test_enforcement_extracts_arp_rule);
     RUN_TEST(test_enforcement_extracts_tcp_ipv4_l4_rule);
+    RUN_TEST(test_enforcement_extracts_host_wide_tcp_any_port_rule);
     RUN_TEST(test_enforcement_extracts_dns_ipv4_l4_rule);
     RUN_TEST(test_enforcement_extracts_primary_scenario_rows);
     RUN_TEST(test_enforcement_preserves_prior_true_predicates_on_false_edges);

--- a/test/intent.bats
+++ b/test/intent.bats
@@ -131,10 +131,19 @@ assert_intent_tc_cleanup() {
 }
 
 @test "Intent live invalid permit rejection leaves TC untouched" {
-    run ip netns exec "${NETNS}" traffico -i "${PEER}" --allow tcp/10.0.0.10
+    run ip netns exec "${NETNS}" traffico -i "${PEER}" --allow tcp/10.0.0.10/443
     [ $status -eq 1 ]
-    [ "${lines[0]}" == "traffico: invalid permit: 'tcp/10.0.0.10'" ]
+    [ "${lines[0]}" == "traffico: invalid permit: 'tcp/10.0.0.10/443'" ]
 
+    assert_intent_tc_cleanup
+}
+
+@test "Intent live host-wide TCP permit creates and cleans TC state" {
+    start_intent_attach "${BATS_TEST_TMPDIR}/intent-host-wide-live.out" \
+        -i "${PEER}" --at egress --allow arp --allow "tcp/${VETH_ADDR}"
+
+    wait_for_intent_tc_state
+    stop_intent_attach
     assert_intent_tc_cleanup
 }
 
@@ -154,7 +163,7 @@ assert_intent_tc_cleanup() {
     [[ "$output" == *"  2. TCP to 10.0.0.10 destination port 443"* ]]
     [[ "$output" == *"  3. UDP to 10.0.0.20 destination port 123"* ]]
     [[ "$output" == *"  4. DNS to 10.0.0.53 over TCP or UDP destination port 53"* ]]
-    [[ "$output" == *"TCP/UDP fragments whose destination port cannot be checked"* ]]
+    [[ "$output" == *"TCP/UDP fragments that cannot be fully classified"* ]]
 }
 
 @test "--explain prints deterministic intent before live attach" {

--- a/test/intent_bpf_unit.c
+++ b/test/intent_bpf_unit.c
@@ -71,6 +71,31 @@ static int test_bpf_lowering_preserves_correlated_rows(void)
     return 0;
 }
 
+static int test_bpf_lowering_accepts_any_destination_port(void)
+{
+    struct intent_enforcement_plan plan = {0};
+    struct intent_bpf_plan bpf_plan = {0};
+    const char *err = NULL;
+
+    plan.direction = INTENT_DIRECTION_EGRESS;
+    plan.rule_count = 1;
+    plan.rules[0].kind = INTENT_ENFORCEMENT_RULE_IPV4_L4;
+    plan.rules[0].ip_dst = 0x0a00000a;
+    plan.rules[0].l4_dst_port_mode = INTENT_L4_DST_PORT_ANY;
+    plan.rules[0].ip_proto_count = 1;
+    plan.rules[0].ip_protos[0] = INTENT_IPPROTO_TCP;
+
+    CHECK(intent_bpf_plan_from_enforcement(&plan, &bpf_plan, &err) == 0);
+    CHECK(bpf_plan.rule_count == 1);
+    CHECK(bpf_plan.rules[0].kind == INTENT_BPF_RULE_IPV4_L4);
+    CHECK(bpf_plan.rules[0].ip_dst == 0x0a00000a);
+    CHECK(bpf_plan.rules[0].l4_dst_port_mode == INTENT_L4_DST_PORT_ANY);
+    CHECK(bpf_plan.rules[0].l4_dst_port == 0);
+    CHECK(bpf_plan.rules[0].ip_proto_count == 1);
+    CHECK(bpf_plan.rules[0].ip_protos[0] == INTENT_IPPROTO_TCP);
+    return 0;
+}
+
 static int expect_unsupported_rule_rejected(const struct intent_enforcement_rule *rule)
 {
     struct intent_enforcement_plan plan = {0};
@@ -207,6 +232,7 @@ static int test_bpf_hook_cleanup_policy(void)
 int main(void)
 {
     RUN_TEST(test_bpf_lowering_preserves_correlated_rows);
+    RUN_TEST(test_bpf_lowering_accepts_any_destination_port);
     RUN_TEST(test_bpf_lowering_rejects_malformed_arp_row);
     RUN_TEST(test_bpf_lowering_rejects_unsupported_proto_value);
     RUN_TEST(test_bpf_lowering_rejects_duplicate_two_entry_proto_set);

--- a/test/intent_forbid.bats
+++ b/test/intent_forbid.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+load helpers
+export BATS_TEST_NAME_PREFIX=$(setsuite)
+bats_require_minimum_version 1.7.0
+
+@test "--forbid selects Intent mode and is parsed before backend support" {
+    run traffico -i lo --at egress \
+        --allow tcp/10.0.0.10 \
+        --forbid tcp/10.0.0.10:22 \
+        --dry-run
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: intent dry-run: forbids are not supported yet" ]
+}
+
+@test "--block is an alias for --forbid" {
+    run traffico -i lo --at egress \
+        --allow tcp/10.0.0.10 \
+        --block tcp/10.0.0.10:22 \
+        --dry-run
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: intent dry-run: forbids are not supported yet" ]
+}
+
+@test "--dry-run --explain prints permits and forbids" {
+    run traffico -i lo --at egress \
+        --allow tcp/10.0.0.10 \
+        --forbid tcp/10.0.0.10:22 \
+        --dry-run --explain
+    [ $status -eq 1 ]
+    [[ "$output" == *"permitted traffic:"* ]]
+    [[ "$output" == *"  1. TCP to 10.0.0.10 any destination port"* ]]
+    [[ "$output" == *"forbidden traffic:"* ]]
+    [[ "$output" == *"  1. TCP to 10.0.0.10 destination port 22"* ]]
+}

--- a/test/intent_host_scapy.bats
+++ b/test/intent_host_scapy.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+
+load helpers
+export BATS_TEST_NAME_PREFIX=$(setsuite)
+bats_require_minimum_version 1.7.0
+
+setup_file() {
+    if ! command -v python3 &>/dev/null; then
+        skip "python3 not found: scapy tests require python3"
+    fi
+    if ! python3 -c "import scapy" &>/dev/null; then
+        skip "scapy not installed: install python-scapy (Arch) or python3-scapy (Ubuntu)"
+    fi
+}
+
+setup() {
+    load net
+    NETNS="ns$((RANDOM % 10))"
+    new_netns "${NETNS}"
+    setup_net "${NETNS}"
+    arp_prewarm "${NETNS}"
+}
+
+teardown() {
+    killall traffico &>/dev/null || true
+    [ -n "${SNIFFER_PID:-}" ] && kill "$SNIFFER_PID" &>/dev/null || true
+    del_netdev
+    del_netns "${NETNS}"
+}
+
+intent_tc_state_exists() {
+    local qdisc
+    local filter
+
+    qdisc="$(ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact)"
+    filter="$(ip netns exec "${NETNS}" tc filter show dev "${PEER}" egress)"
+
+    [[ "${qdisc}" == *"clsact"* && "${filter}" != "" ]]
+}
+
+wait_for_intent_tc_state() {
+    local i
+
+    for i in {1..50}; do
+        if intent_tc_state_exists; then
+            return 0
+        fi
+        sleep 0.1
+    done
+
+    return 1
+}
+
+@test "Intent host-wide TCP permit allows multiple destination ports" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress \
+        --allow arp \
+        --allow "tcp/${VETH_ADDR}" >/dev/null 3>&- &
+    wait_for_intent_tc_state
+
+    assert_packet_seen "${NETNS}" 21001 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 443
+    assert_packet_seen "${NETNS}" 21002 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 8443
+    assert_packet_blocked "${NETNS}" 21003 \
+        --type udp --dst-ip "${VETH_ADDR}" --dst-port 443
+    assert_packet_blocked "${NETNS}" 21004 \
+        --type tcp --dst-ip "${PEER_ADDR}" --dst-port 443
+}
+
+@test "Intent host-wide UDP permit allows multiple destination ports" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress \
+        --allow arp \
+        --allow "udp/${VETH_ADDR}" >/dev/null 3>&- &
+    wait_for_intent_tc_state
+
+    assert_packet_seen "${NETNS}" 22001 \
+        --type udp --dst-ip "${VETH_ADDR}" --dst-port 123
+    assert_packet_seen "${NETNS}" 22002 \
+        --type udp --dst-ip "${VETH_ADDR}" --dst-port 9999
+    assert_packet_blocked "${NETNS}" 22003 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 123
+    assert_packet_blocked "${NETNS}" 22004 \
+        --type udp --dst-ip "${PEER_ADDR}" --dst-port 123
+}

--- a/test/intent_semantics.h
+++ b/test/intent_semantics.h
@@ -1,0 +1,164 @@
+#ifndef TRAFFICO_TEST_INTENT_SEMANTICS_H
+#define TRAFFICO_TEST_INTENT_SEMANTICS_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "api/intent.h"
+
+enum intent_test_packet_kind
+{
+    INTENT_TEST_PACKET_MALFORMED = 0,
+    INTENT_TEST_PACKET_ARP = 1,
+    INTENT_TEST_PACKET_IPV4_L4 = 2,
+    INTENT_TEST_PACKET_UNCLASSIFIABLE = 3,
+};
+
+struct intent_test_packet
+{
+    enum intent_test_packet_kind kind;
+    uint32_t ip_dst;
+    uint8_t ip_proto;
+    uint16_t l4_dst_port;
+};
+
+static inline struct intent_test_packet intent_test_packet_malformed(void)
+{
+    struct intent_test_packet packet = {0};
+    packet.kind = INTENT_TEST_PACKET_MALFORMED;
+    return packet;
+}
+
+static inline struct intent_test_packet intent_test_packet_unclassifiable(void)
+{
+    struct intent_test_packet packet = {0};
+    packet.kind = INTENT_TEST_PACKET_UNCLASSIFIABLE;
+    return packet;
+}
+
+static inline struct intent_test_packet intent_test_packet_arp(void)
+{
+    struct intent_test_packet packet = {0};
+    packet.kind = INTENT_TEST_PACKET_ARP;
+    return packet;
+}
+
+static inline struct intent_test_packet intent_test_packet_l4(uint32_t ip_dst,
+                                                              uint8_t ip_proto,
+                                                              uint16_t l4_dst_port)
+{
+    struct intent_test_packet packet = {0};
+    packet.kind = INTENT_TEST_PACKET_IPV4_L4;
+    packet.ip_dst = ip_dst;
+    packet.ip_proto = ip_proto;
+    packet.l4_dst_port = l4_dst_port;
+    return packet;
+}
+
+static inline struct intent_test_packet intent_test_packet_tcp(uint32_t ip_dst,
+                                                               uint16_t l4_dst_port)
+{
+    return intent_test_packet_l4(ip_dst, INTENT_IPPROTO_TCP, l4_dst_port);
+}
+
+static inline struct intent_test_packet intent_test_packet_udp(uint32_t ip_dst,
+                                                               uint16_t l4_dst_port)
+{
+    return intent_test_packet_l4(ip_dst, INTENT_IPPROTO_UDP, l4_dst_port);
+}
+
+static inline bool intent_test_value_matches(const struct intent_predicate *predicate,
+                                             uint32_t value)
+{
+    for (size_t i = 0; i < predicate->values.count; i++)
+    {
+        if (predicate->values.values[i] == value)
+            return true;
+    }
+    return false;
+}
+
+static inline bool intent_test_predicate_matches(const struct intent_predicate *predicate,
+                                                 const struct intent_test_packet *packet)
+{
+    uint32_t packet_value = 0;
+
+    if (predicate->op != INTENT_OP_EQ &&
+        predicate->op != INTENT_OP_IN)
+        return false;
+
+    if (predicate->field == INTENT_FIELD_ETH_TYPE)
+    {
+        if (packet->kind == INTENT_TEST_PACKET_ARP)
+            packet_value = INTENT_ETH_P_ARP;
+        else if (packet->kind == INTENT_TEST_PACKET_IPV4_L4)
+            packet_value = INTENT_ETH_P_IP;
+        else
+            return false;
+    }
+    else if (predicate->field == INTENT_FIELD_IP_DST)
+    {
+        if (packet->kind != INTENT_TEST_PACKET_IPV4_L4)
+            return false;
+        packet_value = packet->ip_dst;
+    }
+    else if (predicate->field == INTENT_FIELD_IP_PROTO)
+    {
+        if (packet->kind != INTENT_TEST_PACKET_IPV4_L4)
+            return false;
+        packet_value = packet->ip_proto;
+    }
+    else if (predicate->field == INTENT_FIELD_L4_DST_PORT)
+    {
+        if (packet->kind != INTENT_TEST_PACKET_IPV4_L4)
+            return false;
+        packet_value = packet->l4_dst_port;
+    }
+    else
+    {
+        return false;
+    }
+
+    return intent_test_value_matches(predicate, packet_value);
+}
+
+static inline bool intent_test_rule_matches(const struct intent_predicate *predicates,
+                                            size_t predicate_count,
+                                            const struct intent_test_packet *packet)
+{
+    for (size_t i = 0; i < predicate_count; i++)
+    {
+        if (!intent_test_predicate_matches(&predicates[i], packet))
+            return false;
+    }
+    return true;
+}
+
+static inline enum intent_action intent_test_oracle_decide(const struct intent *intent,
+                                                           struct intent_test_packet packet)
+{
+    if (packet.kind == INTENT_TEST_PACKET_MALFORMED ||
+        packet.kind == INTENT_TEST_PACKET_UNCLASSIFIABLE)
+        return INTENT_ACTION_DROP;
+
+    for (size_t i = 0; i < intent->forbid_count; i++)
+    {
+        if (intent_test_rule_matches(intent->forbids[i].predicates,
+                                     intent->forbids[i].predicate_count,
+                                     &packet))
+            return INTENT_ACTION_DROP;
+    }
+
+    for (size_t i = 0; i < intent->permit_count; i++)
+    {
+        if (intent_test_rule_matches(intent->permits[i].predicates,
+                                     intent->permits[i].predicate_count,
+                                     &packet))
+            return INTENT_ACTION_ALLOW;
+    }
+
+    return INTENT_ACTION_DROP;
+}
+
+#endif

--- a/test/intent_unit.c
+++ b/test/intent_unit.c
@@ -151,14 +151,74 @@ static int test_parse_ipv4_addresses(void)
     return 0;
 }
 
+static int test_parse_host_wide_l4_permits(void)
+{
+    struct intent intent = {0};
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", &err) == 0);
+    CHECK(intent_add_permit(&intent, "udp/10.0.0.20", &err) == 0);
+
+    CHECK(intent.permit_count == 2);
+    CHECK(intent.permits[0].predicate_count == 3);
+    CHECK_PREDICATE(&intent.permits[0].predicates[0],
+                    INTENT_FIELD_ETH_TYPE,
+                    INTENT_OP_EQ,
+                    1,
+                    INTENT_ETH_P_IP,
+                    0);
+    CHECK_PREDICATE(&intent.permits[0].predicates[1],
+                    INTENT_FIELD_IP_DST,
+                    INTENT_OP_EQ,
+                    1,
+                    0x0a00000a,
+                    0);
+    CHECK_PREDICATE(&intent.permits[0].predicates[2],
+                    INTENT_FIELD_IP_PROTO,
+                    INTENT_OP_EQ,
+                    1,
+                    INTENT_IPPROTO_TCP,
+                    0);
+
+    CHECK(intent.permits[1].predicate_count == 3);
+    CHECK_PREDICATE(&intent.permits[1].predicates[1],
+                    INTENT_FIELD_IP_DST,
+                    INTENT_OP_EQ,
+                    1,
+                    0x0a000014,
+                    0);
+    CHECK_PREDICATE(&intent.permits[1].predicates[2],
+                    INTENT_FIELD_IP_PROTO,
+                    INTENT_OP_EQ,
+                    1,
+                    INTENT_IPPROTO_UDP,
+                    0);
+
+    return 0;
+}
+
+static int test_rejects_duplicate_host_wide_l4_permits(void)
+{
+    struct intent intent = {0};
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", &err) == 0);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", &err) == -1);
+    CHECK(strcmp(err, "duplicate permit") == 0);
+
+    return 0;
+}
+
 static int test_rejects_invalid_and_duplicate_permits(void)
 {
     struct intent intent = {0};
     const char *err = NULL;
 
     intent_init(&intent, INTENT_DIRECTION_EGRESS);
-    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", &err) == -1);
-    CHECK(strcmp(err, "invalid permit") == 0);
     CHECK(intent_add_permit(&intent, "tcp/10.0.0.10/443", &err) == -1);
     CHECK(strcmp(err, "invalid permit") == 0);
     CHECK(intent_add_permit(&intent, "udp/10.0.0.20:0", &err) == -1);
@@ -173,7 +233,7 @@ static int test_rejects_invalid_and_duplicate_permits(void)
     CHECK(strcmp(err, "dns permits do not accept a port") == 0);
     CHECK(intent_add_permit(&intent, "icmp/10.0.0.10", &err) == -1);
     CHECK(strcmp(err, "unsupported permit") == 0);
-    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", NULL) == -1);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10/443", NULL) == -1);
     CHECK(intent_add_permit(&intent, NULL, &err) == -1);
     CHECK(strcmp(err, "invalid permit") == 0);
     CHECK(intent_add_permit(&intent, "arp", &err) == 0);
@@ -378,6 +438,8 @@ int main(void)
 {
     RUN_TEST(test_parse_first_permits);
     RUN_TEST(test_parse_ipv4_addresses);
+    RUN_TEST(test_parse_host_wide_l4_permits);
+    RUN_TEST(test_rejects_duplicate_host_wide_l4_permits);
     RUN_TEST(test_rejects_invalid_and_duplicate_permits);
     RUN_TEST(test_rejects_duplicate_lowered_permits);
     RUN_TEST(test_rejects_empty_permits);

--- a/test/intent_unit.c
+++ b/test/intent_unit.c
@@ -2,6 +2,7 @@
 #include <string.h>
 
 #include "api/intent.h"
+#include "intent_semantics.h"
 
 #define CHECK(condition)                                                       \
     do                                                                         \
@@ -213,6 +214,81 @@ static int test_rejects_duplicate_host_wide_l4_permits(void)
     return 0;
 }
 
+static int test_parse_forbids(void)
+{
+    struct intent intent = {0};
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+
+    CHECK(intent_add_forbid(&intent, "arp", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "dns/10.0.0.53", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "tcp/10.0.0.10:22", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "udp/10.0.0.20:123", &err) == 0);
+
+    CHECK(intent.forbid_count == 4);
+    CHECK(intent.forbids[0].predicate_count == 1);
+    CHECK(intent.forbids[2].predicate_count == 4);
+    CHECK_PREDICATE(&intent.forbids[2].predicates[3],
+                    INTENT_FIELD_L4_DST_PORT,
+                    INTENT_OP_EQ,
+                    1,
+                    22,
+                    0);
+
+    return 0;
+}
+
+static int test_rejects_invalid_and_duplicate_forbids(void)
+{
+    struct intent intent = {0};
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+
+    CHECK(intent_add_forbid(&intent, "tcp/10.0.0.10", &err) == -1);
+    CHECK(strcmp(err, "invalid forbid") == 0);
+    CHECK(intent_add_forbid(&intent, "dns/10.0.0.53:53", &err) == -1);
+    CHECK(strcmp(err, "dns forbids do not accept a port") == 0);
+    CHECK(intent_add_forbid(&intent, "arp", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "arp", &err) == -1);
+    CHECK(strcmp(err, "duplicate forbid") == 0);
+
+    return 0;
+}
+
+static int test_forbid_duplicates_are_exact_normalized_duplicates(void)
+{
+    struct intent intent = {0};
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+
+    CHECK(intent_add_forbid(&intent, "dns/10.0.0.53", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "dns/10.0.0.53", &err) == -1);
+    CHECK(strcmp(err, "duplicate forbid") == 0);
+
+    CHECK(intent_add_forbid(&intent, "tcp/10.0.0.53:53", &err) == 0);
+    CHECK(intent.forbid_count == 2);
+
+    return 0;
+}
+
+static int test_allow_forbid_overlap_is_valid_intent(void)
+{
+    struct intent intent = {0};
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10:443", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "tcp/10.0.0.10:443", &err) == 0);
+    CHECK(intent.permit_count == 1);
+    CHECK(intent.forbid_count == 1);
+
+    return 0;
+}
+
 static int test_rejects_invalid_and_duplicate_permits(void)
 {
     struct intent intent = {0};
@@ -286,7 +362,7 @@ static int test_rejects_empty_permits(void)
 static int test_rejects_permit_too_long(void)
 {
     struct intent intent = {0};
-    char permit[MAX_INTENT_PERMIT_INPUT_LEN + 1];
+    char permit[MAX_INTENT_SELECTOR_INPUT_LEN + 1];
     const char *err = NULL;
 
     intent_init(&intent, INTENT_DIRECTION_EGRESS);
@@ -434,12 +510,58 @@ static int test_normalization_is_order_independent(void)
     return 0;
 }
 
+static int test_intent_oracle_evaluates_golden_policy(void)
+{
+    struct intent intent = {0};
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    CHECK(intent_add_permit(&intent, "arp", &err) == 0);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "tcp/10.0.0.10:22", &err) == 0);
+    intent_normalize(&intent);
+
+    CHECK(intent_test_oracle_decide(&intent, intent_test_packet_arp()) == INTENT_ACTION_ALLOW);
+    CHECK(intent_test_oracle_decide(&intent, intent_test_packet_tcp(0x0a00000a, 22)) == INTENT_ACTION_DROP);
+    CHECK(intent_test_oracle_decide(&intent, intent_test_packet_tcp(0x0a00000a, 443)) == INTENT_ACTION_ALLOW);
+    CHECK(intent_test_oracle_decide(&intent, intent_test_packet_udp(0x0a00000a, 443)) == INTENT_ACTION_DROP);
+    CHECK(intent_test_oracle_decide(&intent, intent_test_packet_tcp(0x0a000014, 443)) == INTENT_ACTION_DROP);
+    CHECK(intent_test_oracle_decide(&intent, intent_test_packet_malformed()) == INTENT_ACTION_DROP);
+    CHECK(intent_test_oracle_decide(&intent, intent_test_packet_unclassifiable()) == INTENT_ACTION_DROP);
+
+    return 0;
+}
+
+static int test_intent_oracle_evaluates_dns_carveout_policy(void)
+{
+    struct intent intent = {0};
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    CHECK(intent_add_permit(&intent, "arp", &err) == 0);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.53", &err) == 0);
+    CHECK(intent_add_permit(&intent, "udp/10.0.0.53", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "dns/10.0.0.53", &err) == 0);
+    intent_normalize(&intent);
+
+    CHECK(intent_test_oracle_decide(&intent, intent_test_packet_udp(0x0a000035, 53)) == INTENT_ACTION_DROP);
+    CHECK(intent_test_oracle_decide(&intent, intent_test_packet_tcp(0x0a000035, 53)) == INTENT_ACTION_DROP);
+    CHECK(intent_test_oracle_decide(&intent, intent_test_packet_tcp(0x0a000035, 443)) == INTENT_ACTION_ALLOW);
+    CHECK(intent_test_oracle_decide(&intent, intent_test_packet_udp(0x0a000035, 123)) == INTENT_ACTION_ALLOW);
+
+    return 0;
+}
+
 int main(void)
 {
     RUN_TEST(test_parse_first_permits);
     RUN_TEST(test_parse_ipv4_addresses);
     RUN_TEST(test_parse_host_wide_l4_permits);
     RUN_TEST(test_rejects_duplicate_host_wide_l4_permits);
+    RUN_TEST(test_parse_forbids);
+    RUN_TEST(test_rejects_invalid_and_duplicate_forbids);
+    RUN_TEST(test_forbid_duplicates_are_exact_normalized_duplicates);
+    RUN_TEST(test_allow_forbid_overlap_is_valid_intent);
     RUN_TEST(test_rejects_invalid_and_duplicate_permits);
     RUN_TEST(test_rejects_duplicate_lowered_permits);
     RUN_TEST(test_rejects_empty_permits);
@@ -449,6 +571,8 @@ int main(void)
     RUN_TEST(test_rejects_invalid_manual_predicates);
     RUN_TEST(test_rejects_too_many_permits);
     RUN_TEST(test_normalization_is_order_independent);
+    RUN_TEST(test_intent_oracle_evaluates_golden_policy);
+    RUN_TEST(test_intent_oracle_evaluates_dns_carveout_policy);
     puts("intent unit tests: ok");
     return 0;
 }

--- a/traffico.c
+++ b/traffico.c
@@ -50,9 +50,15 @@ const char OPT_ALLOW_ARG[] = "PERMIT";
 #define OPT_PERMIT_KEY 0x84
 const char OPT_PERMIT_LONG[] = "permit";
 const char OPT_PERMIT_ARG[] = "PERMIT";
-#define OPT_DRY_RUN_KEY 0x85
+#define OPT_FORBID_KEY 0x85
+const char OPT_FORBID_LONG[] = "forbid";
+const char OPT_FORBID_ARG[] = "FORBID";
+#define OPT_BLOCK_KEY 0x86
+const char OPT_BLOCK_LONG[] = "block";
+const char OPT_BLOCK_ARG[] = "FORBID";
+#define OPT_DRY_RUN_KEY 0x87
 const char OPT_DRY_RUN_LONG[] = "dry-run";
-#define OPT_EXPLAIN_KEY 0x86
+#define OPT_EXPLAIN_KEY 0x88
 const char OPT_EXPLAIN_LONG[] = "explain";
 const char OPT_EXPLAIN_ARG[] = "intent";
 
@@ -66,6 +72,8 @@ const struct argp_option argp_opts[] = {
     {OPT_CHAIN_LONG, OPT_CHAIN_KEY, OPT_CHAIN_ARG, 0, "Attach a chain of programs (e.g., allow_ipv4:10.0.0.1,allow_port:8080)", 1},
     {OPT_ALLOW_LONG, OPT_ALLOW_KEY, OPT_ALLOW_ARG, 0, "Add an Intent permit", 1},
     {OPT_PERMIT_LONG, OPT_PERMIT_KEY, OPT_PERMIT_ARG, 0, "Alias for --allow", 1},
+    {OPT_FORBID_LONG, OPT_FORBID_KEY, OPT_FORBID_ARG, 0, "Add an Intent forbid", 1},
+    {OPT_BLOCK_LONG, OPT_BLOCK_KEY, OPT_BLOCK_ARG, 0, "Alias for --forbid", 1},
     {OPT_DRY_RUN_LONG, OPT_DRY_RUN_KEY, NULL, 0, "Validate Intent without attaching", 1},
     {OPT_EXPLAIN_LONG, OPT_EXPLAIN_KEY, OPT_EXPLAIN_ARG, OPTION_ARG_OPTIONAL, "Print normalized Intent", 1},
     {"", 0, 0, OPTION_DOC, 0, 0},
@@ -191,6 +199,14 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
             argp_error(state, "%s: '%s'", err_msg, arg);
         }
         break;
+    case OPT_FORBID_KEY:
+    case OPT_BLOCK_KEY:
+        g_intent_mode = true;
+        if (intent_add_forbid(&g_intent, arg, &err_msg) != 0)
+        {
+            argp_error(state, "%s: '%s'", err_msg, arg);
+        }
+        break;
     case OPT_DRY_RUN_KEY:
         g_intent_dry_run = true;
         break;
@@ -232,19 +248,19 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
     case ARGP_KEY_END:
         if (g_intent_mode && g_chain_arg)
         {
-            argp_error(state, "--allow/--permit and --chain are mutually exclusive");
+            argp_error(state, "--allow/--permit/--forbid/--block and --chain are mutually exclusive");
         }
         if (g_intent_mode && state->arg_num > 0)
         {
-            argp_error(state, "--allow/--permit and positional PROGRAM arguments are mutually exclusive");
+            argp_error(state, "--allow/--permit/--forbid/--block and positional PROGRAM arguments are mutually exclusive");
         }
         if (g_intent_dry_run && !g_intent_mode)
         {
-            argp_error(state, "--dry-run currently requires --allow or --permit");
+            argp_error(state, "--dry-run currently requires --allow, --permit, --forbid, or --block");
         }
         if (g_intent_explain && !g_intent_mode)
         {
-            argp_error(state, "--explain currently requires --allow or --permit");
+            argp_error(state, "--explain currently requires --allow, --permit, --forbid, or --block");
         }
         if (g_intent_mode)
         {


### PR DESCRIPTION
## Summary

Stacked on #75.

This PR adds the v0.6 PR2 surface for Intent forbids without claiming backend enforcement yet:

- adds `--forbid` and `--block` CLI parsing as the deny-side aliases to `--allow` / `--permit`
- stores forbids in the Intent IR with normalization and exact duplicate detection
- keeps dry-run/live backend compilation fail-closed with `forbids are not supported yet`
- prints mixed permit/forbid Intent explain output before the backend rejection
- adds a test-only semantic oracle and golden packet matrix to anchor later DDAG/enforcement/BPF agreement tests

## Verification

- RED: `xmake run test test/intent_unit.bats` failed before `intent_add_forbid` existed
- RED: `xmake run test test/intent_unit.bats` failed before `test/intent_semantics.h` existed
- RED: `xmake run test test/intent_forbid.bats` failed before `--forbid` / `--block` existed
- GREEN: Docker `xmake run test test/intent_forbid.bats test/intent_unit.bats test/cli.flags.bats` passed 79 tests
- GREEN: Docker `xmake run test test/intent_forbid.bats test/intent_unit.bats test/cli.flags.bats test/intent.bats test/ddag_unit.bats test/enforcement_unit.bats test/intent_bpf_unit.bats` passed 92 tests
- GREEN after final cleanup: Docker `xmake run test test/intent_forbid.bats test/intent_unit.bats` passed 4 tests
- `git diff --check` passed