### PR TITLE
docs(intent): define v0.6 egress quarantine contract

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -12,6 +12,10 @@ README
     It can be used via a CLI tool (traffico) or as a CNI plugin (traffico-cni).
     For a list of the available programs and what they do see the BUILT-IN PROGRAMS section.
 
+    Intent mode adds network intent guardrails for agent workloads. It can
+    express intent-based egress quarantine policies such as "allow ARP, allow
+    DNS to this resolver, allow TCP to this service, but forbid SSH to it".
+
     The BUILT-IN PROGRAMS are very opinionated and made for the needs of the authors but the framework
     is flexible enough to be used for other purposes. You can add programs to the bpf/ directory
     to extend it to other use cases.
@@ -80,50 +84,85 @@ USAGE
         L2 -> L3 -> L4.
 
         Intent mode
-            Use Intent mode when the policy is an additive allowlist such as
-            "ARP OR DNS to this resolver OR HTTPS to this service". Intent
-            mode is selected by repeating --allow or --permit. --permit is an
-            alias for --allow.
+            Use Intent mode for network intent guardrails and intent-based
+            egress quarantine. It is selected by repeating --allow / --permit
+            and optionally --forbid / --block. --permit is an alias for
+            --allow. --block is an alias for --forbid.
 
-            Supported selectors:
+            Intent mode uses deny-overrides semantics:
+                malformed or unclassifiable packet -> DROP
+                matching forbid                    -> DROP
+                matching permit                    -> ALLOW
+                no matching permit                 -> DROP
+
+            Supported permit selectors:
+                arp
+                dns/IPv4
+                tcp/IPv4
+                udp/IPv4
+                tcp/IPv4:PORT
+                udp/IPv4:PORT
+
+            Supported forbid selectors:
                 arp
                 dns/IPv4
                 tcp/IPv4:PORT
                 udp/IPv4:PORT
 
-            dns/IPv4 permits DNS to that IPv4 resolver over TCP or UDP
-            destination port 53. TCP and UDP selectors match packets whose
-            destination endpoint is IPv4:PORT. Any traffic not matching a
-            permit is dropped, and packets that cannot be safely classified
+            dns/IPv4 matches DNS to that IPv4 resolver over TCP or UDP
+            destination port 53. tcp/IPv4 and udp/IPv4 permit any destination
+            port on that IPv4 host. The tcp/IPv4:PORT and udp/IPv4:PORT
+            selectors match one destination endpoint. Any traffic not matching
+            a permit is dropped, and packets that cannot be safely classified
             are dropped.
+
+            This allows broad service access with narrow carve-outs:
 
             traffico --ifname=eth0 --at=EGRESS \
                 --allow arp \
                 --allow dns/10.0.0.53 \
-                --allow tcp/10.0.0.10:443 \
-                --allow udp/10.0.0.20:123
+                --allow tcp/10.0.0.10 \
+                --forbid tcp/10.0.0.10:22
+
+            For a DNS carve-out inside broader TCP and UDP access to one host:
+
+            traffico --ifname=eth0 --at=EGRESS \
+                --allow arp \
+                --allow tcp/10.0.0.53 \
+                --allow udp/10.0.0.53 \
+                --forbid dns/10.0.0.53
 
             Use --dry-run to compile and validate without attaching:
 
             traffico --ifname=eth0 --at=EGRESS \
                 --allow arp \
-                --allow tcp/10.0.0.10:443 \
+                --allow tcp/10.0.0.10 \
+                --forbid tcp/10.0.0.10:22 \
                 --dry-run
 
             Use --explain to print the normalized Intent before validation
             succeeds or fails:
 
             traffico --ifname=eth0 --at=EGRESS \
-                --allow udp/10.0.0.20:123 \
                 --allow arp \
-                --allow tcp/10.0.0.10:443 \
                 --allow dns/10.0.0.53 \
+                --allow tcp/10.0.0.10 \
+                --forbid tcp/10.0.0.10:22 \
                 --dry-run --explain
 
             Intent mode is mutually exclusive with --chain and with positional
             PROGRAM [INPUT]. The first Intent backend is the Linux BPF egress
             adapter. --at=INGRESS is parsed and can be explained, but backend
             validation rejects it until an ingress backend is implemented.
+
+            Current Intent boundaries:
+                Intent is CLI-only; traffico-cni still uses built-in programs.
+                Intent supports Linux TC BPF egress only.
+                Host-wide tcp/IPv4 and udp/IPv4 are permits only.
+                Host-wide TCP/UDP forbids are not supported yet.
+                CIDR, port ranges, source predicates, labels, DNS names, ICMP
+                selectors, policy files, and --explain=dag are reserved for
+                future releases.
 
     traffico-cni
         traffico-cni is a meta CNI plugin that allows the traffico programs to be used in CNI.

--- a/README.txt
+++ b/README.txt
@@ -116,6 +116,15 @@ USAGE
             a permit is dropped, and packets that cannot be safely classified
             are dropped.
 
+            What v0.6 can do today:
+                Put a workload behind a dedicated Linux egress interface,
+                container veth, or network namespace veth.
+                Attach Intent mode to that interface at egress.
+                Permit the DNS, ARP, TCP, and UDP traffic the workload needs.
+                Add narrow forbids for denied ports, DNS, or ARP carve-outs.
+                Treat the policy as interface-scoped. It is not process-,
+                agent-, container-, or CNI-scoped by itself.
+
             This allows broad service access with narrow carve-outs:
 
             traffico --ifname=eth0 --at=EGRESS \
@@ -163,6 +172,12 @@ USAGE
                 CIDR, port ranges, source predicates, labels, DNS names, ICMP
                 selectors, policy files, and --explain=dag are reserved for
                 future releases.
+
+            Current Intent limits:
+                Up to 32 permits and 32 forbids.
+                The Linux TC BPF backend enforces up to 64 action-bearing rows.
+                Duplicate permits and duplicate forbids are rejected.
+                The 33rd permit or forbid is rejected before attach.
 
     traffico-cni
         traffico-cni is a meta CNI plugin that allows the traffico programs to be used in CNI.

