### PR TITLE
feat(intent): compile forbid precedence in ddag

### DIFF
--- a/api/dag.h
+++ b/api/dag.h
@@ -8,7 +8,7 @@
 #include "intent.h"
 
 /* Validators recurse through a fixed-size userspace graph bounded here. */
-#define MAX_DECISION_NODES (MAX_INTENT_PERMITS * MAX_INTENT_PREDICATES)
+#define MAX_DECISION_NODES ((MAX_INTENT_PERMITS + MAX_INTENT_FORBIDS) * MAX_INTENT_PREDICATES)
 #define INTENT_SUBSET_CONTEXT_COUNT 32
 
 enum decision_terminal
@@ -16,6 +16,7 @@ enum decision_terminal
     DECISION_TERMINAL_NONE = 0,
     DECISION_TERMINAL_ALLOW = 1,
     DECISION_TERMINAL_DROP = 2,
+    DECISION_TERMINAL_FORBID = 3,
 };
 
 struct decision_edge
@@ -38,7 +39,7 @@ struct decision_dag
     enum intent_direction direction;
     size_t root;
     /*
-     * At current limits this array is about 15 KiB. Keep decision_dag on the
+     * At current limits this array is about 30 KiB. Keep decision_dag on the
      * userspace stack or in static storage, never on a BPF/kernel stack.
      */
     struct decision_node nodes[MAX_DECISION_NODES];
@@ -60,10 +61,33 @@ static inline struct decision_edge decision_edge_node(size_t node)
     return edge;
 }
 
