### PR TITLE
feat(intent): lower action-bearing enforcement rows

### DIFF
--- a/api/dag.h
+++ b/api/dag.h
@@ -8,7 +8,7 @@
 #include "intent.h"
 
 /* Validators recurse through a fixed-size userspace graph bounded here. */
-#define MAX_DECISION_NODES (MAX_INTENT_PERMITS * MAX_INTENT_PREDICATES)
+#define MAX_DECISION_NODES ((MAX_INTENT_PERMITS + MAX_INTENT_FORBIDS) * MAX_INTENT_PREDICATES)
 #define INTENT_SUBSET_CONTEXT_COUNT 32
 
 enum decision_terminal
@@ -16,6 +16,7 @@ enum decision_terminal
     DECISION_TERMINAL_NONE = 0,
     DECISION_TERMINAL_ALLOW = 1,
     DECISION_TERMINAL_DROP = 2,
+    DECISION_TERMINAL_FORBID = 3,
 };
 
 struct decision_edge
@@ -38,7 +39,7 @@ struct decision_dag
     enum intent_direction direction;
     size_t root;
     /*
-     * At current limits this array is about 15 KiB. Keep decision_dag on the
+     * At current limits this array is about 30 KiB. Keep decision_dag on the
      * userspace stack or in static storage, never on a BPF/kernel stack.
      */
     struct decision_node nodes[MAX_DECISION_NODES];
@@ -60,10 +61,33 @@ static inline struct decision_edge decision_edge_node(size_t node)
     return edge;
 }
 