--- a/api/enforcement.h
+++ b/api/enforcement.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "dag.h"
@@ -383,64 +384,86 @@ static inline int intent_enforcement_emit_path(const struct intent_enforcement_p
 
 static inline int intent_enforcement_walk_edge(const struct decision_dag *dag,
                                                const struct decision_edge *edge,
-                                               struct intent_enforcement_path path,
+                                               const struct intent_enforcement_path *path,
                                                struct intent_enforcement_plan *plan,
                                                const char **err_msg);
 
 static inline int intent_enforcement_walk_node(const struct decision_dag *dag,
                                                size_t node_index,
-                                               struct intent_enforcement_path path,
+                                               const struct intent_enforcement_path *path,
                                                struct intent_enforcement_plan *plan,
                                                const char **err_msg)
 {
     const struct decision_node *node = &dag->nodes[node_index];
     struct intent_predicate narrowed_predicate = {0};
-    struct intent_enforcement_path true_path = path;
-    struct intent_enforcement_path false_path = path;
+    struct intent_enforcement_path *true_path = malloc(sizeof(*true_path));
+    struct intent_enforcement_path *false_path = malloc(sizeof(*false_path));
     int false_status = 0;
     int true_status = 0;
+    int rc = 0;
+
+    if (!true_path || !false_path)
+    {
+        free(true_path);
+        free(false_path);
+        return intent_fail(err_msg, "enforcement path allocation failed");
+    }
+
+    *true_path = *path;
+    *false_path = *path;
 
     /*
      * The true path carries the current predicate.
      * The false path records that the predicate did not match.
      */
-    false_status = intent_enforcement_add_false_predicate(&false_path,
+    false_status = intent_enforcement_add_false_predicate(false_path,
                                                           &node->predicate,
                                                           err_msg);
     if (false_status < 0)
-        return -1;
-
-    if (!intent_enforcement_narrow_predicate(&path, &node->predicate, &narrowed_predicate))
     {
-        if (false_status == 0)
-            return 0;
-        return intent_enforcement_walk_edge(dag, &node->on_false, false_path, plan, err_msg);
+        rc = -1;
+        goto done;
     }
 
-    true_status = intent_enforcement_apply_true_predicate(&true_path,
+    if (!intent_enforcement_narrow_predicate(path, &node->predicate, &narrowed_predicate))
+    {
+        if (false_status == 0)
+            goto done;
+        rc = intent_enforcement_walk_edge(dag, &node->on_false, false_path, plan, err_msg);
+        goto done;
+    }
+
+    true_status = intent_enforcement_apply_true_predicate(true_path,
                                                           &narrowed_predicate,
                                                           err_msg);
     if (true_status < 0)
-        return -1;
+    {
+        rc = -1;
+        goto done;
+    }
     if (true_status == 0)
     {
         if (false_status == 0)
-            return 0;
-        return intent_enforcement_walk_edge(dag, &node->on_false, false_path, plan, err_msg);
+            goto done;
+        rc = intent_enforcement_walk_edge(dag, &node->on_false, false_path, plan, err_msg);
+        goto done;
     }
 
     if (intent_enforcement_walk_edge(dag, &node->on_true, true_path, plan, err_msg) != 0 ||
         (false_status != 0 &&
          intent_enforcement_walk_edge(dag, &node->on_false, false_path, plan, err_msg) != 0) ||
         intent_enforcement_walk_edge(dag, &node->on_error, path, plan, err_msg) != 0)
-        return -1;
+        rc = -1;
 
-    return 0;
+done:
+    free(true_path);
+    free(false_path);
+    return rc;
 }
 
 static inline int intent_enforcement_walk_edge(const struct decision_dag *dag,
                                                const struct decision_edge *edge,
-                                               struct intent_enforcement_path path,
+                                               const struct intent_enforcement_path *path,
                                                struct intent_enforcement_plan *plan,
                                                const char **err_msg)
 {
@@ -449,11 +472,11 @@ static inline int intent_enforcement_walk_edge(const struct decision_dag *dag,
     case DECISION_TERMINAL_NONE:
         return intent_enforcement_walk_node(dag, edge->node, path, plan, err_msg);
     case DECISION_TERMINAL_ALLOW:
-        return intent_enforcement_emit_path(&path, INTENT_ENFORCEMENT_ALLOW, plan, err_msg);
+        return intent_enforcement_emit_path(path, INTENT_ENFORCEMENT_ALLOW, plan, err_msg);
     case DECISION_TERMINAL_DROP:
         return 0;
     case DECISION_TERMINAL_FORBID:
-        return intent_enforcement_emit_path(&path, INTENT_ENFORCEMENT_DROP, plan, err_msg);
+        return intent_enforcement_emit_path(path, INTENT_ENFORCEMENT_DROP, plan, err_msg);
     default:
         return intent_fail(err_msg, "enforcement path is outside the first supported subset");
     }
@@ -470,7 +493,7 @@ static inline int intent_enforcement_plan_from_dag(const struct decision_dag *da
 
     memset(plan, 0, sizeof(*plan));
     plan->direction = dag->direction;
-    return intent_enforcement_walk_node(dag, dag->root, path, plan, err_msg);
+    return intent_enforcement_walk_node(dag, dag->root, &path, plan, err_msg);
 }
 
 #endif

--- a/api/intent.h
+++ b/api/intent.h
@@ -572,8 +572,9 @@ static inline int intent_add_l4_forbid(struct intent *intent,
     struct intent_forbid forbid;
     intent_forbid_init(&forbid);
 
-    if (!port ||
-        intent_parse_ipv4(ip, &dst_ip) != 0 ||
+    if (!port)
+        return intent_fail(err_msg, "host-wide TCP/UDP forbids are not supported; use tcp/IP:PORT or udp/IP:PORT");
+    if (intent_parse_ipv4(ip, &dst_ip) != 0 ||
         intent_parse_port(port, &dst_port) != 0)
         return intent_fail(err_msg, "invalid forbid");
     if (intent_add_forbid_eq(&forbid, INTENT_FIELD_ETH_TYPE, INTENT_ETH_P_IP, err_msg) != 0 ||

--- a/api/intent_bpf.h
+++ b/api/intent_bpf.h
@@ -12,10 +12,15 @@ _Static_assert(MAX_INTENT_ENFORCEMENT_RULES == INTENT_BPF_MAX_RULES,
                "enforcement and BPF rule limits must match");
 _Static_assert(MAX_INTENT_ENFORCEMENT_PROTOS == INTENT_BPF_MAX_PROTOS,
                "enforcement and BPF proto limits must match");
+_Static_assert(INTENT_ENFORCEMENT_DROP == INTENT_BPF_ACTION_DROP,
+               "enforcement and BPF DROP actions must match");
+_Static_assert(INTENT_ENFORCEMENT_ALLOW == INTENT_BPF_ACTION_ALLOW,
+               "enforcement and BPF ALLOW actions must match");
 
 struct intent_bpf_rule
 {
     uint8_t kind;
+    uint8_t action;
     uint8_t ip_proto_count;
     uint8_t ip_protos[INTENT_BPF_MAX_PROTOS];
     uint8_t l4_dst_port_mode;
@@ -48,6 +53,10 @@ static inline bool intent_bpf_should_destroy_hook(bool cleanup_on_exit,
 
 static inline bool intent_bpf_rule_supported(const struct intent_enforcement_rule *rule)
 {
+    if (rule->action != INTENT_ENFORCEMENT_DROP &&
+        rule->action != INTENT_ENFORCEMENT_ALLOW)
+        return false;
+
     if (rule->kind == INTENT_ENFORCEMENT_RULE_ARP)
         return rule->ip_dst == 0 &&
                rule->l4_dst_port_mode == INTENT_L4_DST_PORT_EXACT &&
@@ -105,16 +114,15 @@ static inline int intent_bpf_plan_from_enforcement(const struct intent_enforceme
         const struct intent_enforcement_rule *src = &plan->rules[i];
         struct intent_bpf_rule *dst = &bpf_plan->rules[i];
 
-        if (src->action == INTENT_ENFORCEMENT_DROP)
-        {
-            return intent_fail(err_msg, "forbids are not supported yet");
-        }
-
         /* This is the BPF backend admissibility gate. */
         if (!intent_bpf_rule_supported(src))
         {
             return intent_fail(err_msg, "Intent BPF plan contains unsupported rule");
         }
+
+        dst->action = src->action == INTENT_ENFORCEMENT_DROP
+                          ? INTENT_BPF_ACTION_DROP
+                          : INTENT_BPF_ACTION_ALLOW;
 
         if (src->kind == INTENT_ENFORCEMENT_RULE_ARP)
         {

--- a/api/intent_bpf_loader.h.in
+++ b/api/intent_bpf_loader.h.in
@@ -7,6 +7,16 @@
 #include "intent.skel.h"
 #include "intent_bpf.h"
 
+enum
+{
+    INTENT_BPF_RODATA_RULE_CAPACITY =
+        sizeof(((struct intent_bpf__rodata *)0)->intent_rules) /
+        sizeof(((struct intent_bpf__rodata *)0)->intent_rules[0])
+};
+
+_Static_assert(INTENT_BPF_RODATA_RULE_CAPACITY == INTENT_BPF_MAX_RULES,
+               "Intent BPF rodata rule capacity must match userspace");
+
 static int attach_intent_bpf(struct config *conf,
                              const struct intent_bpf_plan *plan,
                              after_attach_fn_t cb)
@@ -42,6 +52,7 @@ static int attach_intent_bpf(struct config *conf,
     for (uint32_t i = 0; i < plan->rule_count; i++)
     {
         obj->rodata->intent_rules[i].kind = plan->rules[i].kind;
+        obj->rodata->intent_rules[i].action = plan->rules[i].action;
         obj->rodata->intent_rules[i].ip_proto_count = plan->rules[i].ip_proto_count;
         obj->rodata->intent_rules[i].ip_protos[0] = plan->rules[i].ip_protos[0];
         obj->rodata->intent_rules[i].ip_protos[1] = plan->rules[i].ip_protos[1];

--- a/api/intent_bpf_uapi.h
+++ b/api/intent_bpf_uapi.h
@@ -15,4 +15,10 @@ enum intent_bpf_rule_kind
     INTENT_BPF_RULE_IPV4_L4 = 2,
 };
 
+enum intent_bpf_action
+{
+    INTENT_BPF_ACTION_DROP = 0,
+    INTENT_BPF_ACTION_ALLOW = 1,
+};
+
 #endif

--- a/bpf/intent.bpf.c
+++ b/bpf/intent.bpf.c
@@ -6,9 +6,11 @@
 
 char LICENSE[] SEC("license") = "Dual BSD/GPL";
 
+/* Must match api/intent_bpf.h because the skeleton uses the userspace type. */
 struct intent_bpf_rule
 {
     __u8 kind;
+    __u8 action;
     __u8 ip_proto_count;
     __u8 ip_protos[INTENT_BPF_MAX_PROTOS];
     __u8 l4_dst_port_mode;
@@ -30,6 +32,21 @@ static __always_inline int proto_allowed(const volatile struct intent_bpf_rule *
             return 1;
     }
     return 0;
+}
+
+static __always_inline int rule_matches_l4(const volatile struct intent_bpf_rule *rule,
+                                           __u32 dst_ip,
+                                           __u8 proto,
+                                           __u16 dst_port)
+{
+    if (rule->kind != INTENT_BPF_RULE_IPV4_L4)
+        return 0;
+    if (rule->ip_dst != dst_ip || !proto_allowed(rule, proto))
+        return 0;
+    if (rule->l4_dst_port_mode == INTENT_L4_DST_PORT_ANY)
+        return 1;
+    return rule->l4_dst_port_mode == INTENT_L4_DST_PORT_EXACT &&
+           rule->l4_dst_port == dst_port;
 }
 
 SEC("tc")
@@ -64,7 +81,21 @@ int intent(struct __sk_buff *skb)
         {
             if (i >= intent_rule_count)
                 break;
-            if (intent_rules[i].kind == INTENT_BPF_RULE_ARP)
+
+            const volatile struct intent_bpf_rule *rule = &intent_rules[i];
+            if (rule->kind == INTENT_BPF_RULE_ARP &&
+                rule->action == INTENT_BPF_ACTION_DROP)
+                return TC_ACT_SHOT;
+        }
+
+        for (__u32 i = 0; i < INTENT_BPF_MAX_RULES; i++)
+        {
+            if (i >= intent_rule_count)
+                break;
+
+            const volatile struct intent_bpf_rule *rule = &intent_rules[i];
+            if (rule->kind == INTENT_BPF_RULE_ARP &&
+                rule->action == INTENT_BPF_ACTION_ALLOW)
                 return TC_ACT_OK;
         }
         return TC_ACT_SHOT;
@@ -110,21 +141,26 @@ int intent(struct __sk_buff *skb)
     __u16 dst_port = bpf_ntohs(*dst_port_ptr);
     __u32 dst_ip = bpf_ntohl(ip->daddr);
 
-    /* Rules are correlated tuples, not independent allow sets. */
+    /* Matching forbids take precedence over matching permits. */
     for (__u32 i = 0; i < INTENT_BPF_MAX_RULES; i++)
     {
         if (i >= intent_rule_count)
             break;
 
         const volatile struct intent_bpf_rule *rule = &intent_rules[i];
-        if (rule->kind != INTENT_BPF_RULE_IPV4_L4)
-            continue;
-        if (rule->ip_dst != dst_ip || !proto_allowed(rule, ip->protocol))
-            continue;
-        if (rule->l4_dst_port_mode == INTENT_L4_DST_PORT_ANY)
-            return TC_ACT_OK;
-        if (rule->l4_dst_port_mode == INTENT_L4_DST_PORT_EXACT &&
-            rule->l4_dst_port == dst_port)
+        if (rule->action == INTENT_BPF_ACTION_DROP &&
+            rule_matches_l4(rule, dst_ip, ip->protocol, dst_port))
+            return TC_ACT_SHOT;
+    }
+
+    for (__u32 i = 0; i < INTENT_BPF_MAX_RULES; i++)
+    {
+        if (i >= intent_rule_count)
+            break;
+
+        const volatile struct intent_bpf_rule *rule = &intent_rules[i];
+        if (rule->action == INTENT_BPF_ACTION_ALLOW &&
+            rule_matches_l4(rule, dst_ip, ip->protocol, dst_port))
             return TC_ACT_OK;
     }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,9 @@ traffico is a collection of tools to shape traffic on a network using traffic co
 It can be used via a CLI tool (`traffico`) or as a CNI plugin (`traffico-cni`).
 For a list of the available programs and what they do see the [Built-in programs](#built-in-programs) section.
 
+Intent mode adds network intent guardrails for agent workloads.
+It can express intent-based egress quarantine policies such as "allow ARP, allow DNS to this resolver, allow TCP to this service, but forbid SSH to it".
+
 The built-in programs are very opinionated and made for the needs of the authors but the framework
 is flexible enough to be used for other purposes. You can add programs to the `bpf/` directory
 to extend it to other use cases.
@@ -91,28 +94,62 @@ slot 0 must be `allow_ethertype`, and the layer order must be `L2 -> L3 -> L4`.
 
 #### Intent mode
 
-Use Intent mode when the policy is an additive allowlist such as "ARP OR DNS to
-this resolver OR HTTPS to this service". Intent mode is selected by repeating
-`--allow` or `--permit`; `--permit` is an alias for `--allow`.
+Use Intent mode for network intent guardrails and intent-based egress quarantine.
+It is selected by repeating `--allow` / `--permit` and optionally `--forbid` /
+`--block`.
+`--permit` is an alias for `--allow`.
+`--block` is an alias for `--forbid`.
 
-Supported selectors:
+Intent mode uses deny-overrides semantics:
+
+```text
+malformed or unclassifiable packet => DROP
+matching forbid                   => DROP
+matching permit                   => ALLOW
+no matching permit                => DROP
+```
+
+Supported permit selectors:
+
+- `arp`
+- `dns/IPv4`
+- `tcp/IPv4`
+- `udp/IPv4`
+- `tcp/IPv4:PORT`
+- `udp/IPv4:PORT`
+
+Supported forbid selectors:
 
 - `arp`
 - `dns/IPv4`
 - `tcp/IPv4:PORT`
 - `udp/IPv4:PORT`
 
-`dns/IPv4` permits DNS to that IPv4 resolver over TCP or UDP destination port
-53. TCP and UDP selectors match packets whose destination endpoint is
-`IPv4:PORT`. Any traffic not matching a permit is dropped, and packets that
-cannot be safely classified are dropped.
+`dns/IPv4` matches DNS to that IPv4 resolver over TCP or UDP destination port
+53. `tcp/IPv4` and `udp/IPv4` permit any destination port on that IPv4 host.
+The `tcp/IPv4:PORT` and `udp/IPv4:PORT` selectors match one destination
+endpoint.
+Any traffic not matching a permit is dropped, and packets that cannot be safely
+classified are dropped.
+
+This allows broad service access with narrow carve-outs:
 
 ```bash
 traffico --ifname=eth0 --at=EGRESS \
   --allow arp \
   --allow dns/10.0.0.53 \
-  --allow tcp/10.0.0.10:443 \
-  --allow udp/10.0.0.20:123
+  --allow tcp/10.0.0.10 \
+  --forbid tcp/10.0.0.10:22
+```
+
+For a DNS carve-out inside broader TCP and UDP access to one host:
+
+```bash
+traffico --ifname=eth0 --at=EGRESS \
+  --allow arp \
+  --allow tcp/10.0.0.53 \
+  --allow udp/10.0.0.53 \
+  --forbid dns/10.0.0.53
 ```
 
 Use `--dry-run` to compile and validate without attaching:
@@ -120,7 +157,8 @@ Use `--dry-run` to compile and validate without attaching:
 ```bash
 traffico --ifname=eth0 --at=EGRESS \
   --allow arp \
-  --allow tcp/10.0.0.10:443 \
+  --allow tcp/10.0.0.10 \
+  --forbid tcp/10.0.0.10:22 \
   --dry-run
 ```
 
@@ -129,10 +167,10 @@ fails:
 
 ```bash
 traffico --ifname=eth0 --at=EGRESS \
-  --allow udp/10.0.0.20:123 \
   --allow arp \
-  --allow tcp/10.0.0.10:443 \
   --allow dns/10.0.0.53 \
+  --allow tcp/10.0.0.10 \
+  --forbid tcp/10.0.0.10:22 \
   --dry-run --explain
 ```
 
@@ -140,6 +178,15 @@ Intent mode is mutually exclusive with `--chain` and with positional
 `PROGRAM [INPUT]`. The first Intent backend is the Linux BPF egress adapter.
 `--at=INGRESS` is parsed and can be explained, but backend validation rejects
 it until an ingress backend is implemented.
+
+Current Intent boundaries:
+
+- Intent is CLI-only; `traffico-cni` still uses built-in programs.
+- Intent supports Linux TC BPF egress only.
+- Host-wide `tcp/IPv4` and `udp/IPv4` are permits only.
+- Host-wide TCP/UDP forbids are not supported yet.
+- CIDR, port ranges, source predicates, labels, DNS names, ICMP selectors,
+  policy files, and `--explain=dag` are reserved for future releases.
 
 ### traffico-cni
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -132,6 +132,16 @@ endpoint.
 Any traffic not matching a permit is dropped, and packets that cannot be safely
 classified are dropped.
 
+What v0.6 can do today:
+
+- Put a workload behind a dedicated Linux egress interface, container veth, or
+  network namespace veth.
+- Attach Intent mode to that interface at egress.
+- Permit the DNS, ARP, TCP, and UDP traffic the workload needs.
+- Add narrow forbids for denied ports, DNS, or ARP carve-outs.
+- Treat the policy as interface-scoped. It is not process-, agent-, container-,
+  or CNI-scoped by itself.
+
 This allows broad service access with narrow carve-outs:
 
 ```bash
@@ -187,6 +197,13 @@ Current Intent boundaries:
 - Host-wide TCP/UDP forbids are not supported yet.
 - CIDR, port ranges, source predicates, labels, DNS names, ICMP selectors,
   policy files, and `--explain=dag` are reserved for future releases.
+
+Current Intent limits:
+
+- Up to 32 permits and 32 forbids.
+- The Linux TC BPF backend enforces up to 64 action-bearing rows.
+- Duplicate permits and duplicate forbids are rejected.
+- The 33rd permit or forbid is rejected before attach.
 
 ### traffico-cni
 

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -10,10 +10,24 @@ bats_require_minimum_version 1.7.0
     [ "${lines[0]}" == 'Usage: traffico [OPTION...] [PROGRAM [INPUT]]' ]
 }
 
+@test "help documents Intent selector grammar and scope" {
+    run traffico --help
+    [ $status -eq 0 ]
+    [[ "$output" == *"Intent permits: arp | dns/IP | tcp/IP[:PORT] | udp/IP[:PORT]"* ]]
+    [[ "$output" == *"Intent forbids: arp | dns/IP | tcp/IP:PORT | udp/IP:PORT"* ]]
+    [[ "$output" == *"Intent backend: Linux TC BPF egress only; try --dry-run --explain first"* ]]
+}
+
 @test "usage" {
     run traffico --usage
     [ $status -eq 0 ]
     [ "${lines[0]%% *}" == 'Usage:' ]
+}
+
+@test "version reports the release version" {
+    run traffico --version
+    [ $status -eq 0 ]
+    [ "${lines[0]}" == 'traffico 0.6.0' ]
 }
 
 @test "--allow accepts first Intent values in dry-run mode" {

--- a/test/enforcement_unit.c
+++ b/test/enforcement_unit.c
@@ -570,6 +570,34 @@ static int test_enforcement_errors_accept_null_message_sink(void)
     return 0;
 }
 
+static int test_enforcement_handles_max_mixed_action_envelope(void)
+{
+    struct intent intent = {0};
+    struct intent_enforcement_plan plan = {0};
+    const char *err = NULL;
+    char selector[64];
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    for (int i = 1; i <= MAX_INTENT_PERMITS; i++)
+    {
+        snprintf(selector, sizeof(selector), "tcp/10.22.1.1:%d", 10000 + i);
+        CHECK(intent_add_permit(&intent, selector, &err) == 0);
+    }
+    for (int i = 1; i <= MAX_INTENT_FORBIDS; i++)
+    {
+        snprintf(selector, sizeof(selector), "tcp/10.22.1.1:%d", 20000 + i);
+        CHECK(intent_add_forbid(&intent, selector, &err) == 0);
+    }
+
+    CHECK(build_plan(&intent, &plan, &err) == 0);
+    CHECK(plan.rule_count == MAX_INTENT_ENFORCEMENT_RULES);
+    CHECK(plan.rules[0].action == INTENT_ENFORCEMENT_DROP);
+    CHECK(plan.rules[MAX_INTENT_FORBIDS - 1].action == INTENT_ENFORCEMENT_DROP);
+    CHECK(plan.rules[MAX_INTENT_FORBIDS].action == INTENT_ENFORCEMENT_ALLOW);
+    CHECK(plan.rules[MAX_INTENT_ENFORCEMENT_RULES - 1].action == INTENT_ENFORCEMENT_ALLOW);
+    return 0;
+}
+
 int main(void)
 {
     RUN_TEST(test_enforcement_extracts_arp_rule);
@@ -587,6 +615,7 @@ int main(void)
     RUN_TEST(test_enforcement_rejects_mutated_unguarded_port);
     RUN_TEST(test_enforcement_rejects_unsupported_predicate_before_extraction);
     RUN_TEST(test_enforcement_errors_accept_null_message_sink);
+    RUN_TEST(test_enforcement_handles_max_mixed_action_envelope);
     puts("enforcement unit tests: ok");
     return 0;
 }

--- a/test/intent_bpf_unit.c
+++ b/test/intent_bpf_unit.c
@@ -4,6 +4,7 @@
 #include "api/dag.h"
 #include "api/enforcement.h"
 #include "api/intent_bpf.h"
+#include "intent_semantics.h"
 
 #define CHECK(condition)                                                       \
     do                                                                         \
@@ -38,6 +39,55 @@ static int build_bpf_plan(struct intent_bpf_plan *bpf_plan, const char **err)
     CHECK(intent_build_dag(&intent, &dag, err) == 0);
     CHECK(intent_enforcement_plan_from_dag(&dag, &plan, err) == 0);
     return intent_bpf_plan_from_enforcement(&plan, bpf_plan, err);
+}
+
+static bool test_bpf_rule_matches_packet(const struct intent_bpf_rule *rule,
+                                         const struct intent_test_packet *packet)
+{
+    if (rule->kind == INTENT_BPF_RULE_ARP)
+        return packet->kind == INTENT_TEST_PACKET_ARP;
+
+    if (rule->kind != INTENT_BPF_RULE_IPV4_L4 ||
+        packet->kind != INTENT_TEST_PACKET_IPV4_L4 ||
+        rule->ip_dst != packet->ip_dst)
+        return false;
+
+    bool proto_matches = false;
+    for (size_t i = 0; i < rule->ip_proto_count; i++)
+        proto_matches = proto_matches || rule->ip_protos[i] == packet->ip_proto;
+    if (!proto_matches)
+        return false;
+
+    if (rule->l4_dst_port_mode == INTENT_L4_DST_PORT_ANY)
+        return true;
+    return rule->l4_dst_port_mode == INTENT_L4_DST_PORT_EXACT &&
+           rule->l4_dst_port == packet->l4_dst_port;
+}
+
+static enum intent_action test_bpf_decide(const struct intent_bpf_plan *plan,
+                                          struct intent_test_packet packet)
+{
+    if (packet.kind == INTENT_TEST_PACKET_MALFORMED ||
+        packet.kind == INTENT_TEST_PACKET_UNCLASSIFIABLE)
+        return INTENT_ACTION_DROP;
+
+    for (size_t i = 0; i < plan->rule_count; i++)
+    {
+        if (!test_bpf_rule_matches_packet(&plan->rules[i], &packet))
+            continue;
+        if (plan->rules[i].action == INTENT_BPF_ACTION_DROP)
+            return INTENT_ACTION_DROP;
+    }
+
+    for (size_t i = 0; i < plan->rule_count; i++)
+    {
+        if (!test_bpf_rule_matches_packet(&plan->rules[i], &packet))
+            continue;
+        if (plan->rules[i].action == INTENT_BPF_ACTION_ALLOW)
+            return INTENT_ACTION_ALLOW;
+    }
+
+    return INTENT_ACTION_DROP;
 }
 
 static int test_bpf_lowering_preserves_correlated_rows(void)
@@ -97,7 +147,7 @@ static int test_bpf_lowering_accepts_any_destination_port(void)
     return 0;
 }
 
-static int test_bpf_lowering_rejects_drop_rows_until_runtime_exists(void)
+static int test_bpf_lowering_preserves_drop_before_allow(void)
 {
     struct intent intent = {0};
     struct decision_dag dag = {0};
@@ -112,8 +162,91 @@ static int test_bpf_lowering_rejects_drop_rows_until_runtime_exists(void)
 
     CHECK(intent_build_dag(&intent, &dag, &err) == 0);
     CHECK(intent_enforcement_plan_from_dag(&dag, &plan, &err) == 0);
+    CHECK(intent_bpf_plan_from_enforcement(&plan, &bpf_plan, &err) == 0);
+
+    CHECK(bpf_plan.rule_count == 2);
+    CHECK(bpf_plan.rules[0].action == INTENT_BPF_ACTION_DROP);
+    CHECK(bpf_plan.rules[1].action == INTENT_BPF_ACTION_ALLOW);
+    return 0;
+}
+
+static int test_bpf_rows_match_intent_oracle_for_golden_policy(void)
+{
+    struct intent intent = {0};
+    struct decision_dag dag = {0};
+    struct intent_enforcement_plan plan = {0};
+    struct intent_bpf_plan bpf_plan = {0};
+    const char *err = NULL;
+    struct intent_test_packet packets[] = {
+        intent_test_packet_arp(),
+        intent_test_packet_tcp(0x0a00000a, 22),
+        intent_test_packet_tcp(0x0a00000a, 443),
+        intent_test_packet_udp(0x0a00000a, 443),
+        intent_test_packet_tcp(0x0a000014, 443),
+        intent_test_packet_malformed(),
+        intent_test_packet_unclassifiable(),
+    };
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    CHECK(intent_add_permit(&intent, "arp", &err) == 0);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.10", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "tcp/10.0.0.10:22", &err) == 0);
+    intent_normalize(&intent);
+
+    CHECK(intent_build_dag(&intent, &dag, &err) == 0);
+    CHECK(intent_enforcement_plan_from_dag(&dag, &plan, &err) == 0);
+    CHECK(intent_bpf_plan_from_enforcement(&plan, &bpf_plan, &err) == 0);
+    for (size_t i = 0; i < sizeof(packets) / sizeof(packets[0]); i++)
+    {
+        CHECK(test_bpf_decide(&bpf_plan, packets[i]) ==
+              intent_test_oracle_decide(&intent, packets[i]));
+    }
+    return 0;
+}
+
+static int test_bpf_rows_match_intent_oracle_for_dns_carveout_policy(void)
+{
+    struct intent intent = {0};
+    struct decision_dag dag = {0};
+    struct intent_enforcement_plan plan = {0};
+    struct intent_bpf_plan bpf_plan = {0};
+    const char *err = NULL;
+    struct intent_test_packet packets[] = {
+        intent_test_packet_udp(0x0a000035, 53),
+        intent_test_packet_tcp(0x0a000035, 53),
+        intent_test_packet_tcp(0x0a000035, 443),
+        intent_test_packet_udp(0x0a000035, 123),
+    };
+
+    intent_init(&intent, INTENT_DIRECTION_EGRESS);
+    CHECK(intent_add_permit(&intent, "arp", &err) == 0);
+    CHECK(intent_add_permit(&intent, "tcp/10.0.0.53", &err) == 0);
+    CHECK(intent_add_permit(&intent, "udp/10.0.0.53", &err) == 0);
+    CHECK(intent_add_forbid(&intent, "dns/10.0.0.53", &err) == 0);
+    intent_normalize(&intent);
+
+    CHECK(intent_build_dag(&intent, &dag, &err) == 0);
+    CHECK(intent_enforcement_plan_from_dag(&dag, &plan, &err) == 0);
+    CHECK(intent_bpf_plan_from_enforcement(&plan, &bpf_plan, &err) == 0);
+    for (size_t i = 0; i < sizeof(packets) / sizeof(packets[0]); i++)
+    {
+        CHECK(test_bpf_decide(&bpf_plan, packets[i]) ==
+              intent_test_oracle_decide(&intent, packets[i]));
+    }
+    return 0;
+}
+
+static int test_bpf_lowering_rejects_more_than_max_rules_before_reading_rows(void)
+{
+    struct intent_enforcement_plan plan = {0};
+    struct intent_bpf_plan bpf_plan = {0};
+    const char *err = NULL;
+
+    plan.direction = INTENT_DIRECTION_EGRESS;
+    plan.rule_count = INTENT_BPF_MAX_RULES + 1;
+
     CHECK(intent_bpf_plan_from_enforcement(&plan, &bpf_plan, &err) == -1);
-    CHECK(strcmp(err, "forbids are not supported yet") == 0);
+    CHECK(strcmp(err, "Intent BPF plan exceeds rule limit") == 0);
     return 0;
 }
 
@@ -255,7 +388,10 @@ int main(void)
 {
     RUN_TEST(test_bpf_lowering_preserves_correlated_rows);
     RUN_TEST(test_bpf_lowering_accepts_any_destination_port);
-    RUN_TEST(test_bpf_lowering_rejects_drop_rows_until_runtime_exists);
+    RUN_TEST(test_bpf_lowering_preserves_drop_before_allow);
+    RUN_TEST(test_bpf_rows_match_intent_oracle_for_golden_policy);
+    RUN_TEST(test_bpf_rows_match_intent_oracle_for_dns_carveout_policy);
+    RUN_TEST(test_bpf_lowering_rejects_more_than_max_rules_before_reading_rows);
     RUN_TEST(test_bpf_lowering_rejects_malformed_arp_row);
     RUN_TEST(test_bpf_lowering_rejects_unsupported_proto_value);
     RUN_TEST(test_bpf_lowering_rejects_duplicate_two_entry_proto_set);

--- a/test/intent_forbid.bats
+++ b/test/intent_forbid.bats
@@ -42,3 +42,37 @@ output_contains() {
     output_contains "forbidden traffic:"
     output_contains "  1. TCP to 10.0.0.10 destination port 22"
 }
+
+@test "--forbid without a permit is rejected before compilation" {
+    run traffico -i lo --at egress \
+        --forbid tcp/10.0.0.10:22 \
+        --dry-run
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: --forbid/--block requires at least one --allow/--permit" ]
+    ! output_contains "at least one permit is required"
+}
+
+@test "--block without a permit is rejected before compilation" {
+    run traffico -i lo --at egress \
+        --block tcp/10.0.0.10:22 \
+        --dry-run
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: --forbid/--block requires at least one --allow/--permit" ]
+    ! output_contains "at least one permit is required"
+}
+
+@test "host-wide TCP and UDP forbids explain the v0.6 boundary" {
+    run traffico -i lo --at egress \
+        --allow arp \
+        --forbid tcp/10.0.0.10 \
+        --dry-run
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: host-wide TCP/UDP forbids are not supported; use tcp/IP:PORT or udp/IP:PORT: 'tcp/10.0.0.10'" ]
+
+    run traffico -i lo --at egress \
+        --allow arp \
+        --forbid udp/10.0.0.20 \
+        --dry-run
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: host-wide TCP/UDP forbids are not supported; use tcp/IP:PORT or udp/IP:PORT: 'udp/10.0.0.20'" ]
+}

--- a/test/intent_forbid.bats
+++ b/test/intent_forbid.bats
@@ -4,13 +4,21 @@ load helpers
 export BATS_TEST_NAME_PREFIX=$(setsuite)
 bats_require_minimum_version 1.7.0
 
-@test "--forbid selects Intent mode and is parsed before backend support" {
+output_contains() {
+    case "$output" in
+        *"$1"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+@test "--forbid selects Intent mode and is BPF admissible" {
     run traffico -i lo --at egress \
         --allow tcp/10.0.0.10 \
         --forbid tcp/10.0.0.10:22 \
         --dry-run
-    [ $status -eq 1 ]
-    [ "${lines[0]}" == "traffico: intent dry-run: forbids are not supported yet" ]
+    [ $status -eq 0 ]
+    output_contains "intent dry-run: compiler ok"
+    output_contains "intent backend: bpf admissible"
 }
 
 @test "--block is an alias for --forbid" {
@@ -18,8 +26,9 @@ bats_require_minimum_version 1.7.0
         --allow tcp/10.0.0.10 \
         --block tcp/10.0.0.10:22 \
         --dry-run
-    [ $status -eq 1 ]
-    [ "${lines[0]}" == "traffico: intent dry-run: forbids are not supported yet" ]
+    [ $status -eq 0 ]
+    output_contains "intent dry-run: compiler ok"
+    output_contains "intent backend: bpf admissible"
 }
 
 @test "--dry-run --explain prints permits and forbids" {
@@ -27,9 +36,9 @@ bats_require_minimum_version 1.7.0
         --allow tcp/10.0.0.10 \
         --forbid tcp/10.0.0.10:22 \
         --dry-run --explain
-    [ $status -eq 1 ]
-    [[ "$output" == *"permitted traffic:"* ]]
-    [[ "$output" == *"  1. TCP to 10.0.0.10 any destination port"* ]]
-    [[ "$output" == *"forbidden traffic:"* ]]
-    [[ "$output" == *"  1. TCP to 10.0.0.10 destination port 22"* ]]
+    [ $status -eq 0 ]
+    output_contains "permitted traffic:"
+    output_contains "  1. TCP to 10.0.0.10 any destination port"
+    output_contains "forbidden traffic:"
+    output_contains "  1. TCP to 10.0.0.10 destination port 22"
 }

--- a/test/intent_forbid_scapy.bats
+++ b/test/intent_forbid_scapy.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+
+load helpers
+export BATS_TEST_NAME_PREFIX=$(setsuite)
+bats_require_minimum_version 1.7.0
+
+setup_file() {
+    if ! command -v python3 &>/dev/null; then
+        skip "python3 not found: scapy tests require python3"
+    fi
+    if ! python3 -c "import scapy" &>/dev/null; then
+        skip "scapy not installed: install python-scapy (Arch) or python3-scapy (Ubuntu)"
+    fi
+}
+
+setup() {
+    load net
+    NETNS="ns$((RANDOM % 10))"
+    new_netns "${NETNS}"
+    setup_net "${NETNS}"
+    arp_prewarm "${NETNS}"
+}
+
+teardown() {
+    killall traffico &>/dev/null || true
+    [ -n "${SNIFFER_PID:-}" ] && kill "$SNIFFER_PID" &>/dev/null || true
+    del_netdev
+    del_netns "${NETNS}"
+}
+
+intent_tc_state_exists() {
+    local qdisc
+    local filter
+
+    qdisc="$(ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact)"
+    filter="$(ip netns exec "${NETNS}" tc filter show dev "${PEER}" egress)"
+
+    [[ "${qdisc}" == *"clsact"* && "${filter}" != "" ]]
+}
+
+wait_for_intent_tc_state() {
+    local i
+
+    for i in {1..50}; do
+        if intent_tc_state_exists; then
+            return 0
+        fi
+        sleep 0.1
+    done
+
+    return 1
+}
+
+@test "Intent forbid blocks a port inside a host-wide TCP permit" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress \
+        --allow arp \
+        --allow "tcp/${VETH_ADDR}" \
+        --forbid "tcp/${VETH_ADDR}:22" >/dev/null 3>&- &
+    wait_for_intent_tc_state
+
+    assert_packet_seen "${NETNS}" 22001 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 443
+    assert_packet_seen "${NETNS}" 22002 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 8443
+    assert_packet_blocked "${NETNS}" 22003 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 22
+    assert_packet_blocked "${NETNS}" 22004 \
+        --type udp --dst-ip "${VETH_ADDR}" --dst-port 22
+}
+
+@test "Intent mixed allow forbid stays fail closed for VLAN IPv4 packets" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress \
+        --allow arp \
+        --allow "tcp/${VETH_ADDR}" \
+        --forbid "tcp/${VETH_ADDR}:22" >/dev/null 3>&- &
+    wait_for_intent_tc_state
+
+    assert_packet_blocked "${NETNS}" 22005 \
+        --type vlan-inner-ipv4 --dst-ip "${VETH_ADDR}" --dst-port 443
+}
+
+@test "Intent block alias has the same live semantics as forbid" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress \
+        --allow arp \
+        --allow "udp/${VETH_ADDR}" \
+        --block "udp/${VETH_ADDR}:123" >/dev/null 3>&- &
+    wait_for_intent_tc_state
+
+    assert_packet_seen "${NETNS}" 22101 \
+        --type udp --dst-ip "${VETH_ADDR}" --dst-port 9999
+    assert_packet_blocked "${NETNS}" 22102 \
+        --type udp --dst-ip "${VETH_ADDR}" --dst-port 123
+}
+
+@test "Intent forbid beats an exact allow" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress \
+        --allow arp \
+        --allow "tcp/${VETH_ADDR}:443" \
+        --forbid "tcp/${VETH_ADDR}:443" >/dev/null 3>&- &
+    wait_for_intent_tc_state
+
+    assert_packet_blocked "${NETNS}" 22201 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 443
+}
+
+@test "Intent forbid ARP beats allow ARP" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress \
+        --allow arp \
+        --forbid arp >/dev/null 3>&- &
+    wait_for_intent_tc_state
+
+    assert_packet_blocked "${NETNS}" 22301 \
+        --type arp-request --src-ip "${PEER_ADDR}" --dst-ip "${VETH_ADDR}"
+}
+
+@test "Intent forbid DNS beats allow DNS" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress \
+        --allow arp \
+        --allow "dns/${VETH_ADDR}" \
+        --forbid "dns/${VETH_ADDR}" >/dev/null 3>&- &
+    wait_for_intent_tc_state
+
+    assert_packet_blocked "${NETNS}" 22401 \
+        --type udp --dst-ip "${VETH_ADDR}" --dst-port 53
+    assert_packet_blocked "${NETNS}" 22402 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 53
+}
+
+@test "Intent DNS forbid carves out host-wide TCP and UDP permits" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress \
+        --allow arp \
+        --allow "tcp/${VETH_ADDR}" \
+        --allow "udp/${VETH_ADDR}" \
+        --forbid "dns/${VETH_ADDR}" >/dev/null 3>&- &
+    wait_for_intent_tc_state
+
+    assert_packet_blocked "${NETNS}" 22501 \
+        --type udp --dst-ip "${VETH_ADDR}" --dst-port 53
+    assert_packet_blocked "${NETNS}" 22502 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 53
+    assert_packet_seen "${NETNS}" 22503 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 443
+    assert_packet_seen "${NETNS}" 22504 \
+        --type udp --dst-ip "${VETH_ADDR}" --dst-port 123
+}

--- a/test/intent_unit.c
+++ b/test/intent_unit.c
@@ -247,7 +247,7 @@ static int test_rejects_invalid_and_duplicate_forbids(void)
     intent_init(&intent, INTENT_DIRECTION_EGRESS);
 
     CHECK(intent_add_forbid(&intent, "tcp/10.0.0.10", &err) == -1);
-    CHECK(strcmp(err, "invalid forbid") == 0);
+    CHECK(strcmp(err, "host-wide TCP/UDP forbids are not supported; use tcp/IP:PORT or udp/IP:PORT") == 0);
     CHECK(intent_add_forbid(&intent, "dns/10.0.0.53:53", &err) == -1);
     CHECK(strcmp(err, "dns forbids do not accept a port") == 0);
     CHECK(intent_add_forbid(&intent, "arp", &err) == 0);

--- a/test/intent_verifier.bats
+++ b/test/intent_verifier.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+
+load helpers
+export BATS_TEST_NAME_PREFIX=$(setsuite)
+bats_require_minimum_version 1.7.0
+
+setup_file() {
+    if ! command -v python3 &>/dev/null; then
+        skip "python3 not found: scapy tests require python3"
+    fi
+    if ! python3 -c "import scapy" &>/dev/null; then
+        skip "scapy not installed: install python-scapy (Arch) or python3-scapy (Ubuntu)"
+    fi
+}
+
+setup() {
+    load net
+    NETNS="ns$((RANDOM % 10))"
+    new_netns "${NETNS}"
+    setup_net "${NETNS}"
+    arp_prewarm "${NETNS}"
+}
+
+teardown() {
+    killall traffico &>/dev/null || true
+    del_netdev
+    del_netns "${NETNS}"
+}
+
+intent_tc_state_exists() {
+    local qdisc
+    local filter
+
+    qdisc="$(ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact)"
+    filter="$(ip netns exec "${NETNS}" tc filter show dev "${PEER}" egress)"
+
+    [[ "${qdisc}" == *"clsact"* && "${filter}" != "" ]]
+}
+
+wait_for_intent_tc_state() {
+    local i
+
+    for i in {1..50}; do
+        if intent_tc_state_exists; then
+            return 0
+        fi
+        sleep 0.1
+    done
+
+    return 1
+}
+
+@test "Intent BPF verifier accepts the maximum v0.6 rule envelope" {
+    local args=(-i "${PEER}" --at egress)
+    local i
+
+    # Keep all 64 action rows while permitting ARP for L3 Scapy sends.
+    args+=(--allow arp)
+    for i in {1..31}; do
+        args+=(--allow "tcp/${VETH_ADDR}:$((10000 + i))")
+    done
+    for i in {1..32}; do
+        args+=(--forbid "tcp/${VETH_ADDR}:$((20000 + i))")
+    done
+
+    ip netns exec "${NETNS}" traffico "${args[@]}" >/dev/null 3>&- &
+    wait_for_intent_tc_state
+    arp_prewarm "${NETNS}"
+
+    assert_packet_blocked "${NETNS}" 23001 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 20001
+    assert_packet_blocked "${NETNS}" 23002 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 20032
+    assert_packet_seen "${NETNS}" 23003 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 10001
+    assert_packet_seen "${NETNS}" 23004 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 10031
+    assert_packet_blocked "${NETNS}" 23005 \
+        --type tcp --dst-ip "${VETH_ADDR}" --dst-port 443
+}
+
+@test "Intent rejects the 33rd forbid before attach and leaves TC untouched" {
+    local args=(-i "${PEER}" --at egress --dry-run)
+    local i
+
+    for i in {1..32}; do
+        args+=(--allow "tcp/10.0.0.${i}")
+    done
+    for i in {1..33}; do
+        args+=(--forbid "tcp/10.0.1.${i}:22")
+    done
+
+    run ip netns exec "${NETNS}" traffico "${args[@]}"
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: too many forbids: 'tcp/10.0.1.33:22'" ]
+    run ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact
+    [ "$output" = "" ]
+}

--- a/traffico.c
+++ b/traffico.c
@@ -2,6 +2,7 @@
 #include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <strings.h>
 #include <errno.h>
@@ -19,7 +20,7 @@
 #include "chain.h"
 #include "intent_bpf_loader.h"
 
-const char *argp_program_version = TOOL_NAME " 0.0";
+const char *argp_program_version = TOOL_NAME " 0.6.0";
 const char *argp_program_bug_address = "https://github.com/leodido/traffico/issues";
 // Visibility attribute needed to override glibc's weak symbol
 // when built with -fvisibility=hidden.
@@ -29,6 +30,11 @@ const char argp_program_doc[] =
     "\n"
     "Isolate your host the eBPF way.\n"
     "\v"
+    "  INTENT MODE\n"
+    "  - Intent permits: arp | dns/IP | tcp/IP[:PORT] | udp/IP[:PORT]\n"
+    "  - Intent forbids: arp | dns/IP | tcp/IP:PORT | udp/IP:PORT\n"
+    "  - Intent backend: Linux TC BPF egress only; try --dry-run --explain first\n"
+    "\n"
     "  PROGRAMS\n" PROGRAMS_DESCRIPTION;
 
 const char OPT_VERBOSE_LONG[] = "verbose";
@@ -61,6 +67,8 @@ const char OPT_DRY_RUN_LONG[] = "dry-run";
 #define OPT_EXPLAIN_KEY 0x88
 const char OPT_EXPLAIN_LONG[] = "explain";
 const char OPT_EXPLAIN_ARG[] = "intent";
+#define OPT_VERSION_KEY 0x89
+const char OPT_VERSION_LONG[] = "version";
 
 const struct argp_option argp_opts[] = {
 
@@ -76,6 +84,7 @@ const struct argp_option argp_opts[] = {
     {OPT_BLOCK_LONG, OPT_BLOCK_KEY, OPT_BLOCK_ARG, 0, "Alias for --forbid", 1},
     {OPT_DRY_RUN_LONG, OPT_DRY_RUN_KEY, NULL, 0, "Validate Intent without attaching", 1},
     {OPT_EXPLAIN_LONG, OPT_EXPLAIN_KEY, OPT_EXPLAIN_ARG, OPTION_ARG_OPTIONAL, "Print normalized Intent", 1},
+    {OPT_VERSION_LONG, OPT_VERSION_KEY, NULL, 0, "Print version and exit", 1},
     {"", 0, 0, OPTION_DOC, 0, 0},
     {0} // .
 
@@ -217,6 +226,9 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
             argp_error(state, "unsupported --explain mode: '%s'", arg);
         }
         break;
+    case OPT_VERSION_KEY:
+        printf("%s\n", argp_program_version);
+        exit(0);
 
     // Arguments
     case ARGP_KEY_ARG:
@@ -261,6 +273,10 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
         if (g_intent_explain && !g_intent_mode)
         {
             argp_error(state, "--explain currently requires --allow, --permit, --forbid, or --block");
+        }
+        if (g_intent_mode && g_intent.permit_count == 0 && g_intent.forbid_count > 0)
+        {
+            argp_error(state, "--forbid/--block requires at least one --allow/--permit");
         }
         if (g_intent_mode)
         {


### PR DESCRIPTION
## Summary

PR6 of the v0.6 Intent stack.
This documents and sharpens the behavior proven by the previous implementation PRs.

What a v0.6 user can do today:

- put a workload behind a dedicated Linux egress interface, container veth, or network namespace veth
- attach Intent mode to that interface at egress
- permit the DNS, ARP, TCP, and UDP traffic the workload needs
- add narrow forbids for denied ports, DNS, or ARP carve-outs
- treat the policy as interface-scoped, not process-, agent-, container-, or CNI-scoped by itself

This PR also:

- documents Intent mode as network intent guardrails and intent-based egress quarantine
- documents deny-overrides semantics, permit selectors, forbid selectors, and `--block` / `--permit` aliases
- updates examples to use host-wide TCP/UDP permits with narrow forbid carve-outs
- states the v0.6 release boundaries: CLI-only Intent, Linux TC BPF egress only, no host-wide TCP/UDP forbids, no CNI Intent, no CIDR/ranges/source predicates/labels/DNS names/ICMP selectors/policy files/`--explain=dag`
- exposes the selector grammar and egress-only backend scope in `traffico --help`
- rejects forbid-only policies before DDAG compilation with a user-facing error
- documents the current rule envelope: 32 permits, 32 forbids, 64 BPF action-bearing rows, and no silent truncation

Stacked on #79 (`leox/v0.6-intent-forbid-bpf`).

## Verification

Focused public-surface gate:

```sh
xmake run test test/cli.flags.bats test/intent_forbid.bats
```

Result:

```text
1..83
ok 83 intent_forbid: host-wide TCP and UDP forbids explain the v0.6 boundary
```

Focused unit regression:

```sh
xmake run test test/intent_unit.bats
```

Result:

```text
1..1
ok 1 intent_unit: intent header unit tests
```

Full local Linux gate:

```sh
xmake run test
```

Result:

```text
1..199
ok 199 scapy_helper: Scapy sniffer reports readiness before timeout
```