+static inline void intent_emit_decision_chain(struct decision_dag *dag,
+                                              const struct intent_predicate *predicates,
+                                              size_t predicate_count,
+                                              size_t chain_start,
+                                              enum decision_terminal true_terminal,
+                                              struct decision_edge false_edge)
+{
+    for (size_t i = 0; i < predicate_count; i++)
+    {
+        size_t node_index = chain_start + i;
+        struct decision_node *node = &dag->nodes[node_index];
+
+        node->predicate = predicates[i];
+        node->on_false = false_edge;
+        node->on_error = decision_edge_terminal(DECISION_TERMINAL_DROP);
+        if (i + 1 < predicate_count)
+            node->on_true = decision_edge_node(node_index + 1);
+        else
+            node->on_true = decision_edge_terminal(true_terminal);
+    }
+}
+
 static inline int intent_build_dag(const struct intent *intent,
                                    struct decision_dag *dag,
                                    const char **err_msg)
 {
+    size_t forbid_starts[MAX_INTENT_FORBIDS] = {0};
     size_t permit_starts[MAX_INTENT_PERMITS] = {0};
     size_t node_count = 0;
 
@@ -71,10 +95,23 @@ static inline int intent_build_dag(const struct intent *intent,
         return intent_fail(err_msg, "at least one permit is required");
     if (intent->permit_count > MAX_INTENT_PERMITS)
         return intent_fail(err_msg, "too many permits");
+    if (intent->forbid_count > MAX_INTENT_FORBIDS)
+        return intent_fail(err_msg, "too many forbids");
     if (intent->default_action != INTENT_ACTION_DROP)
         return intent_fail(err_msg, "default action must drop");
-    if (intent->forbid_count != 0)
-        return intent_fail(err_msg, "forbids are not supported yet");
+
+    for (size_t i = 0; i < intent->forbid_count; i++)
+    {
+        const struct intent_forbid *forbid = &intent->forbids[i];
+        if (forbid->predicate_count == 0)
+            return intent_fail(err_msg, "forbid has no predicates");
+        if (forbid->predicate_count > MAX_INTENT_PREDICATES)
+            return intent_fail(err_msg, "invalid forbid");
+        if (forbid->predicate_count > MAX_DECISION_NODES - node_count)
+            return intent_fail(err_msg, "Decision DAG exceeds node limit");
+        forbid_starts[i] = node_count;
+        node_count += forbid->predicate_count;
+    }
 
     for (size_t i = 0; i < intent->permit_count; i++)
     {
@@ -95,33 +132,41 @@ static inline int intent_build_dag(const struct intent *intent,
     dag->node_count = node_count;
 
     /*
-     * Each permit lowers to one linear predicate chain.
-     * Every false predicate edge in non-last permits enters the next chain.
-     * Every false predicate edge in the last permit targets terminal DROP.
+     * Each rule lowers to one linear predicate chain.
+     * Forbids are emitted before permits so explicit deny wins.
+     * False edges enter the next chain or terminal DROP.
      * Shared prefixes are intentionally not merged yet.
      */
+    for (size_t i = 0; i < intent->forbid_count; i++)
+    {
+        const struct intent_forbid *forbid = &intent->forbids[i];
+        struct decision_edge false_edge = decision_edge_node(permit_starts[0]);
+
+        if (i + 1 < intent->forbid_count)
+            false_edge = decision_edge_node(forbid_starts[i + 1]);
+
+        intent_emit_decision_chain(dag,
+                                   forbid->predicates,
+                                   forbid->predicate_count,
+                                   forbid_starts[i],
+                                   DECISION_TERMINAL_FORBID,
+                                   false_edge);
+    }
+
     for (size_t i = 0; i < intent->permit_count; i++)
     {
         const struct intent_permit *permit = &intent->permits[i];
-        size_t permit_start = permit_starts[i];
         struct decision_edge false_edge = decision_edge_terminal(DECISION_TERMINAL_DROP);
 
         if (i + 1 < intent->permit_count)
             false_edge = decision_edge_node(permit_starts[i + 1]);
 
-        for (size_t j = 0; j < permit->predicate_count; j++)
-        {
-            size_t node_index = permit_start + j;
-            struct decision_node *node = &dag->nodes[node_index];
-
-            node->predicate = permit->predicates[j];
-            node->on_false = false_edge;
-            node->on_error = decision_edge_terminal(DECISION_TERMINAL_DROP);
-            if (j + 1 < permit->predicate_count)
-                node->on_true = decision_edge_node(node_index + 1);
-            else
-                node->on_true = decision_edge_terminal(DECISION_TERMINAL_ALLOW);
-        }
+        intent_emit_decision_chain(dag,
+                                   permit->predicates,
+                                   permit->predicate_count,
+                                   permit_starts[i],
+                                   DECISION_TERMINAL_ALLOW,
+                                   false_edge);
     }
 
     return 0;
@@ -145,6 +190,7 @@ static inline int intent_validate_edge(const struct decision_dag *dag,
         return 0;
     case DECISION_TERMINAL_ALLOW:
     case DECISION_TERMINAL_DROP:
+    case DECISION_TERMINAL_FORBID:
         if (edge->node != 0)
             return intent_fail(err_msg, "Decision DAG terminal edge target must be empty");
         return 0;
@@ -396,6 +442,9 @@ static inline int intent_validate_supported_edge(const struct decision_dag *dag,
         if (edge->terminal == DECISION_TERMINAL_ALLOW &&
             !intent_subset_context_allows_terminal(context))
             return intent_fail(err_msg, "Decision DAG allow path is outside the first supported subset");
+        if (edge->terminal == DECISION_TERMINAL_FORBID &&
+            !intent_subset_context_allows_terminal(context))
+            return intent_fail(err_msg, "Decision DAG forbid path is outside the first supported subset");
         return 0;
     }
 

--- a/api/enforcement.h
+++ b/api/enforcement.h
@@ -442,6 +442,8 @@ static inline int intent_enforcement_walk_edge(const struct decision_dag *dag,
         return intent_enforcement_emit_path(&path, plan, err_msg);
     case DECISION_TERMINAL_DROP:
         return 0;
+    case DECISION_TERMINAL_FORBID:
+        return intent_fail(err_msg, "forbids are not supported yet");
     default:
         return intent_fail(err_msg, "enforcement path is outside the first supported subset");
     }

--- a/api/intent.h
+++ b/api/intent.h
@@ -9,9 +9,8 @@
 #include <string.h>
 
 #define MAX_INTENT_PERMITS 32
-/* This bound only covers the IPv4 grammar accepted today. */
-#define MAX_INTENT_PERMIT_INPUT_LEN 128
-/* Forbid storage is reserved for the Intent model. */
+/* This bound only covers the IPv4 selector grammar accepted today. */
+#define MAX_INTENT_SELECTOR_INPUT_LEN 128
 #define MAX_INTENT_FORBIDS 32
 #define MAX_INTENT_PREDICATES 6
 #define MAX_INTENT_SET_VALUES 4
@@ -196,57 +195,127 @@ static inline void intent_normalize_predicate_values(struct intent_predicate *pr
           intent_value_qsort_compare);
 }
 
-static inline int intent_validate_predicate_shape(const struct intent_predicate *predicate,
-                                                  const char **err_msg)
+static inline int intent_validate_predicate_shape_msg(const struct intent_predicate *predicate,
+                                                      const char *invalid_msg,
+                                                      const char **err_msg)
 {
     if (predicate->values.count == 0 ||
         predicate->values.count > MAX_INTENT_SET_VALUES)
-        return intent_fail(err_msg, "invalid permit");
+        return intent_fail(err_msg, invalid_msg);
 
     if (predicate->op == INTENT_OP_EQ)
     {
         if (predicate->values.count != 1)
-            return intent_fail(err_msg, "invalid permit");
+            return intent_fail(err_msg, invalid_msg);
         return 0;
     }
 
     if (predicate->op != INTENT_OP_IN)
-        return intent_fail(err_msg, "invalid permit");
+        return intent_fail(err_msg, invalid_msg);
 
     if (predicate->values.count < 2)
-        return intent_fail(err_msg, "invalid permit");
+        return intent_fail(err_msg, invalid_msg);
     for (size_t i = 1; i < predicate->values.count; i++)
     {
         if (predicate->values.values[i - 1] == predicate->values.values[i])
-            return intent_fail(err_msg, "invalid permit");
+            return intent_fail(err_msg, invalid_msg);
     }
     return 0;
 }
 
-static inline void intent_normalize_permit(struct intent_permit *permit)
+static inline int intent_validate_predicate_shape(const struct intent_predicate *predicate,
+                                                  const char **err_msg)
 {
-    for (size_t i = 0; i < permit->predicate_count; i++)
-        intent_normalize_predicate_values(&permit->predicates[i]);
+    return intent_validate_predicate_shape_msg(predicate, "invalid permit", err_msg);
+}
+
+static inline void intent_normalize_predicates(struct intent_predicate *predicates,
+                                               size_t predicate_count)
+{
+    for (size_t i = 0; i < predicate_count; i++)
+        intent_normalize_predicate_values(&predicates[i]);
 
     /* Canonical predicate order makes duplicate detection order independent. */
-    qsort(permit->predicates,
-          permit->predicate_count,
-          sizeof(permit->predicates[0]),
+    qsort(predicates,
+          predicate_count,
+          sizeof(predicates[0]),
           intent_predicate_qsort_compare);
+}
+
+static inline void intent_normalize_permit(struct intent_permit *permit)
+{
+    intent_normalize_predicates(permit->predicates, permit->predicate_count);
+}
+
+static inline void intent_normalize_forbid(struct intent_forbid *forbid)
+{
+    intent_normalize_predicates(forbid->predicates, forbid->predicate_count);
+}
+
+static inline bool intent_predicate_list_equal(const struct intent_predicate *left,
+                                               size_t left_count,
+                                               const struct intent_predicate *right,
+                                               size_t right_count)
+{
+    if (left_count != right_count)
+        return false;
+
+    for (size_t i = 0; i < left_count; i++)
+    {
+        if (!intent_predicate_equal(&left[i], &right[i]))
+            return false;
+    }
+    return true;
 }
 
 static inline bool intent_permit_equal(const struct intent_permit *left,
                                        const struct intent_permit *right)
 {
-    if (left->predicate_count != right->predicate_count)
-        return false;
+    return intent_predicate_list_equal(left->predicates,
+                                       left->predicate_count,
+                                       right->predicates,
+                                       right->predicate_count);
+}
 
-    for (size_t i = 0; i < left->predicate_count; i++)
-    {
-        if (!intent_predicate_equal(&left->predicates[i], &right->predicates[i]))
-            return false;
-    }
-    return true;
+static inline bool intent_forbid_equal(const struct intent_forbid *left,
+                                       const struct intent_forbid *right)
+{
+    return intent_predicate_list_equal(left->predicates,
+                                       left->predicate_count,
+                                       right->predicates,
+                                       right->predicate_count);
+}
+
+static inline int intent_rule_add_predicate(struct intent_predicate *predicates,
+                                            size_t *predicate_count,
+                                            enum intent_predicate_field field,
+                                            enum intent_predicate_op op,
+                                            const uint32_t *values,
+                                            size_t value_count,
+                                            const char *invalid_msg,
+                                            const char **err_msg)
+{
+    struct intent_predicate predicate = {0};
+
+    if (!predicates || !predicate_count || !values)
+        return intent_fail(err_msg, invalid_msg);
+    if (*predicate_count >= MAX_INTENT_PREDICATES ||
+        value_count == 0 ||
+        value_count > MAX_INTENT_SET_VALUES)
+        return intent_fail(err_msg, invalid_msg);
+
+    predicate.field = field;
+    predicate.op = op;
+    predicate.values.count = value_count;
+    for (size_t i = 0; i < value_count; i++)
+        predicate.values.values[i] = values[i];
+    intent_normalize_predicate_values(&predicate);
+    if (intent_validate_predicate_shape_msg(&predicate, invalid_msg, err_msg) != 0)
+        return -1;
+
+    predicates[*predicate_count] = predicate;
+    (*predicate_count)++;
+    return 0;
 }
 
 static inline int intent_add_predicate(struct intent_permit *permit,
@@ -256,26 +325,95 @@ static inline int intent_add_predicate(struct intent_permit *permit,
                                        size_t value_count,
                                        const char **err_msg)
 {
-    struct intent_predicate predicate = {0};
-
-    if (!permit || !values)
+    if (!permit)
         return intent_fail(err_msg, "invalid permit");
-    if (permit->predicate_count >= MAX_INTENT_PREDICATES ||
-        value_count == 0 ||
-        value_count > MAX_INTENT_SET_VALUES)
-        return intent_fail(err_msg, "invalid permit");
+    return intent_rule_add_predicate(permit->predicates,
+                                     &permit->predicate_count,
+                                     field,
+                                     op,
+                                     values,
+                                     value_count,
+                                     "invalid permit",
+                                     err_msg);
+}
 
-    predicate.field = field;
-    predicate.op = op;
-    predicate.values.count = value_count;
-    for (size_t i = 0; i < value_count; i++)
-        predicate.values.values[i] = values[i];
-    intent_normalize_predicate_values(&predicate);
-    if (intent_validate_predicate_shape(&predicate, err_msg) != 0)
-        return -1;
+static inline int intent_add_forbid_predicate(struct intent_forbid *forbid,
+                                              enum intent_predicate_field field,
+                                              enum intent_predicate_op op,
+                                              const uint32_t *values,
+                                              size_t value_count,
+                                              const char **err_msg)
+{
+    if (!forbid)
+        return intent_fail(err_msg, "invalid forbid");
+    return intent_rule_add_predicate(forbid->predicates,
+                                     &forbid->predicate_count,
+                                     field,
+                                     op,
+                                     values,
+                                     value_count,
+                                     "invalid forbid",
+                                     err_msg);
+}
 
-    permit->predicates[permit->predicate_count] = predicate;
-    permit->predicate_count++;
+static inline int intent_add_forbid_eq(struct intent_forbid *forbid,
+                                       enum intent_predicate_field field,
+                                       uint32_t value,
+                                       const char **err_msg)
+{
+    return intent_add_forbid_predicate(forbid, field, INTENT_OP_EQ, &value, 1, err_msg);
+}
+
+static inline int intent_add_forbid_proto_in_tcp_udp(struct intent_forbid *forbid,
+                                                     const char **err_msg)
+{
+    const uint32_t protos[] = {INTENT_IPPROTO_TCP, INTENT_IPPROTO_UDP};
+    return intent_add_forbid_predicate(forbid,
+                                       INTENT_FIELD_IP_PROTO,
+                                       INTENT_OP_IN,
+                                       protos,
+                                       2,
+                                       err_msg);
+}
+
+static inline void intent_forbid_init(struct intent_forbid *forbid)
+{
+    memset(forbid, 0, sizeof(*forbid));
+}
+
+static inline bool intent_has_forbid(const struct intent *intent,
+                                     const struct intent_forbid *candidate)
+{
+    for (size_t i = 0; i < intent->forbid_count; i++)
+    {
+        if (intent_forbid_equal(&intent->forbids[i], candidate))
+            return true;
+    }
+    return false;
+}
+
+static inline int intent_append_forbid(struct intent *intent,
+                                       const struct intent_forbid *forbid,
+                                       const char **err_msg)
+{
+    struct intent_forbid normalized = *forbid;
+    intent_normalize_forbid(&normalized);
+
+    if (normalized.predicate_count == 0)
+        return intent_fail(err_msg, "forbid has no predicates");
+    for (size_t i = 0; i < normalized.predicate_count; i++)
+    {
+        if (intent_validate_predicate_shape_msg(&normalized.predicates[i],
+                                                "invalid forbid",
+                                                err_msg) != 0)
+            return -1;
+    }
+    if (intent_has_forbid(intent, &normalized))
+        return intent_fail(err_msg, "duplicate forbid");
+    if (intent->forbid_count >= MAX_INTENT_FORBIDS)
+        return intent_fail(err_msg, "too many forbids");
+    intent->forbids[intent->forbid_count] = normalized;
+    intent->forbid_count++;
     return 0;
 }
 
@@ -394,11 +532,64 @@ static inline int intent_add_l4_permit(struct intent *intent,
     return intent_append_permit(intent, &permit, err_msg);
 }
 
+static inline int intent_add_arp_forbid(struct intent *intent,
+                                        const char **err_msg)
+{
+    struct intent_forbid forbid;
+    intent_forbid_init(&forbid);
+    if (intent_add_forbid_eq(&forbid, INTENT_FIELD_ETH_TYPE, INTENT_ETH_P_ARP, err_msg) != 0)
+        return -1;
+    return intent_append_forbid(intent, &forbid, err_msg);
+}
+
+static inline int intent_add_dns_forbid(struct intent *intent,
+                                        const char *ip,
+                                        const char **err_msg)
+{
+    uint32_t dst_ip = 0;
+    struct intent_forbid forbid;
+    intent_forbid_init(&forbid);
+
+    if (intent_parse_ipv4(ip, &dst_ip) != 0)
+        return intent_fail(err_msg, "invalid forbid");
+    if (intent_add_forbid_eq(&forbid, INTENT_FIELD_ETH_TYPE, INTENT_ETH_P_IP, err_msg) != 0 ||
+        intent_add_forbid_eq(&forbid, INTENT_FIELD_IP_DST, dst_ip, err_msg) != 0 ||
+        intent_add_forbid_proto_in_tcp_udp(&forbid, err_msg) != 0 ||
+        intent_add_forbid_eq(&forbid, INTENT_FIELD_L4_DST_PORT, INTENT_DNS_PORT, err_msg) != 0)
+        return -1;
+
+    return intent_append_forbid(intent, &forbid, err_msg);
+}
+
+static inline int intent_add_l4_forbid(struct intent *intent,
+                                       uint32_t proto,
+                                       const char *ip,
+                                       const char *port,
+                                       const char **err_msg)
+{
+    uint32_t dst_ip = 0;
+    uint32_t dst_port = 0;
+    struct intent_forbid forbid;
+    intent_forbid_init(&forbid);
+
+    if (!port ||
+        intent_parse_ipv4(ip, &dst_ip) != 0 ||
+        intent_parse_port(port, &dst_port) != 0)
+        return intent_fail(err_msg, "invalid forbid");
+    if (intent_add_forbid_eq(&forbid, INTENT_FIELD_ETH_TYPE, INTENT_ETH_P_IP, err_msg) != 0 ||
+        intent_add_forbid_eq(&forbid, INTENT_FIELD_IP_DST, dst_ip, err_msg) != 0 ||
+        intent_add_forbid_eq(&forbid, INTENT_FIELD_IP_PROTO, proto, err_msg) != 0 ||
+        intent_add_forbid_eq(&forbid, INTENT_FIELD_L4_DST_PORT, dst_port, err_msg) != 0)
+        return -1;
+
+    return intent_append_forbid(intent, &forbid, err_msg);
+}
+
 static inline int intent_add_permit(struct intent *intent,
                                     const char *arg,
                                     const char **err_msg)
 {
-    char buf[MAX_INTENT_PERMIT_INPUT_LEN];
+    char buf[MAX_INTENT_SELECTOR_INPUT_LEN];
     char *kind = NULL;
     char *target = NULL;
     char *port = NULL;
@@ -451,21 +642,92 @@ static inline int intent_add_permit(struct intent *intent,
     return intent_fail(err_msg, "unsupported permit");
 }
 
-static inline int intent_permit_compare(const void *left, const void *right)
+static inline int intent_add_forbid(struct intent *intent,
+                                    const char *arg,
+                                    const char **err_msg)
 {
-    const struct intent_permit *a = left;
-    const struct intent_permit *b = right;
+    char buf[MAX_INTENT_SELECTOR_INPUT_LEN];
+    char *kind = NULL;
+    char *target = NULL;
+    char *port = NULL;
+    size_t arg_len = 0;
 
-    if (a->predicate_count != b->predicate_count)
-        return a->predicate_count < b->predicate_count ? -1 : 1;
+    if (!arg)
+        return intent_fail(err_msg, "invalid forbid");
+    arg_len = strlen(arg);
 
-    for (size_t i = 0; i < a->predicate_count; i++)
+    if (arg_len >= sizeof(buf))
+        return intent_fail(err_msg, "forbid too long");
+
+    if (strcmp(arg, "arp") == 0)
+        return intent_add_arp_forbid(intent, err_msg);
+
+    memcpy(buf, arg, arg_len + 1);
+    kind = buf;
+    target = strchr(kind, '/');
+    if (!target)
+        return intent_fail(err_msg, "unsupported forbid");
+    *target++ = '\0';
+
+    if (strcmp(kind, "dns") == 0)
     {
-        int cmp = intent_predicate_compare(&a->predicates[i], &b->predicates[i]);
+        if (strchr(target, ':'))
+            return intent_fail(err_msg, "dns forbids do not accept a port");
+        return intent_add_dns_forbid(intent, target, err_msg);
+    }
+    if (strcmp(kind, "tcp") == 0)
+    {
+        port = strrchr(target, ':');
+        if (port)
+            *port++ = '\0';
+        return intent_add_l4_forbid(intent, INTENT_IPPROTO_TCP, target, port, err_msg);
+    }
+    if (strcmp(kind, "udp") == 0)
+    {
+        port = strrchr(target, ':');
+        if (port)
+            *port++ = '\0';
+        return intent_add_l4_forbid(intent, INTENT_IPPROTO_UDP, target, port, err_msg);
+    }
+
+    return intent_fail(err_msg, "unsupported forbid");
+}
+
+static inline int intent_rule_compare(const struct intent_predicate *left,
+                                      size_t left_count,
+                                      const struct intent_predicate *right,
+                                      size_t right_count)
+{
+    if (left_count != right_count)
+        return left_count < right_count ? -1 : 1;
+
+    for (size_t i = 0; i < left_count; i++)
+    {
+        int cmp = intent_predicate_compare(&left[i], &right[i]);
         if (cmp != 0)
             return cmp;
     }
     return 0;
+}
+
+static inline int intent_permit_compare(const void *left, const void *right)
+{
+    const struct intent_permit *a = left;
+    const struct intent_permit *b = right;
+    return intent_rule_compare(a->predicates,
+                               a->predicate_count,
+                               b->predicates,
+                               b->predicate_count);
+}
+
+static inline int intent_forbid_compare(const void *left, const void *right)
+{
+    const struct intent_forbid *a = left;
+    const struct intent_forbid *b = right;
+    return intent_rule_compare(a->predicates,
+                               a->predicate_count,
+                               b->predicates,
+                               b->predicate_count);
 }
 
 static inline void intent_normalize(struct intent *intent)
@@ -476,15 +738,23 @@ static inline void intent_normalize(struct intent *intent)
           intent->permit_count,
           sizeof(intent->permits[0]),
           intent_permit_compare);
+
+    for (size_t i = 0; i < intent->forbid_count; i++)
+        intent_normalize_forbid(&intent->forbids[i]);
+    qsort(intent->forbids,
+          intent->forbid_count,
+          sizeof(intent->forbids[0]),
+          intent_forbid_compare);
 }
 
-static inline bool intent_permit_get_eq(const struct intent_permit *permit,
-                                        enum intent_predicate_field field,
-                                        uint32_t *out)
+static inline bool intent_rule_get_eq(const struct intent_predicate *predicates,
+                                      size_t predicate_count,
+                                      enum intent_predicate_field field,
+                                      uint32_t *out)
 {
-    for (size_t i = 0; i < permit->predicate_count; i++)
+    for (size_t i = 0; i < predicate_count; i++)
     {
-        const struct intent_predicate *predicate = &permit->predicates[i];
+        const struct intent_predicate *predicate = &predicates[i];
         if (predicate->field == field &&
             predicate->op == INTENT_OP_EQ &&
             predicate->values.count == 1)
@@ -496,11 +766,26 @@ static inline bool intent_permit_get_eq(const struct intent_permit *permit,
     return false;
 }
 
-static inline bool intent_permit_has_proto_in_tcp_udp(const struct intent_permit *permit)
+static inline bool intent_permit_get_eq(const struct intent_permit *permit,
+                                        enum intent_predicate_field field,
+                                        uint32_t *out)
 {
-    for (size_t i = 0; i < permit->predicate_count; i++)
+    return intent_rule_get_eq(permit->predicates, permit->predicate_count, field, out);
+}
+
+static inline bool intent_forbid_get_eq(const struct intent_forbid *forbid,
+                                        enum intent_predicate_field field,
+                                        uint32_t *out)
+{
+    return intent_rule_get_eq(forbid->predicates, forbid->predicate_count, field, out);
+}
+
+static inline bool intent_rule_has_proto_in_tcp_udp(const struct intent_predicate *predicates,
+                                                    size_t predicate_count)
+{
+    for (size_t i = 0; i < predicate_count; i++)
     {
-        const struct intent_predicate *predicate = &permit->predicates[i];
+        const struct intent_predicate *predicate = &predicates[i];
         if (predicate->field == INTENT_FIELD_IP_PROTO &&
             predicate->op == INTENT_OP_IN &&
             predicate->values.count == 2)
@@ -522,6 +807,16 @@ static inline bool intent_permit_has_proto_in_tcp_udp(const struct intent_permit
     return false;
 }
 
+static inline bool intent_permit_has_proto_in_tcp_udp(const struct intent_permit *permit)
+{
+    return intent_rule_has_proto_in_tcp_udp(permit->predicates, permit->predicate_count);
+}
+
+static inline bool intent_forbid_has_proto_in_tcp_udp(const struct intent_forbid *forbid)
+{
+    return intent_rule_has_proto_in_tcp_udp(forbid->predicates, forbid->predicate_count);
+}
+
 static inline void intent_format_ip(uint32_t ip, char *buf, size_t len)
 {
     struct in_addr addr = {0};
@@ -529,12 +824,159 @@ static inline void intent_format_ip(uint32_t ip, char *buf, size_t len)
     inet_ntop(AF_INET, &addr, buf, len);
 }
 
+static inline bool intent_print_permit_explain(FILE *out,
+                                               size_t index,
+                                               const struct intent_permit *permit)
+{
+    char ip[INET_ADDRSTRLEN];
+    uint32_t eth_type = 0;
+    uint32_t ip_dst = 0;
+    uint32_t proto = 0;
+    uint32_t port = 0;
+    bool has_port = intent_permit_get_eq(permit, INTENT_FIELD_L4_DST_PORT, &port);
+
+    if (intent_permit_get_eq(permit, INTENT_FIELD_ETH_TYPE, &eth_type) &&
+        eth_type == INTENT_ETH_P_ARP)
+    {
+        fprintf(out, "  %zu. ARP\n", index);
+        return false;
+    }
+
+    if (intent_permit_get_eq(permit, INTENT_FIELD_ETH_TYPE, &eth_type) &&
+        eth_type == INTENT_ETH_P_IP &&
+        intent_permit_get_eq(permit, INTENT_FIELD_IP_DST, &ip_dst) &&
+        has_port &&
+        intent_permit_has_proto_in_tcp_udp(permit) &&
+        port == INTENT_DNS_PORT)
+    {
+        intent_format_ip(ip_dst, ip, sizeof(ip));
+        fprintf(out, "  %zu. DNS to %s over TCP or UDP destination port 53\n",
+                index,
+                ip);
+        return true;
+    }
+
+    if (intent_permit_get_eq(permit, INTENT_FIELD_ETH_TYPE, &eth_type) &&
+        eth_type == INTENT_ETH_P_IP &&
+        intent_permit_get_eq(permit, INTENT_FIELD_IP_DST, &ip_dst) &&
+        intent_permit_get_eq(permit, INTENT_FIELD_IP_PROTO, &proto) &&
+        proto == INTENT_IPPROTO_TCP)
+    {
+        intent_format_ip(ip_dst, ip, sizeof(ip));
+        if (has_port)
+        {
+            fprintf(out, "  %zu. TCP to %s destination port %u\n",
+                    index,
+                    ip,
+                    port);
+        }
+        else
+        {
+            fprintf(out, "  %zu. TCP to %s any destination port\n",
+                    index,
+                    ip);
+        }
+        return true;
+    }
+
+    if (intent_permit_get_eq(permit, INTENT_FIELD_ETH_TYPE, &eth_type) &&
+        eth_type == INTENT_ETH_P_IP &&
+        intent_permit_get_eq(permit, INTENT_FIELD_IP_DST, &ip_dst) &&
+        intent_permit_get_eq(permit, INTENT_FIELD_IP_PROTO, &proto) &&
+        proto == INTENT_IPPROTO_UDP)
+    {
+        intent_format_ip(ip_dst, ip, sizeof(ip));
+        if (has_port)
+        {
+            fprintf(out, "  %zu. UDP to %s destination port %u\n",
+                    index,
+                    ip,
+                    port);
+        }
+        else
+        {
+            fprintf(out, "  %zu. UDP to %s any destination port\n",
+                    index,
+                    ip);
+        }
+        return true;
+    }
+
+    fprintf(out, "  %zu. permit cannot be explained by this traffico version\n", index);
+    return false;
+}
+
+static inline bool intent_print_forbid_explain(FILE *out,
+                                               size_t index,
+                                               const struct intent_forbid *forbid)
+{
+    char ip[INET_ADDRSTRLEN];
+    uint32_t eth_type = 0;
+    uint32_t ip_dst = 0;
+    uint32_t proto = 0;
+    uint32_t port = 0;
+    bool has_port = intent_forbid_get_eq(forbid, INTENT_FIELD_L4_DST_PORT, &port);
+
+    if (intent_forbid_get_eq(forbid, INTENT_FIELD_ETH_TYPE, &eth_type) &&
+        eth_type == INTENT_ETH_P_ARP)
+    {
+        fprintf(out, "  %zu. ARP\n", index);
+        return false;
+    }
+
+    if (intent_forbid_get_eq(forbid, INTENT_FIELD_ETH_TYPE, &eth_type) &&
+        eth_type == INTENT_ETH_P_IP &&
+        intent_forbid_get_eq(forbid, INTENT_FIELD_IP_DST, &ip_dst) &&
+        has_port &&
+        intent_forbid_has_proto_in_tcp_udp(forbid) &&
+        port == INTENT_DNS_PORT)
+    {
+        intent_format_ip(ip_dst, ip, sizeof(ip));
+        fprintf(out, "  %zu. DNS to %s over TCP or UDP destination port 53\n",
+                index,
+                ip);
+        return true;
+    }
+
+    if (intent_forbid_get_eq(forbid, INTENT_FIELD_ETH_TYPE, &eth_type) &&
+        eth_type == INTENT_ETH_P_IP &&
+        intent_forbid_get_eq(forbid, INTENT_FIELD_IP_DST, &ip_dst) &&
+        has_port &&
+        intent_forbid_get_eq(forbid, INTENT_FIELD_IP_PROTO, &proto) &&
+        proto == INTENT_IPPROTO_TCP)
+    {
+        intent_format_ip(ip_dst, ip, sizeof(ip));
+        fprintf(out, "  %zu. TCP to %s destination port %u\n",
+                index,
+                ip,
+                port);
+        return true;
+    }
+
+    if (intent_forbid_get_eq(forbid, INTENT_FIELD_ETH_TYPE, &eth_type) &&
+        eth_type == INTENT_ETH_P_IP &&
+        intent_forbid_get_eq(forbid, INTENT_FIELD_IP_DST, &ip_dst) &&
+        has_port &&
+        intent_forbid_get_eq(forbid, INTENT_FIELD_IP_PROTO, &proto) &&
+        proto == INTENT_IPPROTO_UDP)
+    {
+        intent_format_ip(ip_dst, ip, sizeof(ip));
+        fprintf(out, "  %zu. UDP to %s destination port %u\n",
+                index,
+                ip,
+                port);
+        return true;
+    }
+
+    fprintf(out, "  %zu. forbid cannot be explained by this traffico version\n", index);
+    return false;
+}
+
 static inline void intent_print_explain(FILE *out,
                                         const char *ifname,
                                         const struct intent *intent)
 {
-    char ip[INET_ADDRSTRLEN];
-    bool has_l4_permits = false;
+    bool has_l4_rules = false;
 
     /*
      * The caller passes a normalized Intent.
@@ -549,91 +991,27 @@ static inline void intent_print_explain(FILE *out,
 
     for (size_t i = 0; i < intent->permit_count; i++)
     {
-        const struct intent_permit *permit = &intent->permits[i];
-        uint32_t eth_type = 0;
-        uint32_t ip_dst = 0;
-        uint32_t proto = 0;
-        uint32_t port = 0;
-        bool has_port = intent_permit_get_eq(permit, INTENT_FIELD_L4_DST_PORT, &port);
+        if (intent_print_permit_explain(out, i + 1, &intent->permits[i]))
+            has_l4_rules = true;
+    }
 
-        if (intent_permit_get_eq(permit, INTENT_FIELD_ETH_TYPE, &eth_type) &&
-            eth_type == INTENT_ETH_P_ARP)
+    if (intent->forbid_count > 0)
+    {
+        fprintf(out, "\nforbidden traffic:\n");
+        for (size_t i = 0; i < intent->forbid_count; i++)
         {
-            fprintf(out, "  %zu. ARP\n", i + 1);
-            continue;
+            if (intent_print_forbid_explain(out, i + 1, &intent->forbids[i]))
+                has_l4_rules = true;
         }
-
-        if (intent_permit_get_eq(permit, INTENT_FIELD_ETH_TYPE, &eth_type) &&
-            eth_type == INTENT_ETH_P_IP &&
-            intent_permit_get_eq(permit, INTENT_FIELD_IP_DST, &ip_dst) &&
-            has_port &&
-            intent_permit_has_proto_in_tcp_udp(permit) &&
-            port == INTENT_DNS_PORT)
-        {
-            has_l4_permits = true;
-            intent_format_ip(ip_dst, ip, sizeof(ip));
-            fprintf(out, "  %zu. DNS to %s over TCP or UDP destination port 53\n",
-                    i + 1,
-                    ip);
-            continue;
-        }
-
-        if (intent_permit_get_eq(permit, INTENT_FIELD_ETH_TYPE, &eth_type) &&
-            eth_type == INTENT_ETH_P_IP &&
-            intent_permit_get_eq(permit, INTENT_FIELD_IP_DST, &ip_dst) &&
-            intent_permit_get_eq(permit, INTENT_FIELD_IP_PROTO, &proto) &&
-            proto == INTENT_IPPROTO_TCP)
-        {
-            has_l4_permits = true;
-            intent_format_ip(ip_dst, ip, sizeof(ip));
-            if (has_port)
-            {
-                fprintf(out, "  %zu. TCP to %s destination port %u\n",
-                        i + 1,
-                        ip,
-                        port);
-            }
-            else
-            {
-                fprintf(out, "  %zu. TCP to %s any destination port\n",
-                        i + 1,
-                        ip);
-            }
-            continue;
-        }
-
-        if (intent_permit_get_eq(permit, INTENT_FIELD_ETH_TYPE, &eth_type) &&
-            eth_type == INTENT_ETH_P_IP &&
-            intent_permit_get_eq(permit, INTENT_FIELD_IP_DST, &ip_dst) &&
-            intent_permit_get_eq(permit, INTENT_FIELD_IP_PROTO, &proto) &&
-            proto == INTENT_IPPROTO_UDP)
-        {
-            has_l4_permits = true;
-            intent_format_ip(ip_dst, ip, sizeof(ip));
-            if (has_port)
-            {
-                fprintf(out, "  %zu. UDP to %s destination port %u\n",
-                        i + 1,
-                        ip,
-                        port);
-            }
-            else
-            {
-                fprintf(out, "  %zu. UDP to %s any destination port\n",
-                        i + 1,
-                        ip);
-            }
-            continue;
-        }
-
-        fprintf(out, "  %zu. permit cannot be explained by this traffico version\n", i + 1);
     }
 
     fprintf(out, "\ndropped traffic:\n");
     fprintf(out, "  - malformed packets that cannot be safely classified\n");
-    /* Only mention fragment policy when a permit needs L4 classification. */
-    if (has_l4_permits)
+    /* Only mention fragment policy when a rule needs L4 classification. */
+    if (has_l4_rules)
         fprintf(out, "  - TCP/UDP fragments that cannot be fully classified\n");
+    if (intent->forbid_count > 0)
+        fprintf(out, "  - traffic matching a forbid\n");
     fprintf(out, "  - any traffic not matching a permit\n");
 }
 

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -38,25 +38,25 @@ bats_require_minimum_version 1.7.0
 @test "--allow and --chain are mutually exclusive" {
     run traffico -i lo --allow arp --chain "allow_ethertype:arp" --dry-run
     [ $status -eq 1 ]
-    [ "${lines[0]}" == "traffico: --allow/--permit and --chain are mutually exclusive" ]
+    [ "${lines[0]}" == "traffico: --allow/--permit/--forbid/--block and --chain are mutually exclusive" ]
 }
 
 @test "--allow and positional program are mutually exclusive" {
     run traffico -i lo --allow arp nop --dry-run
     [ $status -eq 1 ]
-    [ "${lines[0]}" == "traffico: --allow/--permit and positional PROGRAM arguments are mutually exclusive" ]
+    [ "${lines[0]}" == "traffico: --allow/--permit/--forbid/--block and positional PROGRAM arguments are mutually exclusive" ]
 }
 
 @test "--dry-run requires Intent mode" {
     run traffico -i lo --dry-run nop
     [ $status -eq 1 ]
-    [ "${lines[0]}" == "traffico: --dry-run currently requires --allow or --permit" ]
+    [ "${lines[0]}" == "traffico: --dry-run currently requires --allow, --permit, --forbid, or --block" ]
 }
 
 @test "--explain requires Intent mode" {
     run traffico -i lo --explain nop
     [ $status -eq 1 ]
-    [ "${lines[0]}" == "traffico: --explain currently requires --allow or --permit" ]
+    [ "${lines[0]}" == "traffico: --explain currently requires --allow, --permit, --forbid, or --block" ]
 }
 
 @test "--explain=dag is reserved for future Intent debug output" {

--- a/test/ddag_unit.c
+++ b/test/ddag_unit.c
@@ -2,6 +2,7 @@
 #include <string.h>
 
 #include "api/dag.h"
+#include "intent_semantics.h"
 
 #define CHECK(condition)                                                       \
     do                                                                         \
@@ -30,6 +31,46 @@ static void set_eq_predicate(struct intent_predicate *predicate,
     predicate->op = INTENT_OP_EQ;
     predicate->values.count = 1;
     predicate->values.values[0] = value;
+}
+
+static enum intent_action test_decision_for_terminal(enum decision_terminal terminal)
+{
+    if (terminal == DECISION_TERMINAL_ALLOW)
+        return INTENT_ACTION_ALLOW;
+    return INTENT_ACTION_DROP;
+}
+
+static enum intent_action test_decision_dag_eval_edge(const struct decision_dag *dag,
+                                                      const struct decision_edge *edge,
+                                                      const struct intent_test_packet *packet);
+
+static enum intent_action test_decision_dag_eval_node(const struct decision_dag *dag,
+                                                      size_t node_index,
+                                                      const struct intent_test_packet *packet)
+{
+    const struct decision_node *node = &dag->nodes[node_index];
+
+    if (!intent_test_predicate_matches(&node->predicate, packet))
+        return test_decision_dag_eval_edge(dag, &node->on_false, packet);
+    return test_decision_dag_eval_edge(dag, &node->on_true, packet);
+}
+
+static enum intent_action test_decision_dag_eval_edge(const struct decision_dag *dag,
+                                                      const struct decision_edge *edge,
+                                                      const struct intent_test_packet *packet)
+{
+    if (edge->terminal != DECISION_TERMINAL_NONE)
+        return test_decision_for_terminal(edge->terminal);
+    return test_decision_dag_eval_node(dag, edge->node, packet);
+}
+
+static enum intent_action test_decision_dag_decide(const struct decision_dag *dag,
+                                                   struct intent_test_packet packet)
+{
+    if (packet.kind == INTENT_TEST_PACKET_MALFORMED ||
+        packet.kind == INTENT_TEST_PACKET_UNCLASSIFIABLE)
+        return INTENT_ACTION_DROP;
+    return test_decision_dag_eval_node(dag, dag->root, &packet);
 }
 
 static int test_decision_dag_builds_predicate_chain(void)
@@ -126,18 +167,100 @@ static int test_decision_dag_accepts_host_wide_l4_permit_path(void)
     return 0;
 }
 
-static int test_decision_dag_rejects_future_forbids(void)
+static int test_decision_dag_builds_forbids_before_permits(void)
 {
     struct intent intent = {0};
     struct decision_dag dag = {0};
     const char *err = NULL;
 
     intent_init(&intent, INTENT_DIRECTION_EGRESS);
-    CHECK(intent_add_permit(&intent, "arp", &err) == 0);
-    intent.forbid_count = 1;
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "tcp/10.0.0.10:22", &err) == 0);
+    intent_normalize(&intent);
 
-    CHECK(intent_build_dag(&intent, &dag, &err) == -1);
-    CHECK(strcmp(err, "forbids are not supported yet") == 0);
+    CHECK(intent_build_dag(&intent, &dag, &err) == 0);
+    CHECK(dag.node_count == 7);
+
+    CHECK(dag.nodes[0].predicate.field == INTENT_FIELD_ETH_TYPE);
+    CHECK(dag.nodes[0].on_true.terminal == DECISION_TERMINAL_NONE);
+    CHECK(dag.nodes[0].on_false.terminal == DECISION_TERMINAL_NONE);
+    CHECK(dag.nodes[0].on_false.node == 4);
+
+    CHECK(dag.nodes[3].predicate.field == INTENT_FIELD_L4_DST_PORT);
+    CHECK(dag.nodes[3].on_true.terminal == DECISION_TERMINAL_FORBID);
+    CHECK(dag.nodes[3].on_false.terminal == DECISION_TERMINAL_NONE);
+    CHECK(dag.nodes[3].on_false.node == 4);
+
+    CHECK(dag.nodes[6].predicate.field == INTENT_FIELD_IP_PROTO);
+    CHECK(dag.nodes[6].on_true.terminal == DECISION_TERMINAL_ALLOW);
+    CHECK(dag.nodes[6].on_false.terminal == DECISION_TERMINAL_DROP);
+
+    CHECK(intent_validate_dag(&dag, &err) == 0);
+    CHECK(intent_validate_supported_subset(&dag, &err) == 0);
+
+    return 0;
+}
+
+static int test_decision_dag_matches_intent_oracle_for_golden_policy(void)
+{
+    struct intent intent = {0};
+    struct decision_dag dag = {0};
+    const char *err = NULL;
+    struct intent_test_packet packets[] = {
+        intent_test_packet_arp(),
+        intent_test_packet_tcp(0x0a00000a, 22),
+        intent_test_packet_tcp(0x0a00000a, 443),
+        intent_test_packet_udp(0x0a00000a, 443),
+        intent_test_packet_tcp(0x0a000014, 443),
+        intent_test_packet_malformed(),
+        intent_test_packet_unclassifiable(),
+    };
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    CHECK(intent_add_permit(&intent, "arp", &err) == 0);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "tcp/10.0.0.10:22", &err) == 0);
+    intent_normalize(&intent);
+
+    CHECK(intent_build_dag(&intent, &dag, &err) == 0);
+    CHECK(intent_validate_dag(&dag, &err) == 0);
+
+    for (size_t i = 0; i < sizeof(packets) / sizeof(packets[0]); i++)
+    {
+        CHECK(test_decision_dag_decide(&dag, packets[i]) ==
+              intent_test_oracle_decide(&intent, packets[i]));
+    }
+
+    return 0;
+}
+
+static int test_decision_dag_matches_intent_oracle_for_dns_carveout_policy(void)
+{
+    struct intent intent = {0};
+    struct decision_dag dag = {0};
+    const char *err = NULL;
+    struct intent_test_packet packets[] = {
+        intent_test_packet_udp(0x0a000035, 53),
+        intent_test_packet_tcp(0x0a000035, 53),
+        intent_test_packet_tcp(0x0a000035, 443),
+        intent_test_packet_udp(0x0a000035, 123),
+    };
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    CHECK(intent_add_permit(&intent, "arp", &err) == 0);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.53", &err) == 0);
+    CHECK(intent_add_permit(&intent, "udp/10.0.0.53", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "dns/10.0.0.53", &err) == 0);
+    intent_normalize(&intent);
+
+    CHECK(intent_build_dag(&intent, &dag, &err) == 0);
+    CHECK(intent_validate_dag(&dag, &err) == 0);
+
+    for (size_t i = 0; i < sizeof(packets) / sizeof(packets[0]); i++)
+    {
+        CHECK(test_decision_dag_decide(&dag, packets[i]) ==
+              intent_test_oracle_decide(&intent, packets[i]));
+    }
 
     return 0;
 }
@@ -476,7 +599,9 @@ int main(void)
     RUN_TEST(test_decision_dag_builds_predicate_chain);
     RUN_TEST(test_decision_dag_chains_three_permit_false_edges);
     RUN_TEST(test_decision_dag_accepts_host_wide_l4_permit_path);
-    RUN_TEST(test_decision_dag_rejects_future_forbids);
+    RUN_TEST(test_decision_dag_builds_forbids_before_permits);
+    RUN_TEST(test_decision_dag_matches_intent_oracle_for_golden_policy);
+    RUN_TEST(test_decision_dag_matches_intent_oracle_for_dns_carveout_policy);
     RUN_TEST(test_decision_dag_rejects_non_drop_default_action);
     RUN_TEST(test_decision_dag_rejects_invalid_public_counts);
     RUN_TEST(test_decision_dag_validates_max_permit_set);

--- a/test/intent_forbid.bats
+++ b/test/intent_forbid.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+load helpers
+export BATS_TEST_NAME_PREFIX=$(setsuite)
+bats_require_minimum_version 1.7.0
+
+@test "--forbid selects Intent mode and is parsed before backend support" {
+    run traffico -i lo --at egress \
+        --allow tcp/10.0.0.10 \
+        --forbid tcp/10.0.0.10:22 \
+        --dry-run
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: intent dry-run: forbids are not supported yet" ]
+}
+
+@test "--block is an alias for --forbid" {
+    run traffico -i lo --at egress \
+        --allow tcp/10.0.0.10 \
+        --block tcp/10.0.0.10:22 \
+        --dry-run
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: intent dry-run: forbids are not supported yet" ]
+}
+
+@test "--dry-run --explain prints permits and forbids" {
+    run traffico -i lo --at egress \
+        --allow tcp/10.0.0.10 \
+        --forbid tcp/10.0.0.10:22 \
+        --dry-run --explain
+    [ $status -eq 1 ]
+    [[ "$output" == *"permitted traffic:"* ]]
+    [[ "$output" == *"  1. TCP to 10.0.0.10 any destination port"* ]]
+    [[ "$output" == *"forbidden traffic:"* ]]
+    [[ "$output" == *"  1. TCP to 10.0.0.10 destination port 22"* ]]
+}

--- a/test/intent_semantics.h
+++ b/test/intent_semantics.h
@@ -1,0 +1,164 @@
+#ifndef TRAFFICO_TEST_INTENT_SEMANTICS_H
+#define TRAFFICO_TEST_INTENT_SEMANTICS_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "api/intent.h"
+
+enum intent_test_packet_kind
+{
+    INTENT_TEST_PACKET_MALFORMED = 0,
+    INTENT_TEST_PACKET_ARP = 1,
+    INTENT_TEST_PACKET_IPV4_L4 = 2,
+    INTENT_TEST_PACKET_UNCLASSIFIABLE = 3,
+};
+
+struct intent_test_packet
+{
+    enum intent_test_packet_kind kind;
+    uint32_t ip_dst;
+    uint8_t ip_proto;
+    uint16_t l4_dst_port;
+};
+
+static inline struct intent_test_packet intent_test_packet_malformed(void)
+{
+    struct intent_test_packet packet = {0};
+    packet.kind = INTENT_TEST_PACKET_MALFORMED;
+    return packet;
+}
+
+static inline struct intent_test_packet intent_test_packet_unclassifiable(void)
+{
+    struct intent_test_packet packet = {0};
+    packet.kind = INTENT_TEST_PACKET_UNCLASSIFIABLE;
+    return packet;
+}
+
+static inline struct intent_test_packet intent_test_packet_arp(void)
+{
+    struct intent_test_packet packet = {0};
+    packet.kind = INTENT_TEST_PACKET_ARP;
+    return packet;
+}
+
+static inline struct intent_test_packet intent_test_packet_l4(uint32_t ip_dst,
+                                                              uint8_t ip_proto,
+                                                              uint16_t l4_dst_port)
+{
+    struct intent_test_packet packet = {0};
+    packet.kind = INTENT_TEST_PACKET_IPV4_L4;
+    packet.ip_dst = ip_dst;
+    packet.ip_proto = ip_proto;
+    packet.l4_dst_port = l4_dst_port;
+    return packet;
+}
+
+static inline struct intent_test_packet intent_test_packet_tcp(uint32_t ip_dst,
+                                                               uint16_t l4_dst_port)
+{
+    return intent_test_packet_l4(ip_dst, INTENT_IPPROTO_TCP, l4_dst_port);
+}
+
+static inline struct intent_test_packet intent_test_packet_udp(uint32_t ip_dst,
+                                                               uint16_t l4_dst_port)
+{
+    return intent_test_packet_l4(ip_dst, INTENT_IPPROTO_UDP, l4_dst_port);
+}
+
+static inline bool intent_test_value_matches(const struct intent_predicate *predicate,
+                                             uint32_t value)
+{
+    for (size_t i = 0; i < predicate->values.count; i++)
+    {
+        if (predicate->values.values[i] == value)
+            return true;
+    }
+    return false;
+}
+
+static inline bool intent_test_predicate_matches(const struct intent_predicate *predicate,
+                                                 const struct intent_test_packet *packet)
+{
+    uint32_t packet_value = 0;
+
+    if (predicate->op != INTENT_OP_EQ &&
+        predicate->op != INTENT_OP_IN)
+        return false;
+
+    if (predicate->field == INTENT_FIELD_ETH_TYPE)
+    {
+        if (packet->kind == INTENT_TEST_PACKET_ARP)
+            packet_value = INTENT_ETH_P_ARP;
+        else if (packet->kind == INTENT_TEST_PACKET_IPV4_L4)
+            packet_value = INTENT_ETH_P_IP;
+        else
+            return false;
+    }
+    else if (predicate->field == INTENT_FIELD_IP_DST)
+    {
+        if (packet->kind != INTENT_TEST_PACKET_IPV4_L4)
+            return false;
+        packet_value = packet->ip_dst;
+    }
+    else if (predicate->field == INTENT_FIELD_IP_PROTO)
+    {
+        if (packet->kind != INTENT_TEST_PACKET_IPV4_L4)
+            return false;
+        packet_value = packet->ip_proto;
+    }
+    else if (predicate->field == INTENT_FIELD_L4_DST_PORT)
+    {
+        if (packet->kind != INTENT_TEST_PACKET_IPV4_L4)
+            return false;
+        packet_value = packet->l4_dst_port;
+    }
+    else
+    {
+        return false;
+    }
+
+    return intent_test_value_matches(predicate, packet_value);
+}
+
+static inline bool intent_test_rule_matches(const struct intent_predicate *predicates,
+                                            size_t predicate_count,
+                                            const struct intent_test_packet *packet)
+{
+    for (size_t i = 0; i < predicate_count; i++)
+    {
+        if (!intent_test_predicate_matches(&predicates[i], packet))
+            return false;
+    }
+    return true;
+}
+
+static inline enum intent_action intent_test_oracle_decide(const struct intent *intent,
+                                                           struct intent_test_packet packet)
+{
+    if (packet.kind == INTENT_TEST_PACKET_MALFORMED ||
+        packet.kind == INTENT_TEST_PACKET_UNCLASSIFIABLE)
+        return INTENT_ACTION_DROP;
+
+    for (size_t i = 0; i < intent->forbid_count; i++)
+    {
+        if (intent_test_rule_matches(intent->forbids[i].predicates,
+                                     intent->forbids[i].predicate_count,
+                                     &packet))
+            return INTENT_ACTION_DROP;
+    }
+
+    for (size_t i = 0; i < intent->permit_count; i++)
+    {
+        if (intent_test_rule_matches(intent->permits[i].predicates,
+                                     intent->permits[i].predicate_count,
+                                     &packet))
+            return INTENT_ACTION_ALLOW;
+    }
+
+    return INTENT_ACTION_DROP;
+}
+
+#endif

--- a/test/intent_unit.c
+++ b/test/intent_unit.c
@@ -2,6 +2,7 @@
 #include <string.h>
 
 #include "api/intent.h"
+#include "intent_semantics.h"
 
 #define CHECK(condition)                                                       \
     do                                                                         \
@@ -213,6 +214,81 @@ static int test_rejects_duplicate_host_wide_l4_permits(void)
     return 0;
 }
 
+static int test_parse_forbids(void)
+{
+    struct intent intent = {0};
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+
+    CHECK(intent_add_forbid(&intent, "arp", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "dns/10.0.0.53", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "tcp/10.0.0.10:22", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "udp/10.0.0.20:123", &err) == 0);
+
+    CHECK(intent.forbid_count == 4);
+    CHECK(intent.forbids[0].predicate_count == 1);
+    CHECK(intent.forbids[2].predicate_count == 4);
+    CHECK_PREDICATE(&intent.forbids[2].predicates[3],
+                    INTENT_FIELD_L4_DST_PORT,
+                    INTENT_OP_EQ,
+                    1,
+                    22,
+                    0);
+
+    return 0;
+}
+
+static int test_rejects_invalid_and_duplicate_forbids(void)
+{
+    struct intent intent = {0};
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+
+    CHECK(intent_add_forbid(&intent, "tcp/10.0.0.10", &err) == -1);
+    CHECK(strcmp(err, "invalid forbid") == 0);
+    CHECK(intent_add_forbid(&intent, "dns/10.0.0.53:53", &err) == -1);
+    CHECK(strcmp(err, "dns forbids do not accept a port") == 0);
+    CHECK(intent_add_forbid(&intent, "arp", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "arp", &err) == -1);
+    CHECK(strcmp(err, "duplicate forbid") == 0);
+
+    return 0;
+}
+
+static int test_forbid_duplicates_are_exact_normalized_duplicates(void)
+{
+    struct intent intent = {0};
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+
+    CHECK(intent_add_forbid(&intent, "dns/10.0.0.53", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "dns/10.0.0.53", &err) == -1);
+    CHECK(strcmp(err, "duplicate forbid") == 0);
+
+    CHECK(intent_add_forbid(&intent, "tcp/10.0.0.53:53", &err) == 0);
+    CHECK(intent.forbid_count == 2);
+
+    return 0;
+}
+
+static int test_allow_forbid_overlap_is_valid_intent(void)
+{
+    struct intent intent = {0};
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10:443", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "tcp/10.0.0.10:443", &err) == 0);
+    CHECK(intent.permit_count == 1);
+    CHECK(intent.forbid_count == 1);
+
+    return 0;
+}
+
 static int test_rejects_invalid_and_duplicate_permits(void)
 {
     struct intent intent = {0};
@@ -286,7 +362,7 @@ static int test_rejects_empty_permits(void)
 static int test_rejects_permit_too_long(void)
 {
     struct intent intent = {0};
-    char permit[MAX_INTENT_PERMIT_INPUT_LEN + 1];
+    char permit[MAX_INTENT_SELECTOR_INPUT_LEN + 1];
     const char *err = NULL;
 
     intent_init(&intent, INTENT_DIRECTION_EGRESS);
@@ -434,12 +510,58 @@ static int test_normalization_is_order_independent(void)
     return 0;
 }
 
+static int test_intent_oracle_evaluates_golden_policy(void)
+{
+    struct intent intent = {0};
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    CHECK(intent_add_permit(&intent, "arp", &err) == 0);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "tcp/10.0.0.10:22", &err) == 0);
+    intent_normalize(&intent);
+
+    CHECK(intent_test_oracle_decide(&intent, intent_test_packet_arp()) == INTENT_ACTION_ALLOW);
+    CHECK(intent_test_oracle_decide(&intent, intent_test_packet_tcp(0x0a00000a, 22)) == INTENT_ACTION_DROP);
+    CHECK(intent_test_oracle_decide(&intent, intent_test_packet_tcp(0x0a00000a, 443)) == INTENT_ACTION_ALLOW);
+    CHECK(intent_test_oracle_decide(&intent, intent_test_packet_udp(0x0a00000a, 443)) == INTENT_ACTION_DROP);
+    CHECK(intent_test_oracle_decide(&intent, intent_test_packet_tcp(0x0a000014, 443)) == INTENT_ACTION_DROP);
+    CHECK(intent_test_oracle_decide(&intent, intent_test_packet_malformed()) == INTENT_ACTION_DROP);
+    CHECK(intent_test_oracle_decide(&intent, intent_test_packet_unclassifiable()) == INTENT_ACTION_DROP);
+
+    return 0;
+}
+
+static int test_intent_oracle_evaluates_dns_carveout_policy(void)
+{
+    struct intent intent = {0};
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    CHECK(intent_add_permit(&intent, "arp", &err) == 0);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.53", &err) == 0);
+    CHECK(intent_add_permit(&intent, "udp/10.0.0.53", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "dns/10.0.0.53", &err) == 0);
+    intent_normalize(&intent);
+
+    CHECK(intent_test_oracle_decide(&intent, intent_test_packet_udp(0x0a000035, 53)) == INTENT_ACTION_DROP);
+    CHECK(intent_test_oracle_decide(&intent, intent_test_packet_tcp(0x0a000035, 53)) == INTENT_ACTION_DROP);
+    CHECK(intent_test_oracle_decide(&intent, intent_test_packet_tcp(0x0a000035, 443)) == INTENT_ACTION_ALLOW);
+    CHECK(intent_test_oracle_decide(&intent, intent_test_packet_udp(0x0a000035, 123)) == INTENT_ACTION_ALLOW);
+
+    return 0;
+}
+
 int main(void)
 {
     RUN_TEST(test_parse_first_permits);
     RUN_TEST(test_parse_ipv4_addresses);
     RUN_TEST(test_parse_host_wide_l4_permits);
     RUN_TEST(test_rejects_duplicate_host_wide_l4_permits);
+    RUN_TEST(test_parse_forbids);
+    RUN_TEST(test_rejects_invalid_and_duplicate_forbids);
+    RUN_TEST(test_forbid_duplicates_are_exact_normalized_duplicates);
+    RUN_TEST(test_allow_forbid_overlap_is_valid_intent);
     RUN_TEST(test_rejects_invalid_and_duplicate_permits);
     RUN_TEST(test_rejects_duplicate_lowered_permits);
     RUN_TEST(test_rejects_empty_permits);
@@ -449,6 +571,8 @@ int main(void)
     RUN_TEST(test_rejects_invalid_manual_predicates);
     RUN_TEST(test_rejects_too_many_permits);
     RUN_TEST(test_normalization_is_order_independent);
+    RUN_TEST(test_intent_oracle_evaluates_golden_policy);
+    RUN_TEST(test_intent_oracle_evaluates_dns_carveout_policy);
     puts("intent unit tests: ok");
     return 0;
 }

--- a/traffico.c
+++ b/traffico.c
@@ -50,9 +50,15 @@ const char OPT_ALLOW_ARG[] = "PERMIT";
 #define OPT_PERMIT_KEY 0x84
 const char OPT_PERMIT_LONG[] = "permit";
 const char OPT_PERMIT_ARG[] = "PERMIT";
-#define OPT_DRY_RUN_KEY 0x85
+#define OPT_FORBID_KEY 0x85
+const char OPT_FORBID_LONG[] = "forbid";
+const char OPT_FORBID_ARG[] = "FORBID";
+#define OPT_BLOCK_KEY 0x86
+const char OPT_BLOCK_LONG[] = "block";
+const char OPT_BLOCK_ARG[] = "FORBID";
+#define OPT_DRY_RUN_KEY 0x87
 const char OPT_DRY_RUN_LONG[] = "dry-run";
-#define OPT_EXPLAIN_KEY 0x86
+#define OPT_EXPLAIN_KEY 0x88
 const char OPT_EXPLAIN_LONG[] = "explain";
 const char OPT_EXPLAIN_ARG[] = "intent";
 
@@ -66,6 +72,8 @@ const struct argp_option argp_opts[] = {
     {OPT_CHAIN_LONG, OPT_CHAIN_KEY, OPT_CHAIN_ARG, 0, "Attach a chain of programs (e.g., allow_ipv4:10.0.0.1,allow_port:8080)", 1},
     {OPT_ALLOW_LONG, OPT_ALLOW_KEY, OPT_ALLOW_ARG, 0, "Add an Intent permit", 1},
     {OPT_PERMIT_LONG, OPT_PERMIT_KEY, OPT_PERMIT_ARG, 0, "Alias for --allow", 1},
+    {OPT_FORBID_LONG, OPT_FORBID_KEY, OPT_FORBID_ARG, 0, "Add an Intent forbid", 1},
+    {OPT_BLOCK_LONG, OPT_BLOCK_KEY, OPT_BLOCK_ARG, 0, "Alias for --forbid", 1},
     {OPT_DRY_RUN_LONG, OPT_DRY_RUN_KEY, NULL, 0, "Validate Intent without attaching", 1},
     {OPT_EXPLAIN_LONG, OPT_EXPLAIN_KEY, OPT_EXPLAIN_ARG, OPTION_ARG_OPTIONAL, "Print normalized Intent", 1},
     {"", 0, 0, OPTION_DOC, 0, 0},
@@ -191,6 +199,14 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
             argp_error(state, "%s: '%s'", err_msg, arg);
         }
         break;
+    case OPT_FORBID_KEY:
+    case OPT_BLOCK_KEY:
+        g_intent_mode = true;
+        if (intent_add_forbid(&g_intent, arg, &err_msg) != 0)
+        {
+            argp_error(state, "%s: '%s'", err_msg, arg);
+        }
+        break;
     case OPT_DRY_RUN_KEY:
         g_intent_dry_run = true;
         break;
@@ -232,19 +248,19 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
     case ARGP_KEY_END:
         if (g_intent_mode && g_chain_arg)
         {
-            argp_error(state, "--allow/--permit and --chain are mutually exclusive");
+            argp_error(state, "--allow/--permit/--forbid/--block and --chain are mutually exclusive");
         }
         if (g_intent_mode && state->arg_num > 0)
         {
-            argp_error(state, "--allow/--permit and positional PROGRAM arguments are mutually exclusive");
+            argp_error(state, "--allow/--permit/--forbid/--block and positional PROGRAM arguments are mutually exclusive");
         }
         if (g_intent_dry_run && !g_intent_mode)
         {
-            argp_error(state, "--dry-run currently requires --allow or --permit");
+            argp_error(state, "--dry-run currently requires --allow, --permit, --forbid, or --block");
         }
         if (g_intent_explain && !g_intent_mode)
         {
-            argp_error(state, "--explain currently requires --allow or --permit");
+            argp_error(state, "--explain currently requires --allow, --permit, --forbid, or --block");
         }
         if (g_intent_mode)
         {


### PR DESCRIPTION
## Summary

Stacked on #76.

This is PR3 of the v0.6 Intent egress forbid arc.

- Lowers forbid chains before permit chains in the Decision DAG so explicit deny wins.
- Adds a distinct `DECISION_TERMINAL_FORBID` terminal while preserving DROP as the final default.
- Keeps enforcement rejecting forbid terminals with `forbids are not supported yet` until action-bearing rows land in PR4.
- Adds DDAG oracle agreement tests for golden forbid policies, including host-wide permit plus narrow forbid and DNS carveout cases.

## Verification

- RED: `docker run --rm --platform linux/amd64 --privileged -v "$PWD:/workspaces/traffico" -v traffico-ubuntu-xmake-cache:/root/.xmake -w /workspaces/traffico d59513717987 xmake run test test/ddag_unit.bats`
  - Failed as expected before implementation because `DECISION_TERMINAL_FORBID` did not exist.
- GREEN: `docker run --rm --platform linux/amd64 --privileged -v "$PWD:/workspaces/traffico" -v traffico-ubuntu-xmake-cache:/root/.xmake -w /workspaces/traffico d59513717987 xmake run test test/ddag_unit.bats test/intent_forbid.bats`
  - Passed 4 tests.
- Wider gate: `docker run --rm --platform linux/amd64 --privileged -v "$PWD:/workspaces/traffico" -v traffico-ubuntu-xmake-cache:/root/.xmake -w /workspaces/traffico d59513717987 xmake run test test/ddag_unit.bats test/enforcement_unit.bats test/intent_bpf_unit.bats test/intent_forbid.bats test/intent_unit.bats test/cli.flags.bats test/intent.bats`
  - Passed 92 tests.