+static inline void intent_emit_decision_chain(struct decision_dag *dag,
+                                              const struct intent_predicate *predicates,
+                                              size_t predicate_count,
+                                              size_t chain_start,
+                                              enum decision_terminal true_terminal,
+                                              struct decision_edge false_edge)
+{
+    for (size_t i = 0; i < predicate_count; i++)
+    {
+        size_t node_index = chain_start + i;
+        struct decision_node *node = &dag->nodes[node_index];
+
+        node->predicate = predicates[i];
+        node->on_false = false_edge;
+        node->on_error = decision_edge_terminal(DECISION_TERMINAL_DROP);
+        if (i + 1 < predicate_count)
+            node->on_true = decision_edge_node(node_index + 1);
+        else
+            node->on_true = decision_edge_terminal(true_terminal);
+    }
+}
+
 static inline int intent_build_dag(const struct intent *intent,
                                    struct decision_dag *dag,
                                    const char **err_msg)
 {
+    size_t forbid_starts[MAX_INTENT_FORBIDS] = {0};
     size_t permit_starts[MAX_INTENT_PERMITS] = {0};
     size_t node_count = 0;
 
@@ -71,10 +95,23 @@ static inline int intent_build_dag(const struct intent *intent,
         return intent_fail(err_msg, "at least one permit is required");
     if (intent->permit_count > MAX_INTENT_PERMITS)
         return intent_fail(err_msg, "too many permits");
+    if (intent->forbid_count > MAX_INTENT_FORBIDS)
+        return intent_fail(err_msg, "too many forbids");
     if (intent->default_action != INTENT_ACTION_DROP)
         return intent_fail(err_msg, "default action must drop");
-    if (intent->forbid_count != 0)
-        return intent_fail(err_msg, "forbids are not supported yet");
+
+    for (size_t i = 0; i < intent->forbid_count; i++)
+    {
+        const struct intent_forbid *forbid = &intent->forbids[i];
+        if (forbid->predicate_count == 0)
+            return intent_fail(err_msg, "forbid has no predicates");
+        if (forbid->predicate_count > MAX_INTENT_PREDICATES)
+            return intent_fail(err_msg, "invalid forbid");
+        if (forbid->predicate_count > MAX_DECISION_NODES - node_count)
+            return intent_fail(err_msg, "Decision DAG exceeds node limit");
+        forbid_starts[i] = node_count;
+        node_count += forbid->predicate_count;
+    }
 
     for (size_t i = 0; i < intent->permit_count; i++)
     {
@@ -95,33 +132,41 @@ static inline int intent_build_dag(const struct intent *intent,
     dag->node_count = node_count;
 
     /*
-     * Each permit lowers to one linear predicate chain.
-     * Every false predicate edge in non-last permits enters the next chain.
-     * Every false predicate edge in the last permit targets terminal DROP.
+     * Each rule lowers to one linear predicate chain.
+     * Forbids are emitted before permits so explicit deny wins.
+     * False edges enter the next chain or terminal DROP.
      * Shared prefixes are intentionally not merged yet.
      */
+    for (size_t i = 0; i < intent->forbid_count; i++)
+    {
+        const struct intent_forbid *forbid = &intent->forbids[i];
+        struct decision_edge false_edge = decision_edge_node(permit_starts[0]);
+
+        if (i + 1 < intent->forbid_count)
+            false_edge = decision_edge_node(forbid_starts[i + 1]);
+
+        intent_emit_decision_chain(dag,
+                                   forbid->predicates,
+                                   forbid->predicate_count,
+                                   forbid_starts[i],
+                                   DECISION_TERMINAL_FORBID,
+                                   false_edge);
+    }
+
     for (size_t i = 0; i < intent->permit_count; i++)
     {
         const struct intent_permit *permit = &intent->permits[i];
-        size_t permit_start = permit_starts[i];
         struct decision_edge false_edge = decision_edge_terminal(DECISION_TERMINAL_DROP);
 
         if (i + 1 < intent->permit_count)
             false_edge = decision_edge_node(permit_starts[i + 1]);
 
-        for (size_t j = 0; j < permit->predicate_count; j++)
-        {
-            size_t node_index = permit_start + j;
-            struct decision_node *node = &dag->nodes[node_index];
-
-            node->predicate = permit->predicates[j];
-            node->on_false = false_edge;
-            node->on_error = decision_edge_terminal(DECISION_TERMINAL_DROP);
-            if (j + 1 < permit->predicate_count)
-                node->on_true = decision_edge_node(node_index + 1);
-            else
-                node->on_true = decision_edge_terminal(DECISION_TERMINAL_ALLOW);
-        }
+        intent_emit_decision_chain(dag,
+                                   permit->predicates,
+                                   permit->predicate_count,
+                                   permit_starts[i],
+                                   DECISION_TERMINAL_ALLOW,
+                                   false_edge);
     }
 
     return 0;
@@ -145,6 +190,7 @@ static inline int intent_validate_edge(const struct decision_dag *dag,
         return 0;
     case DECISION_TERMINAL_ALLOW:
     case DECISION_TERMINAL_DROP:
+    case DECISION_TERMINAL_FORBID:
         if (edge->node != 0)
             return intent_fail(err_msg, "Decision DAG terminal edge target must be empty");
         return 0;
@@ -396,6 +442,9 @@ static inline int intent_validate_supported_edge(const struct decision_dag *dag,
         if (edge->terminal == DECISION_TERMINAL_ALLOW &&
             !intent_subset_context_allows_terminal(context))
             return intent_fail(err_msg, "Decision DAG allow path is outside the first supported subset");
+        if (edge->terminal == DECISION_TERMINAL_FORBID &&
+            !intent_subset_context_allows_terminal(context))
+            return intent_fail(err_msg, "Decision DAG forbid path is outside the first supported subset");
         return 0;
     }
 

--- a/api/enforcement.h
+++ b/api/enforcement.h
@@ -17,9 +17,16 @@ enum intent_enforcement_rule_kind
     INTENT_ENFORCEMENT_RULE_IPV4_L4 = 2,
 };
 
+enum intent_enforcement_action
+{
+    INTENT_ENFORCEMENT_DROP = 0,
+    INTENT_ENFORCEMENT_ALLOW = 1,
+};
+
 struct intent_enforcement_rule
 {
     enum intent_enforcement_rule_kind kind;
+    enum intent_enforcement_action action;
     uint32_t ip_dst;
     enum intent_l4_dst_port_mode l4_dst_port_mode;
     uint16_t l4_dst_port;
@@ -253,7 +260,8 @@ static inline int intent_enforcement_append_rule(struct intent_enforcement_plan 
     for (size_t i = 0; i < plan->rule_count; i++)
     {
         const struct intent_enforcement_rule *existing = &plan->rules[i];
-        if (existing->kind == rule->kind &&
+        if (existing->action == rule->action &&
+            existing->kind == rule->kind &&
             existing->ip_dst == rule->ip_dst &&
             existing->l4_dst_port_mode == rule->l4_dst_port_mode &&
             existing->l4_dst_port == rule->l4_dst_port &&
@@ -274,6 +282,7 @@ static inline int intent_enforcement_append_rule(struct intent_enforcement_plan 
 }
 
 static inline int intent_enforcement_emit_path(const struct intent_enforcement_path *path,
+                                               enum intent_enforcement_action action,
                                                struct intent_enforcement_plan *plan,
                                                const char **err_msg)
 {
@@ -288,6 +297,7 @@ static inline int intent_enforcement_emit_path(const struct intent_enforcement_p
      * The first backend-neutral plan emits ARP rows and IPv4 L4 rows.
      * Everything else stays rejected before a backend sees it.
      */
+    rule.action = action;
     for (size_t i = 0; i < path->predicate_count; i++)
     {
         const struct intent_predicate *predicate = &path->predicates[i];
@@ -439,11 +449,11 @@ static inline int intent_enforcement_walk_edge(const struct decision_dag *dag,
     case DECISION_TERMINAL_NONE:
         return intent_enforcement_walk_node(dag, edge->node, path, plan, err_msg);
     case DECISION_TERMINAL_ALLOW:
-        return intent_enforcement_emit_path(&path, plan, err_msg);
+        return intent_enforcement_emit_path(&path, INTENT_ENFORCEMENT_ALLOW, plan, err_msg);
     case DECISION_TERMINAL_DROP:
         return 0;
     case DECISION_TERMINAL_FORBID:
-        return intent_fail(err_msg, "forbids are not supported yet");
+        return intent_enforcement_emit_path(&path, INTENT_ENFORCEMENT_DROP, plan, err_msg);
     default:
         return intent_fail(err_msg, "enforcement path is outside the first supported subset");
     }

--- a/api/enforcement.h
+++ b/api/enforcement.h
@@ -442,6 +442,8 @@ static inline int intent_enforcement_walk_edge(const struct decision_dag *dag,
         return intent_enforcement_emit_path(&path, plan, err_msg);
     case DECISION_TERMINAL_DROP:
         return 0;
+    case DECISION_TERMINAL_FORBID:
+        return intent_fail(err_msg, "forbids are not supported yet");
     default:
         return intent_fail(err_msg, "enforcement path is outside the first supported subset");
     }

--- a/api/intent_bpf.h
+++ b/api/intent_bpf.h
@@ -105,6 +105,11 @@ static inline int intent_bpf_plan_from_enforcement(const struct intent_enforceme
         const struct intent_enforcement_rule *src = &plan->rules[i];
         struct intent_bpf_rule *dst = &bpf_plan->rules[i];
 
+        if (src->action == INTENT_ENFORCEMENT_DROP)
+        {
+            return intent_fail(err_msg, "forbids are not supported yet");
+        }
+
         /* This is the BPF backend admissibility gate. */
         if (!intent_bpf_rule_supported(src))
         {

--- a/test/ddag_unit.c
+++ b/test/ddag_unit.c
@@ -2,6 +2,7 @@
 #include <string.h>
 
 #include "api/dag.h"
+#include "intent_semantics.h"
 
 #define CHECK(condition)                                                       \
     do                                                                         \
@@ -30,6 +31,46 @@ static void set_eq_predicate(struct intent_predicate *predicate,
     predicate->op = INTENT_OP_EQ;
     predicate->values.count = 1;
     predicate->values.values[0] = value;
+}
+
+static enum intent_action test_decision_for_terminal(enum decision_terminal terminal)
+{
+    if (terminal == DECISION_TERMINAL_ALLOW)
+        return INTENT_ACTION_ALLOW;
+    return INTENT_ACTION_DROP;
+}
+
+static enum intent_action test_decision_dag_eval_edge(const struct decision_dag *dag,
+                                                      const struct decision_edge *edge,
+                                                      const struct intent_test_packet *packet);
+
+static enum intent_action test_decision_dag_eval_node(const struct decision_dag *dag,
+                                                      size_t node_index,
+                                                      const struct intent_test_packet *packet)
+{
+    const struct decision_node *node = &dag->nodes[node_index];
+
+    if (!intent_test_predicate_matches(&node->predicate, packet))
+        return test_decision_dag_eval_edge(dag, &node->on_false, packet);
+    return test_decision_dag_eval_edge(dag, &node->on_true, packet);
+}
+
+static enum intent_action test_decision_dag_eval_edge(const struct decision_dag *dag,
+                                                      const struct decision_edge *edge,
+                                                      const struct intent_test_packet *packet)
+{
+    if (edge->terminal != DECISION_TERMINAL_NONE)
+        return test_decision_for_terminal(edge->terminal);
+    return test_decision_dag_eval_node(dag, edge->node, packet);
+}
+
+static enum intent_action test_decision_dag_decide(const struct decision_dag *dag,
+                                                   struct intent_test_packet packet)
+{
+    if (packet.kind == INTENT_TEST_PACKET_MALFORMED ||
+        packet.kind == INTENT_TEST_PACKET_UNCLASSIFIABLE)
+        return INTENT_ACTION_DROP;
+    return test_decision_dag_eval_node(dag, dag->root, &packet);
 }
 
 static int test_decision_dag_builds_predicate_chain(void)
@@ -126,18 +167,100 @@ static int test_decision_dag_accepts_host_wide_l4_permit_path(void)
     return 0;
 }
 
-static int test_decision_dag_rejects_future_forbids(void)
+static int test_decision_dag_builds_forbids_before_permits(void)
 {
     struct intent intent = {0};
     struct decision_dag dag = {0};
     const char *err = NULL;
 
     intent_init(&intent, INTENT_DIRECTION_EGRESS);
-    CHECK(intent_add_permit(&intent, "arp", &err) == 0);
-    intent.forbid_count = 1;
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "tcp/10.0.0.10:22", &err) == 0);
+    intent_normalize(&intent);
 
-    CHECK(intent_build_dag(&intent, &dag, &err) == -1);
-    CHECK(strcmp(err, "forbids are not supported yet") == 0);
+    CHECK(intent_build_dag(&intent, &dag, &err) == 0);
+    CHECK(dag.node_count == 7);
+
+    CHECK(dag.nodes[0].predicate.field == INTENT_FIELD_ETH_TYPE);
+    CHECK(dag.nodes[0].on_true.terminal == DECISION_TERMINAL_NONE);
+    CHECK(dag.nodes[0].on_false.terminal == DECISION_TERMINAL_NONE);
+    CHECK(dag.nodes[0].on_false.node == 4);
+
+    CHECK(dag.nodes[3].predicate.field == INTENT_FIELD_L4_DST_PORT);
+    CHECK(dag.nodes[3].on_true.terminal == DECISION_TERMINAL_FORBID);
+    CHECK(dag.nodes[3].on_false.terminal == DECISION_TERMINAL_NONE);
+    CHECK(dag.nodes[3].on_false.node == 4);
+
+    CHECK(dag.nodes[6].predicate.field == INTENT_FIELD_IP_PROTO);
+    CHECK(dag.nodes[6].on_true.terminal == DECISION_TERMINAL_ALLOW);
+    CHECK(dag.nodes[6].on_false.terminal == DECISION_TERMINAL_DROP);
+
+    CHECK(intent_validate_dag(&dag, &err) == 0);
+    CHECK(intent_validate_supported_subset(&dag, &err) == 0);
+
+    return 0;
+}
+
+static int test_decision_dag_matches_intent_oracle_for_golden_policy(void)
+{
+    struct intent intent = {0};
+    struct decision_dag dag = {0};
+    const char *err = NULL;
+    struct intent_test_packet packets[] = {
+        intent_test_packet_arp(),
+        intent_test_packet_tcp(0x0a00000a, 22),
+        intent_test_packet_tcp(0x0a00000a, 443),
+        intent_test_packet_udp(0x0a00000a, 443),
+        intent_test_packet_tcp(0x0a000014, 443),
+        intent_test_packet_malformed(),
+        intent_test_packet_unclassifiable(),
+    };
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    CHECK(intent_add_permit(&intent, "arp", &err) == 0);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "tcp/10.0.0.10:22", &err) == 0);
+    intent_normalize(&intent);
+
+    CHECK(intent_build_dag(&intent, &dag, &err) == 0);
+    CHECK(intent_validate_dag(&dag, &err) == 0);
+
+    for (size_t i = 0; i < sizeof(packets) / sizeof(packets[0]); i++)
+    {
+        CHECK(test_decision_dag_decide(&dag, packets[i]) ==
+              intent_test_oracle_decide(&intent, packets[i]));
+    }
+
+    return 0;
+}
+
+static int test_decision_dag_matches_intent_oracle_for_dns_carveout_policy(void)
+{
+    struct intent intent = {0};
+    struct decision_dag dag = {0};
+    const char *err = NULL;
+    struct intent_test_packet packets[] = {
+        intent_test_packet_udp(0x0a000035, 53),
+        intent_test_packet_tcp(0x0a000035, 53),
+        intent_test_packet_tcp(0x0a000035, 443),
+        intent_test_packet_udp(0x0a000035, 123),
+    };
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    CHECK(intent_add_permit(&intent, "arp", &err) == 0);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.53", &err) == 0);
+    CHECK(intent_add_permit(&intent, "udp/10.0.0.53", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "dns/10.0.0.53", &err) == 0);
+    intent_normalize(&intent);
+
+    CHECK(intent_build_dag(&intent, &dag, &err) == 0);
+    CHECK(intent_validate_dag(&dag, &err) == 0);
+
+    for (size_t i = 0; i < sizeof(packets) / sizeof(packets[0]); i++)
+    {
+        CHECK(test_decision_dag_decide(&dag, packets[i]) ==
+              intent_test_oracle_decide(&intent, packets[i]));
+    }
 
     return 0;
 }
@@ -476,7 +599,9 @@ int main(void)
     RUN_TEST(test_decision_dag_builds_predicate_chain);
     RUN_TEST(test_decision_dag_chains_three_permit_false_edges);
     RUN_TEST(test_decision_dag_accepts_host_wide_l4_permit_path);
-    RUN_TEST(test_decision_dag_rejects_future_forbids);
+    RUN_TEST(test_decision_dag_builds_forbids_before_permits);
+    RUN_TEST(test_decision_dag_matches_intent_oracle_for_golden_policy);
+    RUN_TEST(test_decision_dag_matches_intent_oracle_for_dns_carveout_policy);
     RUN_TEST(test_decision_dag_rejects_non_drop_default_action);
     RUN_TEST(test_decision_dag_rejects_invalid_public_counts);
     RUN_TEST(test_decision_dag_validates_max_permit_set);

--- a/test/enforcement_unit.c
+++ b/test/enforcement_unit.c
@@ -3,6 +3,7 @@
 
 #include "api/dag.h"
 #include "api/enforcement.h"
+#include "intent_semantics.h"
 
 #define CHECK(condition)                                                       \
     do                                                                         \
@@ -53,6 +54,55 @@ static void set_in2_predicate(struct intent_predicate *predicate,
     predicate->values.count = 2;
     predicate->values.values[0] = first;
     predicate->values.values[1] = second;
+}
+
+static bool test_enforcement_rule_matches_packet(const struct intent_enforcement_rule *rule,
+                                                 const struct intent_test_packet *packet)
+{
+    if (rule->kind == INTENT_ENFORCEMENT_RULE_ARP)
+        return packet->kind == INTENT_TEST_PACKET_ARP;
+
+    if (rule->kind != INTENT_ENFORCEMENT_RULE_IPV4_L4 ||
+        packet->kind != INTENT_TEST_PACKET_IPV4_L4 ||
+        rule->ip_dst != packet->ip_dst)
+        return false;
+
+    bool proto_matches = false;
+    for (size_t i = 0; i < rule->ip_proto_count; i++)
+        proto_matches = proto_matches || rule->ip_protos[i] == packet->ip_proto;
+    if (!proto_matches)
+        return false;
+
+    if (rule->l4_dst_port_mode == INTENT_L4_DST_PORT_ANY)
+        return true;
+    return rule->l4_dst_port_mode == INTENT_L4_DST_PORT_EXACT &&
+           rule->l4_dst_port == packet->l4_dst_port;
+}
+
+static enum intent_action test_enforcement_decide(const struct intent_enforcement_plan *plan,
+                                                  struct intent_test_packet packet)
+{
+    if (packet.kind == INTENT_TEST_PACKET_MALFORMED ||
+        packet.kind == INTENT_TEST_PACKET_UNCLASSIFIABLE)
+        return INTENT_ACTION_DROP;
+
+    for (size_t i = 0; i < plan->rule_count; i++)
+    {
+        if (!test_enforcement_rule_matches_packet(&plan->rules[i], &packet))
+            continue;
+        if (plan->rules[i].action == INTENT_ENFORCEMENT_DROP)
+            return INTENT_ACTION_DROP;
+    }
+
+    for (size_t i = 0; i < plan->rule_count; i++)
+    {
+        if (!test_enforcement_rule_matches_packet(&plan->rules[i], &packet))
+            continue;
+        if (plan->rules[i].action == INTENT_ENFORCEMENT_ALLOW)
+            return INTENT_ACTION_ALLOW;
+    }
+
+    return INTENT_ACTION_DROP;
 }
 
 static int test_enforcement_extracts_arp_rule(void)
@@ -109,6 +159,86 @@ static int test_enforcement_extracts_host_wide_tcp_any_port_rule(void)
     CHECK(plan.rules[0].l4_dst_port == 0);
     CHECK(plan.rules[0].ip_proto_count == 1);
     CHECK(plan.rules[0].ip_protos[0] == INTENT_IPPROTO_TCP);
+    return 0;
+}
+
+static int test_enforcement_extracts_drop_before_broad_allow(void)
+{
+    struct intent intent = {0};
+    struct intent_enforcement_plan plan = {0};
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "tcp/10.0.0.10:22", &err) == 0);
+
+    CHECK(build_plan(&intent, &plan, &err) == 0);
+    CHECK(plan.rule_count == 2);
+
+    CHECK(plan.rules[0].action == INTENT_ENFORCEMENT_DROP);
+    CHECK(plan.rules[0].l4_dst_port_mode == INTENT_L4_DST_PORT_EXACT);
+    CHECK(plan.rules[0].l4_dst_port == 22);
+
+    CHECK(plan.rules[1].action == INTENT_ENFORCEMENT_ALLOW);
+    CHECK(plan.rules[1].l4_dst_port_mode == INTENT_L4_DST_PORT_ANY);
+    return 0;
+}
+
+static int test_enforcement_matches_intent_oracle_for_golden_policy(void)
+{
+    struct intent intent = {0};
+    struct intent_enforcement_plan plan = {0};
+    const char *err = NULL;
+    struct intent_test_packet packets[] = {
+        intent_test_packet_arp(),
+        intent_test_packet_tcp(0x0a00000a, 22),
+        intent_test_packet_tcp(0x0a00000a, 443),
+        intent_test_packet_udp(0x0a00000a, 443),
+        intent_test_packet_tcp(0x0a000014, 443),
+        intent_test_packet_malformed(),
+        intent_test_packet_unclassifiable(),
+    };
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    CHECK(intent_add_permit(&intent, "arp", &err) == 0);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "tcp/10.0.0.10:22", &err) == 0);
+    intent_normalize(&intent);
+
+    CHECK(build_plan(&intent, &plan, &err) == 0);
+    for (size_t i = 0; i < sizeof(packets) / sizeof(packets[0]); i++)
+    {
+        CHECK(test_enforcement_decide(&plan, packets[i]) ==
+              intent_test_oracle_decide(&intent, packets[i]));
+    }
+    return 0;
+}
+
+static int test_enforcement_matches_intent_oracle_for_dns_carveout_policy(void)
+{
+    struct intent intent = {0};
+    struct intent_enforcement_plan plan = {0};
+    const char *err = NULL;
+    struct intent_test_packet packets[] = {
+        intent_test_packet_udp(0x0a000035, 53),
+        intent_test_packet_tcp(0x0a000035, 53),
+        intent_test_packet_tcp(0x0a000035, 443),
+        intent_test_packet_udp(0x0a000035, 123),
+    };
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    CHECK(intent_add_permit(&intent, "arp", &err) == 0);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.53", &err) == 0);
+    CHECK(intent_add_permit(&intent, "udp/10.0.0.53", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "dns/10.0.0.53", &err) == 0);
+    intent_normalize(&intent);
+
+    CHECK(build_plan(&intent, &plan, &err) == 0);
+    for (size_t i = 0; i < sizeof(packets) / sizeof(packets[0]); i++)
+    {
+        CHECK(test_enforcement_decide(&plan, packets[i]) ==
+              intent_test_oracle_decide(&intent, packets[i]));
+    }
     return 0;
 }
 
@@ -445,6 +575,9 @@ int main(void)
     RUN_TEST(test_enforcement_extracts_arp_rule);
     RUN_TEST(test_enforcement_extracts_tcp_ipv4_l4_rule);
     RUN_TEST(test_enforcement_extracts_host_wide_tcp_any_port_rule);
+    RUN_TEST(test_enforcement_extracts_drop_before_broad_allow);
+    RUN_TEST(test_enforcement_matches_intent_oracle_for_golden_policy);
+    RUN_TEST(test_enforcement_matches_intent_oracle_for_dns_carveout_policy);
     RUN_TEST(test_enforcement_extracts_dns_ipv4_l4_rule);
     RUN_TEST(test_enforcement_extracts_primary_scenario_rows);
     RUN_TEST(test_enforcement_preserves_prior_true_predicates_on_false_edges);

--- a/test/intent_bpf_unit.c
+++ b/test/intent_bpf_unit.c
@@ -80,6 +80,7 @@ static int test_bpf_lowering_accepts_any_destination_port(void)
     plan.direction = INTENT_DIRECTION_EGRESS;
     plan.rule_count = 1;
     plan.rules[0].kind = INTENT_ENFORCEMENT_RULE_IPV4_L4;
+    plan.rules[0].action = INTENT_ENFORCEMENT_ALLOW;
     plan.rules[0].ip_dst = 0x0a00000a;
     plan.rules[0].l4_dst_port_mode = INTENT_L4_DST_PORT_ANY;
     plan.rules[0].ip_proto_count = 1;
@@ -96,6 +97,26 @@ static int test_bpf_lowering_accepts_any_destination_port(void)
     return 0;
 }
 
+static int test_bpf_lowering_rejects_drop_rows_until_runtime_exists(void)
+{
+    struct intent intent = {0};
+    struct decision_dag dag = {0};
+    struct intent_enforcement_plan plan = {0};
+    struct intent_bpf_plan bpf_plan = {0};
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "tcp/10.0.0.10:22", &err) == 0);
+    intent_normalize(&intent);
+
+    CHECK(intent_build_dag(&intent, &dag, &err) == 0);
+    CHECK(intent_enforcement_plan_from_dag(&dag, &plan, &err) == 0);
+    CHECK(intent_bpf_plan_from_enforcement(&plan, &bpf_plan, &err) == -1);
+    CHECK(strcmp(err, "forbids are not supported yet") == 0);
+    return 0;
+}
+
 static int expect_unsupported_rule_rejected(const struct intent_enforcement_rule *rule)
 {
     struct intent_enforcement_plan plan = {0};
@@ -104,6 +125,7 @@ static int expect_unsupported_rule_rejected(const struct intent_enforcement_rule
 
     plan.rule_count = 1;
     plan.rules[0] = *rule;
+    plan.rules[0].action = INTENT_ENFORCEMENT_ALLOW;
 
     CHECK(intent_bpf_plan_from_enforcement(&plan, &bpf_plan, &err) == -1);
     CHECK(err != NULL);
@@ -233,6 +255,7 @@ int main(void)
 {
     RUN_TEST(test_bpf_lowering_preserves_correlated_rows);
     RUN_TEST(test_bpf_lowering_accepts_any_destination_port);
+    RUN_TEST(test_bpf_lowering_rejects_drop_rows_until_runtime_exists);
     RUN_TEST(test_bpf_lowering_rejects_malformed_arp_row);
     RUN_TEST(test_bpf_lowering_rejects_unsupported_proto_value);
     RUN_TEST(test_bpf_lowering_rejects_duplicate_two_entry_proto_set);


### PR DESCRIPTION
## Summary

PR4 in the v0.6 Intent egress quarantine stack.

Stacked on #77.

This change carries explicit enforcement actions through the backend-neutral enforcement plan:

- adds `INTENT_ENFORCEMENT_ALLOW` and `INTENT_ENFORCEMENT_DROP` rows
- lowers matched-forbid DDAG terminals into DROP enforcement rows instead of rejecting them at enforcement extraction
- keeps default/error DROP implicit rather than materializing catch-all DROP rows
- keeps the Linux TC BPF backend rejecting DROP rows with `forbids are not supported yet` until PR5 adds runtime action support

## Verification

RED/GREEN steps run locally in the Docker Linux runner:

- RED: `xmake run test test/enforcement_unit.bats` failed before enforcement rows had an `action` field
- GREEN: `xmake run test test/enforcement_unit.bats` passed after ALLOW/DROP extraction
- RED: `xmake run test test/intent_bpf_unit.bats` failed before the BPF backend rejected DROP rows
- GREEN: `xmake run test test/enforcement_unit.bats test/intent_bpf_unit.bats test/intent_forbid.bats` passed after the BPF boundary check

Full gate:

- `docker run --rm --platform linux/amd64 --privileged -v "$PWD:/workspaces/traffico" -v traffico-ubuntu-xmake-cache:/root/.xmake -w /workspaces/traffico d59513717987 xmake run test`
- Result: `1..185`, all tests passed
