### PR TITLE
feat(intent): enforce forbids in bpf backend

### DIFF
--- a/api/enforcement.h
+++ b/api/enforcement.h
@@ -17,9 +17,16 @@ enum intent_enforcement_rule_kind
     INTENT_ENFORCEMENT_RULE_IPV4_L4 = 2,
 };
 
+enum intent_enforcement_action
+{
+    INTENT_ENFORCEMENT_DROP = 0,
+    INTENT_ENFORCEMENT_ALLOW = 1,
+};
+
 struct intent_enforcement_rule
 {
     enum intent_enforcement_rule_kind kind;
+    enum intent_enforcement_action action;
     uint32_t ip_dst;
     enum intent_l4_dst_port_mode l4_dst_port_mode;
     uint16_t l4_dst_port;
@@ -253,7 +260,8 @@ static inline int intent_enforcement_append_rule(struct intent_enforcement_plan 
     for (size_t i = 0; i < plan->rule_count; i++)
     {
         const struct intent_enforcement_rule *existing = &plan->rules[i];
-        if (existing->kind == rule->kind &&
+        if (existing->action == rule->action &&
+            existing->kind == rule->kind &&
             existing->ip_dst == rule->ip_dst &&
             existing->l4_dst_port_mode == rule->l4_dst_port_mode &&
             existing->l4_dst_port == rule->l4_dst_port &&
@@ -274,6 +282,7 @@ static inline int intent_enforcement_append_rule(struct intent_enforcement_plan 
 }
 
 static inline int intent_enforcement_emit_path(const struct intent_enforcement_path *path,
+                                               enum intent_enforcement_action action,
                                                struct intent_enforcement_plan *plan,
                                                const char **err_msg)
 {
@@ -288,6 +297,7 @@ static inline int intent_enforcement_emit_path(const struct intent_enforcement_p
      * The first backend-neutral plan emits ARP rows and IPv4 L4 rows.
      * Everything else stays rejected before a backend sees it.
      */
+    rule.action = action;
     for (size_t i = 0; i < path->predicate_count; i++)
     {
         const struct intent_predicate *predicate = &path->predicates[i];
@@ -439,11 +449,11 @@ static inline int intent_enforcement_walk_edge(const struct decision_dag *dag,
     case DECISION_TERMINAL_NONE:
         return intent_enforcement_walk_node(dag, edge->node, path, plan, err_msg);
     case DECISION_TERMINAL_ALLOW:
-        return intent_enforcement_emit_path(&path, plan, err_msg);
+        return intent_enforcement_emit_path(&path, INTENT_ENFORCEMENT_ALLOW, plan, err_msg);
     case DECISION_TERMINAL_DROP:
         return 0;
     case DECISION_TERMINAL_FORBID:
-        return intent_fail(err_msg, "forbids are not supported yet");
+        return intent_enforcement_emit_path(&path, INTENT_ENFORCEMENT_DROP, plan, err_msg);
     default:
         return intent_fail(err_msg, "enforcement path is outside the first supported subset");
     }

--- a/api/enforcement.h
+++ b/api/enforcement.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "dag.h"
@@ -383,64 +384,86 @@ static inline int intent_enforcement_emit_path(const struct intent_enforcement_p
 
 static inline int intent_enforcement_walk_edge(const struct decision_dag *dag,
                                                const struct decision_edge *edge,
-                                               struct intent_enforcement_path path,
+                                               const struct intent_enforcement_path *path,
                                                struct intent_enforcement_plan *plan,
                                                const char **err_msg);
 
 static inline int intent_enforcement_walk_node(const struct decision_dag *dag,
                                                size_t node_index,
-                                               struct intent_enforcement_path path,
+                                               const struct intent_enforcement_path *path,
                                                struct intent_enforcement_plan *plan,
                                                const char **err_msg)
 {
     const struct decision_node *node = &dag->nodes[node_index];
     struct intent_predicate narrowed_predicate = {0};
-    struct intent_enforcement_path true_path = path;
-    struct intent_enforcement_path false_path = path;
+    struct intent_enforcement_path *true_path = malloc(sizeof(*true_path));
+    struct intent_enforcement_path *false_path = malloc(sizeof(*false_path));
     int false_status = 0;
     int true_status = 0;
+    int rc = 0;
+
+    if (!true_path || !false_path)
+    {
+        free(true_path);
+        free(false_path);
+        return intent_fail(err_msg, "enforcement path allocation failed");
+    }
+
+    *true_path = *path;
+    *false_path = *path;
 
     /*
      * The true path carries the current predicate.
      * The false path records that the predicate did not match.
      */
-    false_status = intent_enforcement_add_false_predicate(&false_path,
+    false_status = intent_enforcement_add_false_predicate(false_path,
                                                           &node->predicate,
                                                           err_msg);
     if (false_status < 0)
-        return -1;
-
-    if (!intent_enforcement_narrow_predicate(&path, &node->predicate, &narrowed_predicate))
     {
-        if (false_status == 0)
-            return 0;
-        return intent_enforcement_walk_edge(dag, &node->on_false, false_path, plan, err_msg);
+        rc = -1;
+        goto done;
     }
 
-    true_status = intent_enforcement_apply_true_predicate(&true_path,
+    if (!intent_enforcement_narrow_predicate(path, &node->predicate, &narrowed_predicate))
+    {
+        if (false_status == 0)
+            goto done;
+        rc = intent_enforcement_walk_edge(dag, &node->on_false, false_path, plan, err_msg);
+        goto done;
+    }
+
+    true_status = intent_enforcement_apply_true_predicate(true_path,
                                                           &narrowed_predicate,
                                                           err_msg);
     if (true_status < 0)
-        return -1;
+    {
+        rc = -1;
+        goto done;
+    }
     if (true_status == 0)
     {
         if (false_status == 0)
-            return 0;
-        return intent_enforcement_walk_edge(dag, &node->on_false, false_path, plan, err_msg);
+            goto done;
+        rc = intent_enforcement_walk_edge(dag, &node->on_false, false_path, plan, err_msg);
+        goto done;
     }
 
     if (intent_enforcement_walk_edge(dag, &node->on_true, true_path, plan, err_msg) != 0 ||
         (false_status != 0 &&
          intent_enforcement_walk_edge(dag, &node->on_false, false_path, plan, err_msg) != 0) ||
         intent_enforcement_walk_edge(dag, &node->on_error, path, plan, err_msg) != 0)
-        return -1;
+        rc = -1;
 
-    return 0;
+done:
+    free(true_path);
+    free(false_path);
+    return rc;
 }
 
 static inline int intent_enforcement_walk_edge(const struct decision_dag *dag,
                                                const struct decision_edge *edge,
-                                               struct intent_enforcement_path path,
+                                               const struct intent_enforcement_path *path,
                                                struct intent_enforcement_plan *plan,
                                                const char **err_msg)
 {
@@ -449,11 +472,11 @@ static inline int intent_enforcement_walk_edge(const struct decision_dag *dag,
     case DECISION_TERMINAL_NONE:
         return intent_enforcement_walk_node(dag, edge->node, path, plan, err_msg);
     case DECISION_TERMINAL_ALLOW:
-        return intent_enforcement_emit_path(&path, INTENT_ENFORCEMENT_ALLOW, plan, err_msg);
+        return intent_enforcement_emit_path(path, INTENT_ENFORCEMENT_ALLOW, plan, err_msg);
     case DECISION_TERMINAL_DROP:
         return 0;
     case DECISION_TERMINAL_FORBID:
-        return intent_enforcement_emit_path(&path, INTENT_ENFORCEMENT_DROP, plan, err_msg);
+        return intent_enforcement_emit_path(path, INTENT_ENFORCEMENT_DROP, plan, err_msg);
     default:
         return intent_fail(err_msg, "enforcement path is outside the first supported subset");
     }
@@ -470,7 +493,7 @@ static inline int intent_enforcement_plan_from_dag(const struct decision_dag *da
 
     memset(plan, 0, sizeof(*plan));
     plan->direction = dag->direction;
-    return intent_enforcement_walk_node(dag, dag->root, path, plan, err_msg);
+    return intent_enforcement_walk_node(dag, dag->root, &path, plan, err_msg);
 }
 
 #endif

--- a/api/intent_bpf.h
+++ b/api/intent_bpf.h
@@ -105,6 +105,11 @@ static inline int intent_bpf_plan_from_enforcement(const struct intent_enforceme
         const struct intent_enforcement_rule *src = &plan->rules[i];
         struct intent_bpf_rule *dst = &bpf_plan->rules[i];
 
+        if (src->action == INTENT_ENFORCEMENT_DROP)
+        {
+            return intent_fail(err_msg, "forbids are not supported yet");
+        }
+
         /* This is the BPF backend admissibility gate. */
         if (!intent_bpf_rule_supported(src))
         {

--- a/api/intent_bpf.h
+++ b/api/intent_bpf.h
@@ -12,10 +12,15 @@ _Static_assert(MAX_INTENT_ENFORCEMENT_RULES == INTENT_BPF_MAX_RULES,
                "enforcement and BPF rule limits must match");
 _Static_assert(MAX_INTENT_ENFORCEMENT_PROTOS == INTENT_BPF_MAX_PROTOS,
                "enforcement and BPF proto limits must match");
+_Static_assert(INTENT_ENFORCEMENT_DROP == INTENT_BPF_ACTION_DROP,
+               "enforcement and BPF DROP actions must match");
+_Static_assert(INTENT_ENFORCEMENT_ALLOW == INTENT_BPF_ACTION_ALLOW,
+               "enforcement and BPF ALLOW actions must match");
 
 struct intent_bpf_rule
 {
     uint8_t kind;
+    uint8_t action;
     uint8_t ip_proto_count;
     uint8_t ip_protos[INTENT_BPF_MAX_PROTOS];
     uint8_t l4_dst_port_mode;
@@ -48,6 +53,10 @@ static inline bool intent_bpf_should_destroy_hook(bool cleanup_on_exit,
 
 static inline bool intent_bpf_rule_supported(const struct intent_enforcement_rule *rule)
 {
+    if (rule->action != INTENT_ENFORCEMENT_DROP &&
+        rule->action != INTENT_ENFORCEMENT_ALLOW)
+        return false;
+
     if (rule->kind == INTENT_ENFORCEMENT_RULE_ARP)
         return rule->ip_dst == 0 &&
                rule->l4_dst_port_mode == INTENT_L4_DST_PORT_EXACT &&
@@ -105,16 +114,15 @@ static inline int intent_bpf_plan_from_enforcement(const struct intent_enforceme
         const struct intent_enforcement_rule *src = &plan->rules[i];
         struct intent_bpf_rule *dst = &bpf_plan->rules[i];
 
-        if (src->action == INTENT_ENFORCEMENT_DROP)
-        {
-            return intent_fail(err_msg, "forbids are not supported yet");
-        }
-
         /* This is the BPF backend admissibility gate. */
         if (!intent_bpf_rule_supported(src))
         {
             return intent_fail(err_msg, "Intent BPF plan contains unsupported rule");
         }
+
+        dst->action = src->action == INTENT_ENFORCEMENT_DROP
+                          ? INTENT_BPF_ACTION_DROP
+                          : INTENT_BPF_ACTION_ALLOW;
 
         if (src->kind == INTENT_ENFORCEMENT_RULE_ARP)
         {

--- a/api/intent_bpf_loader.h.in
+++ b/api/intent_bpf_loader.h.in
@@ -7,6 +7,16 @@
 #include "intent.skel.h"
 #include "intent_bpf.h"
 
+enum
+{
+    INTENT_BPF_RODATA_RULE_CAPACITY =
+        sizeof(((struct intent_bpf__rodata *)0)->intent_rules) /
+        sizeof(((struct intent_bpf__rodata *)0)->intent_rules[0])
+};
+
+_Static_assert(INTENT_BPF_RODATA_RULE_CAPACITY == INTENT_BPF_MAX_RULES,
+               "Intent BPF rodata rule capacity must match userspace");
+
 static int attach_intent_bpf(struct config *conf,
                              const struct intent_bpf_plan *plan,
                              after_attach_fn_t cb)
@@ -42,6 +52,7 @@ static int attach_intent_bpf(struct config *conf,
     for (uint32_t i = 0; i < plan->rule_count; i++)
     {
         obj->rodata->intent_rules[i].kind = plan->rules[i].kind;
+        obj->rodata->intent_rules[i].action = plan->rules[i].action;
         obj->rodata->intent_rules[i].ip_proto_count = plan->rules[i].ip_proto_count;
         obj->rodata->intent_rules[i].ip_protos[0] = plan->rules[i].ip_protos[0];
         obj->rodata->intent_rules[i].ip_protos[1] = plan->rules[i].ip_protos[1];

--- a/api/intent_bpf_uapi.h
+++ b/api/intent_bpf_uapi.h
@@ -15,4 +15,10 @@ enum intent_bpf_rule_kind
     INTENT_BPF_RULE_IPV4_L4 = 2,
 };
 
+enum intent_bpf_action
+{
+    INTENT_BPF_ACTION_DROP = 0,
+    INTENT_BPF_ACTION_ALLOW = 1,
+};
+
 #endif

--- a/bpf/intent.bpf.c
+++ b/bpf/intent.bpf.c
@@ -6,9 +6,11 @@
 
 char LICENSE[] SEC("license") = "Dual BSD/GPL";
 
+/* Must match api/intent_bpf.h because the skeleton uses the userspace type. */
 struct intent_bpf_rule
 {
     __u8 kind;
+    __u8 action;
     __u8 ip_proto_count;
     __u8 ip_protos[INTENT_BPF_MAX_PROTOS];
     __u8 l4_dst_port_mode;
@@ -30,6 +32,21 @@ static __always_inline int proto_allowed(const volatile struct intent_bpf_rule *
             return 1;
     }
     return 0;
+}
+
+static __always_inline int rule_matches_l4(const volatile struct intent_bpf_rule *rule,
+                                           __u32 dst_ip,
+                                           __u8 proto,
+                                           __u16 dst_port)
+{
+    if (rule->kind != INTENT_BPF_RULE_IPV4_L4)
+        return 0;
+    if (rule->ip_dst != dst_ip || !proto_allowed(rule, proto))
+        return 0;
+    if (rule->l4_dst_port_mode == INTENT_L4_DST_PORT_ANY)
+        return 1;
+    return rule->l4_dst_port_mode == INTENT_L4_DST_PORT_EXACT &&
+           rule->l4_dst_port == dst_port;
 }
 
 SEC("tc")
@@ -64,7 +81,21 @@ int intent(struct __sk_buff *skb)
         {
             if (i >= intent_rule_count)
                 break;
-            if (intent_rules[i].kind == INTENT_BPF_RULE_ARP)
+
+            const volatile struct intent_bpf_rule *rule = &intent_rules[i];
+            if (rule->kind == INTENT_BPF_RULE_ARP &&
+                rule->action == INTENT_BPF_ACTION_DROP)
+                return TC_ACT_SHOT;
+        }
+
+        for (__u32 i = 0; i < INTENT_BPF_MAX_RULES; i++)
+        {
+            if (i >= intent_rule_count)
+                break;
+
+            const volatile struct intent_bpf_rule *rule = &intent_rules[i];
+            if (rule->kind == INTENT_BPF_RULE_ARP &&
+                rule->action == INTENT_BPF_ACTION_ALLOW)
                 return TC_ACT_OK;
         }
         return TC_ACT_SHOT;
@@ -110,21 +141,26 @@ int intent(struct __sk_buff *skb)
     __u16 dst_port = bpf_ntohs(*dst_port_ptr);
     __u32 dst_ip = bpf_ntohl(ip->daddr);
 
-    /* Rules are correlated tuples, not independent allow sets. */
+    /* Matching forbids take precedence over matching permits. */
     for (__u32 i = 0; i < INTENT_BPF_MAX_RULES; i++)
     {
         if (i >= intent_rule_count)
             break;
 
         const volatile struct intent_bpf_rule *rule = &intent_rules[i];
-        if (rule->kind != INTENT_BPF_RULE_IPV4_L4)
-            continue;
-        if (rule->ip_dst != dst_ip || !proto_allowed(rule, ip->protocol))
-            continue;
-        if (rule->l4_dst_port_mode == INTENT_L4_DST_PORT_ANY)
-            return TC_ACT_OK;
-        if (rule->l4_dst_port_mode == INTENT_L4_DST_PORT_EXACT &&
-            rule->l4_dst_port == dst_port)
+        if (rule->action == INTENT_BPF_ACTION_DROP &&
+            rule_matches_l4(rule, dst_ip, ip->protocol, dst_port))
+            return TC_ACT_SHOT;
+    }
+
+    for (__u32 i = 0; i < INTENT_BPF_MAX_RULES; i++)
+    {
+        if (i >= intent_rule_count)
+            break;
+
+        const volatile struct intent_bpf_rule *rule = &intent_rules[i];
+        if (rule->action == INTENT_BPF_ACTION_ALLOW &&
+            rule_matches_l4(rule, dst_ip, ip->protocol, dst_port))
             return TC_ACT_OK;
     }
 

--- a/test/enforcement_unit.c
+++ b/test/enforcement_unit.c
@@ -570,6 +570,34 @@ static int test_enforcement_errors_accept_null_message_sink(void)
     return 0;
 }
 
+static int test_enforcement_handles_max_mixed_action_envelope(void)
+{
+    struct intent intent = {0};
+    struct intent_enforcement_plan plan = {0};
+    const char *err = NULL;
+    char selector[64];
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    for (int i = 1; i <= MAX_INTENT_PERMITS; i++)
+    {
+        snprintf(selector, sizeof(selector), "tcp/10.22.1.1:%d", 10000 + i);
+        CHECK(intent_add_permit(&intent, selector, &err) == 0);
+    }
+    for (int i = 1; i <= MAX_INTENT_FORBIDS; i++)
+    {
+        snprintf(selector, sizeof(selector), "tcp/10.22.1.1:%d", 20000 + i);
+        CHECK(intent_add_forbid(&intent, selector, &err) == 0);
+    }
+
+    CHECK(build_plan(&intent, &plan, &err) == 0);
+    CHECK(plan.rule_count == MAX_INTENT_ENFORCEMENT_RULES);
+    CHECK(plan.rules[0].action == INTENT_ENFORCEMENT_DROP);
+    CHECK(plan.rules[MAX_INTENT_FORBIDS - 1].action == INTENT_ENFORCEMENT_DROP);
+    CHECK(plan.rules[MAX_INTENT_FORBIDS].action == INTENT_ENFORCEMENT_ALLOW);
+    CHECK(plan.rules[MAX_INTENT_ENFORCEMENT_RULES - 1].action == INTENT_ENFORCEMENT_ALLOW);
+    return 0;
+}
+
 int main(void)
 {
     RUN_TEST(test_enforcement_extracts_arp_rule);
@@ -587,6 +615,7 @@ int main(void)
     RUN_TEST(test_enforcement_rejects_mutated_unguarded_port);
     RUN_TEST(test_enforcement_rejects_unsupported_predicate_before_extraction);
     RUN_TEST(test_enforcement_errors_accept_null_message_sink);
+    RUN_TEST(test_enforcement_handles_max_mixed_action_envelope);
     puts("enforcement unit tests: ok");
     return 0;
 }

--- a/test/enforcement_unit.c
+++ b/test/enforcement_unit.c
@@ -3,6 +3,7 @@
 
 #include "api/dag.h"
 #include "api/enforcement.h"
+#include "intent_semantics.h"
 
 #define CHECK(condition)                                                       \
     do                                                                         \
@@ -53,6 +54,55 @@ static void set_in2_predicate(struct intent_predicate *predicate,
     predicate->values.count = 2;
     predicate->values.values[0] = first;
     predicate->values.values[1] = second;
+}
+
+static bool test_enforcement_rule_matches_packet(const struct intent_enforcement_rule *rule,
+                                                 const struct intent_test_packet *packet)
+{
+    if (rule->kind == INTENT_ENFORCEMENT_RULE_ARP)
+        return packet->kind == INTENT_TEST_PACKET_ARP;
+
+    if (rule->kind != INTENT_ENFORCEMENT_RULE_IPV4_L4 ||
+        packet->kind != INTENT_TEST_PACKET_IPV4_L4 ||
+        rule->ip_dst != packet->ip_dst)
+        return false;
+
+    bool proto_matches = false;
+    for (size_t i = 0; i < rule->ip_proto_count; i++)
+        proto_matches = proto_matches || rule->ip_protos[i] == packet->ip_proto;
+    if (!proto_matches)
+        return false;
+
+    if (rule->l4_dst_port_mode == INTENT_L4_DST_PORT_ANY)
+        return true;
+    return rule->l4_dst_port_mode == INTENT_L4_DST_PORT_EXACT &&
+           rule->l4_dst_port == packet->l4_dst_port;
+}
+
+static enum intent_action test_enforcement_decide(const struct intent_enforcement_plan *plan,
+                                                  struct intent_test_packet packet)
+{
+    if (packet.kind == INTENT_TEST_PACKET_MALFORMED ||
+        packet.kind == INTENT_TEST_PACKET_UNCLASSIFIABLE)
+        return INTENT_ACTION_DROP;
+
+    for (size_t i = 0; i < plan->rule_count; i++)
+    {
+        if (!test_enforcement_rule_matches_packet(&plan->rules[i], &packet))
+            continue;
+        if (plan->rules[i].action == INTENT_ENFORCEMENT_DROP)
+            return INTENT_ACTION_DROP;
+    }
+
+    for (size_t i = 0; i < plan->rule_count; i++)
+    {
+        if (!test_enforcement_rule_matches_packet(&plan->rules[i], &packet))
+            continue;
+        if (plan->rules[i].action == INTENT_ENFORCEMENT_ALLOW)
+            return INTENT_ACTION_ALLOW;
+    }
+
+    return INTENT_ACTION_DROP;
 }
 
 static int test_enforcement_extracts_arp_rule(void)
@@ -109,6 +159,86 @@ static int test_enforcement_extracts_host_wide_tcp_any_port_rule(void)
     CHECK(plan.rules[0].l4_dst_port == 0);
     CHECK(plan.rules[0].ip_proto_count == 1);
     CHECK(plan.rules[0].ip_protos[0] == INTENT_IPPROTO_TCP);
+    return 0;
+}
+
+static int test_enforcement_extracts_drop_before_broad_allow(void)
+{
+    struct intent intent = {0};
+    struct intent_enforcement_plan plan = {0};
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "tcp/10.0.0.10:22", &err) == 0);
+
+    CHECK(build_plan(&intent, &plan, &err) == 0);
+    CHECK(plan.rule_count == 2);
+
+    CHECK(plan.rules[0].action == INTENT_ENFORCEMENT_DROP);
+    CHECK(plan.rules[0].l4_dst_port_mode == INTENT_L4_DST_PORT_EXACT);
+    CHECK(plan.rules[0].l4_dst_port == 22);
+
+    CHECK(plan.rules[1].action == INTENT_ENFORCEMENT_ALLOW);
+    CHECK(plan.rules[1].l4_dst_port_mode == INTENT_L4_DST_PORT_ANY);
+    return 0;
+}
+
+static int test_enforcement_matches_intent_oracle_for_golden_policy(void)
+{
+    struct intent intent = {0};
+    struct intent_enforcement_plan plan = {0};
+    const char *err = NULL;
+    struct intent_test_packet packets[] = {
+        intent_test_packet_arp(),
+        intent_test_packet_tcp(0x0a00000a, 22),
+        intent_test_packet_tcp(0x0a00000a, 443),
+        intent_test_packet_udp(0x0a00000a, 443),
+        intent_test_packet_tcp(0x0a000014, 443),
+        intent_test_packet_malformed(),
+        intent_test_packet_unclassifiable(),
+    };
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    CHECK(intent_add_permit(&intent, "arp", &err) == 0);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "tcp/10.0.0.10:22", &err) == 0);
+    intent_normalize(&intent);
+
+    CHECK(build_plan(&intent, &plan, &err) == 0);
+    for (size_t i = 0; i < sizeof(packets) / sizeof(packets[0]); i++)
+    {
+        CHECK(test_enforcement_decide(&plan, packets[i]) ==
+              intent_test_oracle_decide(&intent, packets[i]));
+    }
+    return 0;
+}
+
+static int test_enforcement_matches_intent_oracle_for_dns_carveout_policy(void)
+{
+    struct intent intent = {0};
+    struct intent_enforcement_plan plan = {0};
+    const char *err = NULL;
+    struct intent_test_packet packets[] = {
+        intent_test_packet_udp(0x0a000035, 53),
+        intent_test_packet_tcp(0x0a000035, 53),
+        intent_test_packet_tcp(0x0a000035, 443),
+        intent_test_packet_udp(0x0a000035, 123),
+    };
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    CHECK(intent_add_permit(&intent, "arp", &err) == 0);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.53", &err) == 0);
+    CHECK(intent_add_permit(&intent, "udp/10.0.0.53", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "dns/10.0.0.53", &err) == 0);
+    intent_normalize(&intent);
+
+    CHECK(build_plan(&intent, &plan, &err) == 0);
+    for (size_t i = 0; i < sizeof(packets) / sizeof(packets[0]); i++)
+    {
+        CHECK(test_enforcement_decide(&plan, packets[i]) ==
+              intent_test_oracle_decide(&intent, packets[i]));
+    }
     return 0;
 }
 
@@ -445,6 +575,9 @@ int main(void)
     RUN_TEST(test_enforcement_extracts_arp_rule);
     RUN_TEST(test_enforcement_extracts_tcp_ipv4_l4_rule);
     RUN_TEST(test_enforcement_extracts_host_wide_tcp_any_port_rule);
+    RUN_TEST(test_enforcement_extracts_drop_before_broad_allow);
+    RUN_TEST(test_enforcement_matches_intent_oracle_for_golden_policy);
+    RUN_TEST(test_enforcement_matches_intent_oracle_for_dns_carveout_policy);
     RUN_TEST(test_enforcement_extracts_dns_ipv4_l4_rule);
     RUN_TEST(test_enforcement_extracts_primary_scenario_rows);
     RUN_TEST(test_enforcement_preserves_prior_true_predicates_on_false_edges);

--- a/test/intent_bpf_unit.c
+++ b/test/intent_bpf_unit.c
@@ -4,6 +4,7 @@
 #include "api/dag.h"
 #include "api/enforcement.h"
 #include "api/intent_bpf.h"
+#include "intent_semantics.h"
 
 #define CHECK(condition)                                                       \
     do                                                                         \
@@ -38,6 +39,55 @@ static int build_bpf_plan(struct intent_bpf_plan *bpf_plan, const char **err)
     CHECK(intent_build_dag(&intent, &dag, err) == 0);
     CHECK(intent_enforcement_plan_from_dag(&dag, &plan, err) == 0);
     return intent_bpf_plan_from_enforcement(&plan, bpf_plan, err);
+}
+
+static bool test_bpf_rule_matches_packet(const struct intent_bpf_rule *rule,
+                                         const struct intent_test_packet *packet)
+{
+    if (rule->kind == INTENT_BPF_RULE_ARP)
+        return packet->kind == INTENT_TEST_PACKET_ARP;
+
+    if (rule->kind != INTENT_BPF_RULE_IPV4_L4 ||
+        packet->kind != INTENT_TEST_PACKET_IPV4_L4 ||
+        rule->ip_dst != packet->ip_dst)
+        return false;
+
+    bool proto_matches = false;
+    for (size_t i = 0; i < rule->ip_proto_count; i++)
+        proto_matches = proto_matches || rule->ip_protos[i] == packet->ip_proto;
+    if (!proto_matches)
+        return false;
+
+    if (rule->l4_dst_port_mode == INTENT_L4_DST_PORT_ANY)
+        return true;
+    return rule->l4_dst_port_mode == INTENT_L4_DST_PORT_EXACT &&
+           rule->l4_dst_port == packet->l4_dst_port;
+}
+
+static enum intent_action test_bpf_decide(const struct intent_bpf_plan *plan,
+                                          struct intent_test_packet packet)
+{
+    if (packet.kind == INTENT_TEST_PACKET_MALFORMED ||
+        packet.kind == INTENT_TEST_PACKET_UNCLASSIFIABLE)
+        return INTENT_ACTION_DROP;
+
+    for (size_t i = 0; i < plan->rule_count; i++)
+    {
+        if (!test_bpf_rule_matches_packet(&plan->rules[i], &packet))
+            continue;
+        if (plan->rules[i].action == INTENT_BPF_ACTION_DROP)
+            return INTENT_ACTION_DROP;
+    }
+
+    for (size_t i = 0; i < plan->rule_count; i++)
+    {
+        if (!test_bpf_rule_matches_packet(&plan->rules[i], &packet))
+            continue;
+        if (plan->rules[i].action == INTENT_BPF_ACTION_ALLOW)
+            return INTENT_ACTION_ALLOW;
+    }
+
+    return INTENT_ACTION_DROP;
 }
 
 static int test_bpf_lowering_preserves_correlated_rows(void)
@@ -97,7 +147,7 @@ static int test_bpf_lowering_accepts_any_destination_port(void)
     return 0;
 }
 
-static int test_bpf_lowering_rejects_drop_rows_until_runtime_exists(void)
+static int test_bpf_lowering_preserves_drop_before_allow(void)
 {
     struct intent intent = {0};
     struct decision_dag dag = {0};
@@ -112,8 +162,91 @@ static int test_bpf_lowering_rejects_drop_rows_until_runtime_exists(void)
 
     CHECK(intent_build_dag(&intent, &dag, &err) == 0);
     CHECK(intent_enforcement_plan_from_dag(&dag, &plan, &err) == 0);
+    CHECK(intent_bpf_plan_from_enforcement(&plan, &bpf_plan, &err) == 0);
+
+    CHECK(bpf_plan.rule_count == 2);
+    CHECK(bpf_plan.rules[0].action == INTENT_BPF_ACTION_DROP);
+    CHECK(bpf_plan.rules[1].action == INTENT_BPF_ACTION_ALLOW);
+    return 0;
+}
+
+static int test_bpf_rows_match_intent_oracle_for_golden_policy(void)
+{
+    struct intent intent = {0};
+    struct decision_dag dag = {0};
+    struct intent_enforcement_plan plan = {0};
+    struct intent_bpf_plan bpf_plan = {0};
+    const char *err = NULL;
+    struct intent_test_packet packets[] = {
+        intent_test_packet_arp(),
+        intent_test_packet_tcp(0x0a00000a, 22),
+        intent_test_packet_tcp(0x0a00000a, 443),
+        intent_test_packet_udp(0x0a00000a, 443),
+        intent_test_packet_tcp(0x0a000014, 443),
+        intent_test_packet_malformed(),
+        intent_test_packet_unclassifiable(),
+    };
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    CHECK(intent_add_permit(&intent, "arp", &err) == 0);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "tcp/10.0.0.10:22", &err) == 0);
+    intent_normalize(&intent);
+
+    CHECK(intent_build_dag(&intent, &dag, &err) == 0);
+    CHECK(intent_enforcement_plan_from_dag(&dag, &plan, &err) == 0);
+    CHECK(intent_bpf_plan_from_enforcement(&plan, &bpf_plan, &err) == 0);
+    for (size_t i = 0; i < sizeof(packets) / sizeof(packets[0]); i++)
+    {
+        CHECK(test_bpf_decide(&bpf_plan, packets[i]) ==
+              intent_test_oracle_decide(&intent, packets[i]));
+    }
+    return 0;
+}
+
+static int test_bpf_rows_match_intent_oracle_for_dns_carveout_policy(void)
+{
+    struct intent intent = {0};
+    struct decision_dag dag = {0};
+    struct intent_enforcement_plan plan = {0};
+    struct intent_bpf_plan bpf_plan = {0};
+    const char *err = NULL;
+    struct intent_test_packet packets[] = {
+        intent_test_packet_udp(0x0a000035, 53),
+        intent_test_packet_tcp(0x0a000035, 53),
+        intent_test_packet_tcp(0x0a000035, 443),
+        intent_test_packet_udp(0x0a000035, 123),
+    };
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    CHECK(intent_add_permit(&intent, "arp", &err) == 0);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.53", &err) == 0);
+    CHECK(intent_add_permit(&intent, "udp/10.0.0.53", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "dns/10.0.0.53", &err) == 0);
+    intent_normalize(&intent);
+
+    CHECK(intent_build_dag(&intent, &dag, &err) == 0);
+    CHECK(intent_enforcement_plan_from_dag(&dag, &plan, &err) == 0);
+    CHECK(intent_bpf_plan_from_enforcement(&plan, &bpf_plan, &err) == 0);
+    for (size_t i = 0; i < sizeof(packets) / sizeof(packets[0]); i++)
+    {
+        CHECK(test_bpf_decide(&bpf_plan, packets[i]) ==
+              intent_test_oracle_decide(&intent, packets[i]));
+    }
+    return 0;
+}
+
+static int test_bpf_lowering_rejects_more_than_max_rules_before_reading_rows(void)
+{
+    struct intent_enforcement_plan plan = {0};
+    struct intent_bpf_plan bpf_plan = {0};
+    const char *err = NULL;
+
+    plan.direction = INTENT_DIRECTION_EGRESS;
+    plan.rule_count = INTENT_BPF_MAX_RULES + 1;
+
     CHECK(intent_bpf_plan_from_enforcement(&plan, &bpf_plan, &err) == -1);
-    CHECK(strcmp(err, "forbids are not supported yet") == 0);
+    CHECK(strcmp(err, "Intent BPF plan exceeds rule limit") == 0);
     return 0;
 }
 
@@ -255,7 +388,10 @@ int main(void)
 {
     RUN_TEST(test_bpf_lowering_preserves_correlated_rows);
     RUN_TEST(test_bpf_lowering_accepts_any_destination_port);
-    RUN_TEST(test_bpf_lowering_rejects_drop_rows_until_runtime_exists);
+    RUN_TEST(test_bpf_lowering_preserves_drop_before_allow);
+    RUN_TEST(test_bpf_rows_match_intent_oracle_for_golden_policy);
+    RUN_TEST(test_bpf_rows_match_intent_oracle_for_dns_carveout_policy);
+    RUN_TEST(test_bpf_lowering_rejects_more_than_max_rules_before_reading_rows);
     RUN_TEST(test_bpf_lowering_rejects_malformed_arp_row);
     RUN_TEST(test_bpf_lowering_rejects_unsupported_proto_value);
     RUN_TEST(test_bpf_lowering_rejects_duplicate_two_entry_proto_set);

--- a/test/intent_bpf_unit.c
+++ b/test/intent_bpf_unit.c
@@ -80,6 +80,7 @@ static int test_bpf_lowering_accepts_any_destination_port(void)
     plan.direction = INTENT_DIRECTION_EGRESS;
     plan.rule_count = 1;
     plan.rules[0].kind = INTENT_ENFORCEMENT_RULE_IPV4_L4;
+    plan.rules[0].action = INTENT_ENFORCEMENT_ALLOW;
     plan.rules[0].ip_dst = 0x0a00000a;
     plan.rules[0].l4_dst_port_mode = INTENT_L4_DST_PORT_ANY;
     plan.rules[0].ip_proto_count = 1;
@@ -96,6 +97,26 @@ static int test_bpf_lowering_accepts_any_destination_port(void)
     return 0;
 }
 
+static int test_bpf_lowering_rejects_drop_rows_until_runtime_exists(void)
+{
+    struct intent intent = {0};
+    struct decision_dag dag = {0};
+    struct intent_enforcement_plan plan = {0};
+    struct intent_bpf_plan bpf_plan = {0};
+    const char *err = NULL;
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "tcp/10.0.0.10:22", &err) == 0);
+    intent_normalize(&intent);
+
+    CHECK(intent_build_dag(&intent, &dag, &err) == 0);
+    CHECK(intent_enforcement_plan_from_dag(&dag, &plan, &err) == 0);
+    CHECK(intent_bpf_plan_from_enforcement(&plan, &bpf_plan, &err) == -1);
+    CHECK(strcmp(err, "forbids are not supported yet") == 0);
+    return 0;
+}
+
 static int expect_unsupported_rule_rejected(const struct intent_enforcement_rule *rule)
 {
     struct intent_enforcement_plan plan = {0};
@@ -104,6 +125,7 @@ static int expect_unsupported_rule_rejected(const struct intent_enforcement_rule
 
     plan.rule_count = 1;
     plan.rules[0] = *rule;
+    plan.rules[0].action = INTENT_ENFORCEMENT_ALLOW;
 
     CHECK(intent_bpf_plan_from_enforcement(&plan, &bpf_plan, &err) == -1);
     CHECK(err != NULL);
@@ -233,6 +255,7 @@ int main(void)
 {
     RUN_TEST(test_bpf_lowering_preserves_correlated_rows);
     RUN_TEST(test_bpf_lowering_accepts_any_destination_port);
+    RUN_TEST(test_bpf_lowering_rejects_drop_rows_until_runtime_exists);
     RUN_TEST(test_bpf_lowering_rejects_malformed_arp_row);
     RUN_TEST(test_bpf_lowering_rejects_unsupported_proto_value);
     RUN_TEST(test_bpf_lowering_rejects_duplicate_two_entry_proto_set);

--- a/test/intent_forbid.bats
+++ b/test/intent_forbid.bats
@@ -4,13 +4,21 @@ load helpers
 export BATS_TEST_NAME_PREFIX=$(setsuite)
 bats_require_minimum_version 1.7.0
 
-@test "--forbid selects Intent mode and is parsed before backend support" {
+output_contains() {
+    case "$output" in
+        *"$1"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+@test "--forbid selects Intent mode and is BPF admissible" {
     run traffico -i lo --at egress \
         --allow tcp/10.0.0.10 \
         --forbid tcp/10.0.0.10:22 \
         --dry-run
-    [ $status -eq 1 ]
-    [ "${lines[0]}" == "traffico: intent dry-run: forbids are not supported yet" ]
+    [ $status -eq 0 ]
+    output_contains "intent dry-run: compiler ok"
+    output_contains "intent backend: bpf admissible"
 }
 
 @test "--block is an alias for --forbid" {
@@ -18,8 +26,9 @@ bats_require_minimum_version 1.7.0
         --allow tcp/10.0.0.10 \
         --block tcp/10.0.0.10:22 \
         --dry-run
-    [ $status -eq 1 ]
-    [ "${lines[0]}" == "traffico: intent dry-run: forbids are not supported yet" ]
+    [ $status -eq 0 ]
+    output_contains "intent dry-run: compiler ok"
+    output_contains "intent backend: bpf admissible"
 }
 
 @test "--dry-run --explain prints permits and forbids" {
@@ -27,9 +36,9 @@ bats_require_minimum_version 1.7.0
         --allow tcp/10.0.0.10 \
         --forbid tcp/10.0.0.10:22 \
         --dry-run --explain
-    [ $status -eq 1 ]
-    [[ "$output" == *"permitted traffic:"* ]]
-    [[ "$output" == *"  1. TCP to 10.0.0.10 any destination port"* ]]
-    [[ "$output" == *"forbidden traffic:"* ]]
-    [[ "$output" == *"  1. TCP to 10.0.0.10 destination port 22"* ]]
+    [ $status -eq 0 ]
+    output_contains "permitted traffic:"
+    output_contains "  1. TCP to 10.0.0.10 any destination port"
+    output_contains "forbidden traffic:"
+    output_contains "  1. TCP to 10.0.0.10 destination port 22"
 }

--- a/test/intent_forbid_scapy.bats
+++ b/test/intent_forbid_scapy.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+
+load helpers
+export BATS_TEST_NAME_PREFIX=$(setsuite)
+bats_require_minimum_version 1.7.0
+
+setup_file() {
+    if ! command -v python3 &>/dev/null; then
+        skip "python3 not found: scapy tests require python3"
+    fi
+    if ! python3 -c "import scapy" &>/dev/null; then
+        skip "scapy not installed: install python-scapy (Arch) or python3-scapy (Ubuntu)"
+    fi
+}
+
+setup() {
+    load net
+    NETNS="ns$((RANDOM % 10))"
+    new_netns "${NETNS}"
+    setup_net "${NETNS}"
+    arp_prewarm "${NETNS}"
+}
+
+teardown() {
+    killall traffico &>/dev/null || true
+    [ -n "${SNIFFER_PID:-}" ] && kill "$SNIFFER_PID" &>/dev/null || true
+    del_netdev
+    del_netns "${NETNS}"
+}
+
+intent_tc_state_exists() {
+    local qdisc
+    local filter
+
+    qdisc="$(ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact)"
+    filter="$(ip netns exec "${NETNS}" tc filter show dev "${PEER}" egress)"
+
+    [[ "${qdisc}" == *"clsact"* && "${filter}" != "" ]]
+}
+
+wait_for_intent_tc_state() {
+    local i
+
+    for i in {1..50}; do
+        if intent_tc_state_exists; then
+            return 0
+        fi
+        sleep 0.1
+    done
+
+    return 1
+}
+
+@test "Intent forbid blocks a port inside a host-wide TCP permit" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress \
+        --allow arp \
+        --allow "tcp/${VETH_ADDR}" \
+        --forbid "tcp/${VETH_ADDR}:22" >/dev/null 3>&- &
+    wait_for_intent_tc_state
+
+    assert_packet_seen "${NETNS}" 22001 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 443
+    assert_packet_seen "${NETNS}" 22002 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 8443
+    assert_packet_blocked "${NETNS}" 22003 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 22
+    assert_packet_blocked "${NETNS}" 22004 \
+        --type udp --dst-ip "${VETH_ADDR}" --dst-port 22
+}
+
+@test "Intent mixed allow forbid stays fail closed for VLAN IPv4 packets" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress \
+        --allow arp \
+        --allow "tcp/${VETH_ADDR}" \
+        --forbid "tcp/${VETH_ADDR}:22" >/dev/null 3>&- &
+    wait_for_intent_tc_state
+
+    assert_packet_blocked "${NETNS}" 22005 \
+        --type vlan-inner-ipv4 --dst-ip "${VETH_ADDR}" --dst-port 443
+}
+
+@test "Intent block alias has the same live semantics as forbid" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress \
+        --allow arp \
+        --allow "udp/${VETH_ADDR}" \
+        --block "udp/${VETH_ADDR}:123" >/dev/null 3>&- &
+    wait_for_intent_tc_state
+
+    assert_packet_seen "${NETNS}" 22101 \
+        --type udp --dst-ip "${VETH_ADDR}" --dst-port 9999
+    assert_packet_blocked "${NETNS}" 22102 \
+        --type udp --dst-ip "${VETH_ADDR}" --dst-port 123
+}
+
+@test "Intent forbid beats an exact allow" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress \
+        --allow arp \
+        --allow "tcp/${VETH_ADDR}:443" \
+        --forbid "tcp/${VETH_ADDR}:443" >/dev/null 3>&- &
+    wait_for_intent_tc_state
+
+    assert_packet_blocked "${NETNS}" 22201 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 443
+}
+
+@test "Intent forbid ARP beats allow ARP" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress \
+        --allow arp \
+        --forbid arp >/dev/null 3>&- &
+    wait_for_intent_tc_state
+
+    assert_packet_blocked "${NETNS}" 22301 \
+        --type arp-request --src-ip "${PEER_ADDR}" --dst-ip "${VETH_ADDR}"
+}
+
+@test "Intent forbid DNS beats allow DNS" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress \
+        --allow arp \
+        --allow "dns/${VETH_ADDR}" \
+        --forbid "dns/${VETH_ADDR}" >/dev/null 3>&- &
+    wait_for_intent_tc_state
+
+    assert_packet_blocked "${NETNS}" 22401 \
+        --type udp --dst-ip "${VETH_ADDR}" --dst-port 53
+    assert_packet_blocked "${NETNS}" 22402 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 53
+}
+
+@test "Intent DNS forbid carves out host-wide TCP and UDP permits" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress \
+        --allow arp \
+        --allow "tcp/${VETH_ADDR}" \
+        --allow "udp/${VETH_ADDR}" \
+        --forbid "dns/${VETH_ADDR}" >/dev/null 3>&- &
+    wait_for_intent_tc_state
+
+    assert_packet_blocked "${NETNS}" 22501 \
+        --type udp --dst-ip "${VETH_ADDR}" --dst-port 53
+    assert_packet_blocked "${NETNS}" 22502 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 53
+    assert_packet_seen "${NETNS}" 22503 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 443
+    assert_packet_seen "${NETNS}" 22504 \
+        --type udp --dst-ip "${VETH_ADDR}" --dst-port 123
+}

--- a/test/intent_verifier.bats
+++ b/test/intent_verifier.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+
+load helpers
+export BATS_TEST_NAME_PREFIX=$(setsuite)
+bats_require_minimum_version 1.7.0
+
+setup_file() {
+    if ! command -v python3 &>/dev/null; then
+        skip "python3 not found: scapy tests require python3"
+    fi
+    if ! python3 -c "import scapy" &>/dev/null; then
+        skip "scapy not installed: install python-scapy (Arch) or python3-scapy (Ubuntu)"
+    fi
+}
+
+setup() {
+    load net
+    NETNS="ns$((RANDOM % 10))"
+    new_netns "${NETNS}"
+    setup_net "${NETNS}"
+    arp_prewarm "${NETNS}"
+}
+
+teardown() {
+    killall traffico &>/dev/null || true
+    del_netdev
+    del_netns "${NETNS}"
+}
+
+intent_tc_state_exists() {
+    local qdisc
+    local filter
+
+    qdisc="$(ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact)"
+    filter="$(ip netns exec "${NETNS}" tc filter show dev "${PEER}" egress)"
+
+    [[ "${qdisc}" == *"clsact"* && "${filter}" != "" ]]
+}
+
+wait_for_intent_tc_state() {
+    local i
+
+    for i in {1..50}; do
+        if intent_tc_state_exists; then
+            return 0
+        fi
+        sleep 0.1
+    done
+
+    return 1
+}
+
+@test "Intent BPF verifier accepts the maximum v0.6 rule envelope" {
+    local args=(-i "${PEER}" --at egress)
+    local i
+
+    # Keep all 64 action rows while permitting ARP for L3 Scapy sends.
+    args+=(--allow arp)
+    for i in {1..31}; do
+        args+=(--allow "tcp/${VETH_ADDR}:$((10000 + i))")
+    done
+    for i in {1..32}; do
+        args+=(--forbid "tcp/${VETH_ADDR}:$((20000 + i))")
+    done
+
+    ip netns exec "${NETNS}" traffico "${args[@]}" >/dev/null 3>&- &
+    wait_for_intent_tc_state
+    arp_prewarm "${NETNS}"
+
+    assert_packet_blocked "${NETNS}" 23001 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 20001
+    assert_packet_blocked "${NETNS}" 23002 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 20032
+    assert_packet_seen "${NETNS}" 23003 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 10001
+    assert_packet_seen "${NETNS}" 23004 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 10031
+    assert_packet_blocked "${NETNS}" 23005 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 443
+}
+
+@test "Intent rejects the 33rd forbid before attach and leaves TC untouched" {
+    local args=(-i "${PEER}" --at egress --dry-run)
+    local i
+
+    for i in {1..32}; do
+        args+=(--allow "tcp/10.0.0.${i}")
+    done
+    for i in {1..33}; do
+        args+=(--forbid "tcp/10.0.1.${i}:22")
+    done
+
+    run ip netns exec "${NETNS}" traffico "${args[@]}"
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: too many forbids: 'tcp/10.0.1.33:22'" ]
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$output" = "" ]
+}


### PR DESCRIPTION
## Summary

PR5 of the v0.6 Intent stack.
This turns action-bearing enforcement rows into live TC BPF behavior.

- carries DROP/ALLOW actions through the Intent BPF plan, generated skeleton rodata, and loader copy path
- enforces matching DROP rows before matching ALLOW rows in the TC BPF program
- keeps the backend fail-closed for unmatched, malformed, unclassifiable, VLAN-wrapped, and unsupported packets
- moves mixed-action enforcement path state off the recursive stack so the 64-row envelope can compile reliably
- adds live Scapy coverage for forbid precedence, `--block`, ARP, DNS carve-outs, VLAN fail-closed behavior, and the max verifier envelope

Stacked on #78 (`leox/v0.6-intent-action-enforcement`).

## TDD / Verification

RED/GREEN checkpoints run in the privileged Ubuntu Docker runner:

- `xmake run test test/intent_bpf_unit.bats`
  - initially failed because BPF rows had no action field/action constants
- `xmake run test test/intent_forbid_scapy.bats`
  - initially failed until the BPF runtime applied forbid semantics
- `xmake run test test/enforcement_unit.bats`
  - initially exposed the mixed 64-row enforcement extraction crash
- `xmake run test test/intent_verifier.bats`
  - verifies 32 permits + 32 forbids live-attach, and rejects the 65th row before attach

Final full local gate:

```sh
xmake run test
```

Result in the privileged Ubuntu Docker runner:

```text
1..194
ok 194 scapy_helper: Scapy sniffer reports readiness before timeout
```

## Notes

The BPF-side `struct intent_bpf_rule` must stay layout-compatible with `api/intent_bpf.h`.
The generated skeleton exposes the userspace type for rodata writes, and the live tests caught a field-order mismatch while developing this PR.
