### PR TITLE
test(infra): add lima smoke tests

### DIFF
--- a/.agents/skills/running-traffico-linux-tests/SKILL.md
+++ b/.agents/skills/running-traffico-linux-tests/SKILL.md
@@ -80,6 +80,11 @@ docker start -ai traffico-ubuntu-test-runner
 
 If the runner command, image, or mount changes, remove only the named container and recreate it. Keep `traffico-ubuntu-xmake-cache` unless intentionally forcing xmake to rebuild package dependencies.
 
+## Host-Realistic Smoke Tests
+
+Use this skill for fast Linux test iteration.
+Use `running-traffico-smoke-tests` when release confidence requires the Lima `traffico-ebpf` VM.
+
 ## Troubleshooting Generated State
 
 If the Docker build fails inside generated headers under `build/.gens` after branch switches, xmake graph changes, or partial rebuilds, suspect stale generated state before blaming CI or BPF source.

--- a/.agents/skills/running-traffico-smoke-tests/SKILL.md
+++ b/.agents/skills/running-traffico-smoke-tests/SKILL.md
@@ -56,24 +56,25 @@ If the VM already exists and Lima rejects `--name`, start it by instance name:
 limactl start traffico-ebpf
 ```
 
-Dry-run the transport command before running the VM smoke gate:
+Dry-run the default release smoke gate before running it in the VM:
 
 ```sh
-python3 tools/lima_traffico_runner.py --dry-run --test test/intent_examples.bats
+python3 tools/lima_traffico_runner.py --dry-run
 ```
 
-Run the real-world Intent examples:
+Run the default release smoke gate:
+
+```sh
+python3 tools/lima_traffico_runner.py
+```
+
+The default gate runs both real-world Intent examples and the verifier envelope.
+Do not treat examples-only output as release-complete evidence.
+
+Run only the examples when narrowing a failure:
 
 ```sh
 python3 tools/lima_traffico_runner.py --test test/intent_examples.bats
-```
-
-Run the examples plus verifier envelope:
-
-```sh
-python3 tools/lima_traffico_runner.py \
-  --test test/intent_examples.bats \
-  --test test/intent_verifier.bats
 ```
 
 Inspect the runner report:

--- a/.agents/skills/running-traffico-smoke-tests/SKILL.md
+++ b/.agents/skills/running-traffico-smoke-tests/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: running-traffico-smoke-tests
+description: Use when working in the traffico repository and needing host-realistic release smoke evidence through the Lima traffico-ebpf VM, including validating the Lima config, starting the VM, running intent_examples.bats, running intent_verifier.bats, or inspecting artifacts/lima reports.
+---
+
+# Running Traffico Smoke Tests
+
+## Overview
+
+Use this skill for release-confidence smoke gates that need a normal Ubuntu VM kernel.
+Use `running-traffico-linux-tests` for the fast/default Docker loop.
+
+Only supported backend: Lima VM named `traffico-ebpf`.
+Do not invent other smoke backends unless the repo adds them.
+
+The Lima runner still uses traffico's xmake/BATS/Scapy tests.
+It is an execution backend, not a second semantic framework.
+
+Automated smoke tests must attach to the namespace peer interface created by BATS.
+Do not attach automated tests to the VM's default network interface.
+
+## Workflow
+
+Run commands from the traffico repository root unless `--repo-in-vm` is passed explicitly.
+
+Validate the VM config:
+
+```sh
+limactl validate lima/traffico-ebpf.yml
+```
+
+Inspect any existing VM before starting it:
+
+```sh
+limactl list --format '{{.Name}} {{.Status}}'
+```
+
+If `traffico-ebpf` already exists, inspect the stored Lima config before reusing it:
+
+```sh
+rg -n "ubuntu-24.04|python3-scapy|/sys/fs/bpf|xmake" "$HOME/.lima/traffico-ebpf/lima.yaml"
+```
+
+Stop if the existing VM does not look like the traffico smoke VM.
+Do not silently reuse a stale instance created from a different config.
+
+Start or create the VM:
+
+```sh
+limactl start --name=traffico-ebpf lima/traffico-ebpf.yml
+```
+
+If the VM already exists and Lima rejects `--name`, start it by instance name:
+
+```sh
+limactl start traffico-ebpf
+```
+
+Dry-run the transport command before running the VM smoke gate:
+
+```sh
+python3 tools/lima_traffico_runner.py --dry-run --test test/intent_examples.bats
+```
+
+Run the real-world Intent examples:
+
+```sh
+python3 tools/lima_traffico_runner.py --test test/intent_examples.bats
+```
+
+Run the examples plus verifier envelope:
+
+```sh
+python3 tools/lima_traffico_runner.py \
+  --test test/intent_examples.bats \
+  --test test/intent_verifier.bats
+```
+
+Inspect the runner report:
+
+```sh
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+report = Path("artifacts/lima/traffico-runner-report.json")
+data = json.loads(report.read_text())
+assert data["status"] == "ok"
+assert data["instance"] == "traffico-ebpf"
+assert "limactl" in data["lima_command"][0]
+assert "xmake" in data["guest_command"]
+print("lima smoke report ok")
+PY
+```
+
+## Failure Rules
+
+If `limactl` is missing, stop and report that the smoke gate cannot run on this machine.
+Do not use Docker results as a substitute for Lima smoke evidence.
+
+If an existing `traffico-ebpf` VM does not match the stored config checks, stop and ask before recreating it.
+
+If provisioning or package installation fails, report the Lima failure.
+Do not weaken the smoke gate to make the VM pass.
+
+Generated reports must stay under `artifacts/`.
+They must not be committed.

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .xmake/
 build/
 .DS_Store
+artifacts/
+__pycache__/
+*.py[cod]

--- a/README.txt
+++ b/README.txt
@@ -12,6 +12,10 @@ README
     It can be used via a CLI tool (traffico) or as a CNI plugin (traffico-cni).
     For a list of the available programs and what they do see the BUILT-IN PROGRAMS section.
 
+    Intent mode adds network intent guardrails for agent workloads. It can
+    express intent-based egress quarantine policies such as "allow ARP, allow
+    DNS to this resolver, allow TCP to this service, but forbid SSH to it".
+
     The BUILT-IN PROGRAMS are very opinionated and made for the needs of the authors but the framework
     is flexible enough to be used for other purposes. You can add programs to the bpf/ directory
     to extend it to other use cases.
@@ -80,50 +84,85 @@ USAGE
         L2 -> L3 -> L4.
 
         Intent mode
-            Use Intent mode when the policy is an additive allowlist such as
-            "ARP OR DNS to this resolver OR HTTPS to this service". Intent
-            mode is selected by repeating --allow or --permit. --permit is an
-            alias for --allow.
+            Use Intent mode for network intent guardrails and intent-based
+            egress quarantine. It is selected by repeating --allow / --permit
+            and optionally --forbid / --block. --permit is an alias for
+            --allow. --block is an alias for --forbid.
 
-            Supported selectors:
+            Intent mode uses deny-overrides semantics:
+                malformed or unclassifiable packet -> DROP
+                matching forbid                    -> DROP
+                matching permit                    -> ALLOW
+                no matching permit                 -> DROP
+
+            Supported permit selectors:
+                arp
+                dns/IPv4
+                tcp/IPv4
+                udp/IPv4
+                tcp/IPv4:PORT
+                udp/IPv4:PORT
+
+            Supported forbid selectors:
                 arp
                 dns/IPv4
                 tcp/IPv4:PORT
                 udp/IPv4:PORT
 
-            dns/IPv4 permits DNS to that IPv4 resolver over TCP or UDP
-            destination port 53. TCP and UDP selectors match packets whose
-            destination endpoint is IPv4:PORT. Any traffic not matching a
-            permit is dropped, and packets that cannot be safely classified
+            dns/IPv4 matches DNS to that IPv4 resolver over TCP or UDP
+            destination port 53. tcp/IPv4 and udp/IPv4 permit any destination
+            port on that IPv4 host. The tcp/IPv4:PORT and udp/IPv4:PORT
+            selectors match one destination endpoint. Any traffic not matching
+            a permit is dropped, and packets that cannot be safely classified
             are dropped.
+
+            This allows broad service access with narrow carve-outs:
 
             traffico --ifname=eth0 --at=EGRESS \
                 --allow arp \
                 --allow dns/10.0.0.53 \
-                --allow tcp/10.0.0.10:443 \
-                --allow udp/10.0.0.20:123
+                --allow tcp/10.0.0.10 \
+                --forbid tcp/10.0.0.10:22
+
+            For a DNS carve-out inside broader TCP and UDP access to one host:
+
+            traffico --ifname=eth0 --at=EGRESS \
+                --allow arp \
+                --allow tcp/10.0.0.53 \
+                --allow udp/10.0.0.53 \
+                --forbid dns/10.0.0.53
 
             Use --dry-run to compile and validate without attaching:
 
             traffico --ifname=eth0 --at=EGRESS \
                 --allow arp \
-                --allow tcp/10.0.0.10:443 \
+                --allow tcp/10.0.0.10 \
+                --forbid tcp/10.0.0.10:22 \
                 --dry-run
 
             Use --explain to print the normalized Intent before validation
             succeeds or fails:
 
             traffico --ifname=eth0 --at=EGRESS \
-                --allow udp/10.0.0.20:123 \
                 --allow arp \
-                --allow tcp/10.0.0.10:443 \
                 --allow dns/10.0.0.53 \
+                --allow tcp/10.0.0.10 \
+                --forbid tcp/10.0.0.10:22 \
                 --dry-run --explain
 
             Intent mode is mutually exclusive with --chain and with positional
             PROGRAM [INPUT]. The first Intent backend is the Linux BPF egress
             adapter. --at=INGRESS is parsed and can be explained, but backend
             validation rejects it until an ingress backend is implemented.
+
+            Current Intent boundaries:
+                Intent is CLI-only; traffico-cni still uses built-in programs.
+                Intent supports Linux TC BPF egress only.
+                Host-wide tcp/IPv4 and udp/IPv4 are permits only.
+                Host-wide TCP/UDP forbids are not supported yet.
+                CIDR, port ranges, source predicates, labels, DNS names, ICMP
+                selectors, policy files, and --explain=dag are reserved for
+                future releases.
 
     traffico-cni
         traffico-cni is a meta CNI plugin that allows the traffico programs to be used in CNI.

--- a/README.txt
+++ b/README.txt
@@ -114,7 +114,9 @@ USAGE
             port on that IPv4 host. The tcp/IPv4:PORT and udp/IPv4:PORT
             selectors match one destination endpoint. Any traffic not matching
             a permit is dropped, and packets that cannot be safely classified
-            are dropped.
+            are dropped. In v0.6, Intent mode drops subsequent TCP/UDP
+            fragments because the TCP/UDP header is not present in those
+            packets.
 
             What v0.6 can do today:
                 Put a workload behind a dedicated Linux egress interface,
@@ -168,6 +170,8 @@ USAGE
                 Intent is CLI-only; traffico-cni still uses built-in programs.
                 Intent supports Linux TC BPF egress only.
                 Host-wide tcp/IPv4 and udp/IPv4 are permits only.
+                Subsequent TCP/UDP fragments are dropped, even under host-wide
+                permits.
                 Host-wide TCP/UDP forbids are not supported yet.
                 CIDR, port ranges, source predicates, labels, DNS names, ICMP
                 selectors, policy files, and --explain=dag are reserved for

--- a/README.txt
+++ b/README.txt
@@ -116,6 +116,15 @@ USAGE
             a permit is dropped, and packets that cannot be safely classified
             are dropped.
 
+            What v0.6 can do today:
+                Put a workload behind a dedicated Linux egress interface,
+                container veth, or network namespace veth.
+                Attach Intent mode to that interface at egress.
+                Permit the DNS, ARP, TCP, and UDP traffic the workload needs.
+                Add narrow forbids for denied ports, DNS, or ARP carve-outs.
+                Treat the policy as interface-scoped. It is not process-,
+                agent-, container-, or CNI-scoped by itself.
+
             This allows broad service access with narrow carve-outs:
 
             traffico --ifname=eth0 --at=EGRESS \
@@ -163,6 +172,12 @@ USAGE
                 CIDR, port ranges, source predicates, labels, DNS names, ICMP
                 selectors, policy files, and --explain=dag are reserved for
                 future releases.
+
+            Current Intent limits:
+                Up to 32 permits and 32 forbids.
+                The Linux TC BPF backend enforces up to 64 action-bearing rows.
+                Duplicate permits and duplicate forbids are rejected.
+                The 33rd permit or forbid is rejected before attach.
 
     traffico-cni
         traffico-cni is a meta CNI plugin that allows the traffico programs to be used in CNI.

--- a/api/intent.h
+++ b/api/intent.h
@@ -572,8 +572,9 @@ static inline int intent_add_l4_forbid(struct intent *intent,
     struct intent_forbid forbid;
     intent_forbid_init(&forbid);
 
-    if (!port ||
-        intent_parse_ipv4(ip, &dst_ip) != 0 ||
+    if (!port)
+        return intent_fail(err_msg, "host-wide TCP/UDP forbids are not supported; use tcp/IP:PORT or udp/IP:PORT");
+    if (intent_parse_ipv4(ip, &dst_ip) != 0 ||
         intent_parse_port(port, &dst_port) != 0)
         return intent_fail(err_msg, "invalid forbid");
     if (intent_add_forbid_eq(&forbid, INTENT_FIELD_ETH_TYPE, INTENT_ETH_P_IP, err_msg) != 0 ||

--- a/docs/README.md
+++ b/docs/README.md
@@ -131,6 +131,8 @@ The `tcp/IPv4:PORT` and `udp/IPv4:PORT` selectors match one destination
 endpoint.
 Any traffic not matching a permit is dropped, and packets that cannot be safely
 classified are dropped.
+In v0.6, Intent mode drops subsequent TCP/UDP fragments because the TCP/UDP
+header is not present in those packets.
 
 What v0.6 can do today:
 
@@ -194,6 +196,7 @@ Current Intent boundaries:
 - Intent is CLI-only; `traffico-cni` still uses built-in programs.
 - Intent supports Linux TC BPF egress only.
 - Host-wide `tcp/IPv4` and `udp/IPv4` are permits only.
+- Subsequent TCP/UDP fragments are dropped, even under host-wide permits.
 - Host-wide TCP/UDP forbids are not supported yet.
 - CIDR, port ranges, source predicates, labels, DNS names, ICMP selectors,
   policy files, and `--explain=dag` are reserved for future releases.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,9 @@ traffico is a collection of tools to shape traffic on a network using traffic co
 It can be used via a CLI tool (`traffico`) or as a CNI plugin (`traffico-cni`).
 For a list of the available programs and what they do see the [Built-in programs](#built-in-programs) section.
 
+Intent mode adds network intent guardrails for agent workloads.
+It can express intent-based egress quarantine policies such as "allow ARP, allow DNS to this resolver, allow TCP to this service, but forbid SSH to it".
+
 The built-in programs are very opinionated and made for the needs of the authors but the framework
 is flexible enough to be used for other purposes. You can add programs to the `bpf/` directory
 to extend it to other use cases.
@@ -91,28 +94,62 @@ slot 0 must be `allow_ethertype`, and the layer order must be `L2 -> L3 -> L4`.
 
 #### Intent mode
 
-Use Intent mode when the policy is an additive allowlist such as "ARP OR DNS to
-this resolver OR HTTPS to this service". Intent mode is selected by repeating
-`--allow` or `--permit`; `--permit` is an alias for `--allow`.
+Use Intent mode for network intent guardrails and intent-based egress quarantine.
+It is selected by repeating `--allow` / `--permit` and optionally `--forbid` /
+`--block`.
+`--permit` is an alias for `--allow`.
+`--block` is an alias for `--forbid`.
 
-Supported selectors:
+Intent mode uses deny-overrides semantics:
+
+```text
+malformed or unclassifiable packet => DROP
+matching forbid                   => DROP
+matching permit                   => ALLOW
+no matching permit                => DROP
+```
+
+Supported permit selectors:
+
+- `arp`
+- `dns/IPv4`
+- `tcp/IPv4`
+- `udp/IPv4`
+- `tcp/IPv4:PORT`
+- `udp/IPv4:PORT`
+
+Supported forbid selectors:
 
 - `arp`
 - `dns/IPv4`
 - `tcp/IPv4:PORT`
 - `udp/IPv4:PORT`
 
-`dns/IPv4` permits DNS to that IPv4 resolver over TCP or UDP destination port
-53. TCP and UDP selectors match packets whose destination endpoint is
-`IPv4:PORT`. Any traffic not matching a permit is dropped, and packets that
-cannot be safely classified are dropped.
+`dns/IPv4` matches DNS to that IPv4 resolver over TCP or UDP destination port
+53. `tcp/IPv4` and `udp/IPv4` permit any destination port on that IPv4 host.
+The `tcp/IPv4:PORT` and `udp/IPv4:PORT` selectors match one destination
+endpoint.
+Any traffic not matching a permit is dropped, and packets that cannot be safely
+classified are dropped.
+
+This allows broad service access with narrow carve-outs:
 
 ```bash
 traffico --ifname=eth0 --at=EGRESS \
   --allow arp \
   --allow dns/10.0.0.53 \
-  --allow tcp/10.0.0.10:443 \
-  --allow udp/10.0.0.20:123
+  --allow tcp/10.0.0.10 \
+  --forbid tcp/10.0.0.10:22
+```
+
+For a DNS carve-out inside broader TCP and UDP access to one host:
+
+```bash
+traffico --ifname=eth0 --at=EGRESS \
+  --allow arp \
+  --allow tcp/10.0.0.53 \
+  --allow udp/10.0.0.53 \
+  --forbid dns/10.0.0.53
 ```
 
 Use `--dry-run` to compile and validate without attaching:
@@ -120,7 +157,8 @@ Use `--dry-run` to compile and validate without attaching:
 ```bash
 traffico --ifname=eth0 --at=EGRESS \
   --allow arp \
-  --allow tcp/10.0.0.10:443 \
+  --allow tcp/10.0.0.10 \
+  --forbid tcp/10.0.0.10:22 \
   --dry-run
 ```
 
@@ -129,10 +167,10 @@ fails:
 
 ```bash
 traffico --ifname=eth0 --at=EGRESS \
-  --allow udp/10.0.0.20:123 \
   --allow arp \
-  --allow tcp/10.0.0.10:443 \
   --allow dns/10.0.0.53 \
+  --allow tcp/10.0.0.10 \
+  --forbid tcp/10.0.0.10:22 \
   --dry-run --explain
 ```
 
@@ -140,6 +178,15 @@ Intent mode is mutually exclusive with `--chain` and with positional
 `PROGRAM [INPUT]`. The first Intent backend is the Linux BPF egress adapter.
 `--at=INGRESS` is parsed and can be explained, but backend validation rejects
 it until an ingress backend is implemented.
+
+Current Intent boundaries:
+
+- Intent is CLI-only; `traffico-cni` still uses built-in programs.
+- Intent supports Linux TC BPF egress only.
+- Host-wide `tcp/IPv4` and `udp/IPv4` are permits only.
+- Host-wide TCP/UDP forbids are not supported yet.
+- CIDR, port ranges, source predicates, labels, DNS names, ICMP selectors,
+  policy files, and `--explain=dag` are reserved for future releases.
 
 ### traffico-cni
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -132,6 +132,16 @@ endpoint.
 Any traffic not matching a permit is dropped, and packets that cannot be safely
 classified are dropped.
 
+What v0.6 can do today:
+
+- Put a workload behind a dedicated Linux egress interface, container veth, or
+  network namespace veth.
+- Attach Intent mode to that interface at egress.
+- Permit the DNS, ARP, TCP, and UDP traffic the workload needs.
+- Add narrow forbids for denied ports, DNS, or ARP carve-outs.
+- Treat the policy as interface-scoped. It is not process-, agent-, container-,
+  or CNI-scoped by itself.
+
 This allows broad service access with narrow carve-outs:
 
 ```bash
@@ -187,6 +197,13 @@ Current Intent boundaries:
 - Host-wide TCP/UDP forbids are not supported yet.
 - CIDR, port ranges, source predicates, labels, DNS names, ICMP selectors,
   policy files, and `--explain=dag` are reserved for future releases.
+
+Current Intent limits:
+
+- Up to 32 permits and 32 forbids.
+- The Linux TC BPF backend enforces up to 64 action-bearing rows.
+- Duplicate permits and duplicate forbids are rejected.
+- The 33rd permit or forbid is rejected before attach.
 
 ### traffico-cni
 

--- a/lima/traffico-ebpf.yml
+++ b/lima/traffico-ebpf.yml
@@ -88,12 +88,12 @@ provision:
     script: |
       set -eux
 
-      if ! command -v xmake >/dev/null 2>&1; then
-        curl -fsSL https://xmake.io/shget.text | bash
-      fi
-
       profile="${HOME}/.profile"
       touch "${profile}"
-      grep -q '.local/bin' "${profile}" || echo 'export PATH="${HOME}/.local/bin:${PATH}"' >> "${profile}"
+      grep -q 'export PATH="${HOME}/.local/bin:${PATH}"' "${profile}" || echo 'export PATH="${HOME}/.local/bin:${PATH}"' >> "${profile}"
 
+      export PATH="${HOME}/.local/bin:${PATH}"
+      curl -fsSLo /tmp/xmake-v3.0.9.gz.run https://github.com/xmake-io/xmake/releases/download/v3.0.9/xmake-v3.0.9.gz.run
+      sh /tmp/xmake-v3.0.9.gz.run --accept --noprogress
+      hash -r
       "${HOME}/.local/bin/xmake" --version

--- a/lima/traffico-ebpf.yml
+++ b/lima/traffico-ebpf.yml
@@ -1,0 +1,99 @@
+minimumLimaVersion: "1.0.0"
+
+images:
+  - location: "https://cloud-images.ubuntu.com/releases/24.04/release-20250115/ubuntu-24.04-server-cloudimg-amd64.img"
+    arch: "x86_64"
+    digest: "sha256:28d2f9df3ac0d24440eaf6998507df3405142cf94a55e1f90802c78e43d2d9df"
+  - location: "https://cloud-images.ubuntu.com/releases/24.04/release-20250115/ubuntu-24.04-server-cloudimg-arm64.img"
+    arch: "aarch64"
+    digest: "sha256:f11282a728ad42f8bfe0b646a6807674d79a019bfc229d80032345dd3228a2db"
+  - location: "https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-amd64.img"
+    arch: "x86_64"
+  - location: "https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-arm64.img"
+    arch: "aarch64"
+
+memory: "4GiB"
+cpus: 4
+disk: "50GiB"
+vmType: vz
+
+mounts:
+  - location: "~"
+    writable: true
+
+rosetta:
+  enabled: true
+  binfmt: true
+
+provision:
+  - mode: system
+    script: |
+      set -eux
+      export DEBIAN_FRONTEND=noninteractive
+
+      apt-get update
+      apt-get install --yes --no-install-recommends \
+        apt-transport-https \
+        bzip2 \
+        ca-certificates \
+        clang \
+        cmake \
+        curl \
+        diffutils \
+        dwarves \
+        g++ \
+        gcc \
+        git \
+        iproute2 \
+        iputils-ping \
+        jq \
+        libelf-dev \
+        libffi-dev \
+        libpcap-dev \
+        libssl-dev \
+        linux-headers-generic \
+        linux-libc-dev \
+        llvm \
+        m4 \
+        make \
+        ninja-build \
+        pkg-config \
+        psmisc \
+        python3 \
+        python3-pip \
+        python3-scapy \
+        sudo \
+        unzip \
+        xz-utils \
+        zlib1g-dev
+
+      apt-get install --yes bpftool || true
+      apt-get install --yes linux-tools-common linux-tools-$(uname -r) || true
+      apt-get install --yes linux-tools-generic || true
+      apt-get install --yes linux-tools-virtual || true
+
+      if ! command -v bpftool >/dev/null 2>&1; then
+        bpftool_path="$(find /usr/lib/linux-tools* -type f -name bpftool 2>/dev/null | sort | tail -n 1)"
+        test -n "${bpftool_path}"
+        ln -sf "${bpftool_path}" /usr/local/bin/bpftool
+      fi
+
+      mkdir -p /sys/fs/bpf
+      mountpoint -q /sys/fs/bpf || mount -t bpf bpffs /sys/fs/bpf
+
+      clang --version
+      bpftool version
+      python3 -c "import scapy; print('scapy ok')"
+  - mode: user
+    script: |
+      set -eux
+
+      if ! command -v xmake >/dev/null 2>&1; then
+        curl -fsSL https://xmake.io/shget.text | bash
+      fi
+
+      profile="${HOME}/.profile"
+      touch "${profile}"
+      grep -q '.local/bin' "${profile}" || echo 'export PATH="${HOME}/.local/bin:${PATH}"' >> "${profile}"
+
+      "${HOME}/.local/bin/xmake" --version

--- a/test/cli.flags.bats
+++ b/test/cli.flags.bats
@@ -10,10 +10,24 @@ bats_require_minimum_version 1.7.0
     [ "${lines[0]}" == 'Usage: traffico [OPTION...] [PROGRAM [INPUT]]' ]
 }
 
+@test "help documents Intent selector grammar and scope" {
+    run traffico --help
+    [ $status -eq 0 ]
+    [[ "$output" == *"Intent permits: arp | dns/IP | tcp/IP[:PORT] | udp/IP[:PORT]"* ]]
+    [[ "$output" == *"Intent forbids: arp | dns/IP | tcp/IP:PORT | udp/IP:PORT"* ]]
+    [[ "$output" == *"Intent backend: Linux TC BPF egress only; try --dry-run --explain first"* ]]
+}
+
 @test "usage" {
     run traffico --usage
     [ $status -eq 0 ]
     [ "${lines[0]%% *}" == 'Usage:' ]
+}
+
+@test "version reports the release version" {
+    run traffico --version
+    [ $status -eq 0 ]
+    [ "${lines[0]}" == 'traffico 0.6.0' ]
 }
 
 @test "--allow accepts first Intent values in dry-run mode" {

--- a/test/intent_examples.bats
+++ b/test/intent_examples.bats
@@ -18,6 +18,8 @@ setup() {
     NETNS="ns$((RANDOM % 10))"
     RESOLVER_ADDR="198.51.100.53"
     SERVICE_ADDR="203.0.113.10"
+    API_ADDR="203.0.113.20"
+    TIME_ADDR="192.0.2.123"
     new_netns "${NETNS}"
     setup_net "${NETNS}"
     arp_prewarm "${NETNS}"
@@ -108,4 +110,33 @@ wait_for_intent_tc_state() {
         --type udp --dst-ip "${SERVICE_ADDR}" --dst-port 9999
     assert_packet_blocked "${NETNS}" 23202 \
         --type udp --dst-ip "${SERVICE_ADDR}" --dst-port 123
+}
+
+@test "ai agent egress quarantine allows resolver api and time source only" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress \
+        --allow arp \
+        --allow "dns/${RESOLVER_ADDR}" \
+        --allow "tcp/${API_ADDR}:443" \
+        --allow "udp/${TIME_ADDR}:123" \
+        --block "tcp/${API_ADDR}:22" >/dev/null 3>&- &
+    wait_for_intent_tc_state
+
+    assert_packet_seen "${NETNS}" 23301 \
+        --type arp-request --src-ip "${PEER_ADDR}" --dst-ip "${VETH_ADDR}"
+    assert_packet_seen "${NETNS}" 23302 \
+        --type udp --dst-ip "${RESOLVER_ADDR}" --dst-port 53
+    assert_packet_seen "${NETNS}" 23303 \
+        --type tcp --dst-ip "${RESOLVER_ADDR}" --dst-port 53
+    assert_packet_seen "${NETNS}" 23304 \
+        --type tcp --dst-ip "${API_ADDR}" --dst-port 443
+    assert_packet_seen "${NETNS}" 23305 \
+        --type udp --dst-ip "${TIME_ADDR}" --dst-port 123
+    assert_packet_blocked "${NETNS}" 23306 \
+        --type tcp --dst-ip "${API_ADDR}" --dst-port 22
+    assert_packet_blocked "${NETNS}" 23307 \
+        --type udp --dst-ip "${API_ADDR}" --dst-port 443
+    assert_packet_blocked "${NETNS}" 23308 \
+        --type tcp --dst-ip "${SERVICE_ADDR}" --dst-port 443
+    assert_packet_blocked "${NETNS}" 23309 \
+        --type icmp --dst-ip "${API_ADDR}"
 }

--- a/test/intent_examples.bats
+++ b/test/intent_examples.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+
+load helpers
+export BATS_TEST_NAME_PREFIX=$(setsuite)
+bats_require_minimum_version 1.7.0
+
+setup_file() {
+    if ! command -v python3 &>/dev/null; then
+        skip "python3 not found: scapy tests require python3"
+    fi
+    if ! python3 -c "import scapy" &>/dev/null; then
+        skip "scapy not installed: install python-scapy (Arch) or python3-scapy (Ubuntu)"
+    fi
+}
+
+setup() {
+    load net
+    NETNS="ns$((RANDOM % 10))"
+    RESOLVER_ADDR="198.51.100.53"
+    SERVICE_ADDR="203.0.113.10"
+    new_netns "${NETNS}"
+    setup_net "${NETNS}"
+    arp_prewarm "${NETNS}"
+}
+
+teardown() {
+    killall traffico &>/dev/null || true
+    [ -n "${SNIFFER_PID:-}" ] && kill "$SNIFFER_PID" &>/dev/null || true
+    del_netdev
+    del_netns "${NETNS}"
+}
+
+intent_tc_state_exists() {
+    local qdisc
+    local filter
+
+    qdisc="$(ip netns exec "${NETNS}" tc qdisc show dev "${PEER}" clsact)"
+    filter="$(ip netns exec "${NETNS}" tc filter show dev "${PEER}" egress)"
+
+    [[ "${qdisc}" == *"clsact"* && "${filter}" != "" ]]
+}
+
+wait_for_intent_tc_state() {
+    local i
+
+    for i in {1..50}; do
+        if intent_tc_state_exists; then
+            return 0
+        fi
+        sleep 0.1
+    done
+
+    return 1
+}
+
+@test "agent workload can use one resolver and one service while SSH is blocked" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress \
+        --allow arp \
+        --allow "dns/${RESOLVER_ADDR}" \
+        --allow "tcp/${SERVICE_ADDR}" \
+        --forbid "tcp/${SERVICE_ADDR}:22" >/dev/null 3>&- &
+    wait_for_intent_tc_state
+
+    assert_packet_seen "${NETNS}" 23001 \
+        --type arp-request --src-ip "${PEER_ADDR}" --dst-ip "${VETH_ADDR}"
+    assert_packet_seen "${NETNS}" 23002 \
+        --type udp --dst-ip "${RESOLVER_ADDR}" --dst-port 53
+    assert_packet_seen "${NETNS}" 23003 \
+        --type tcp --dst-ip "${RESOLVER_ADDR}" --dst-port 53
+    assert_packet_seen "${NETNS}" 23004 \
+        --type tcp --dst-ip "${SERVICE_ADDR}" --dst-port 443
+    assert_packet_blocked "${NETNS}" 23005 \
+        --type tcp --dst-ip "${SERVICE_ADDR}" --dst-port 22
+    assert_packet_blocked "${NETNS}" 23006 \
+        --type udp --dst-ip "${SERVICE_ADDR}" --dst-port 22
+    assert_packet_blocked "${NETNS}" 23007 \
+        --type icmp --dst-ip "${SERVICE_ADDR}"
+}
+
+@test "service access can be broad while DNS is carved out" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress \
+        --allow arp \
+        --allow "tcp/${SERVICE_ADDR}" \
+        --allow "udp/${SERVICE_ADDR}" \
+        --forbid "dns/${SERVICE_ADDR}" >/dev/null 3>&- &
+    wait_for_intent_tc_state
+
+    assert_packet_blocked "${NETNS}" 23101 \
+        --type udp --dst-ip "${SERVICE_ADDR}" --dst-port 53
+    assert_packet_blocked "${NETNS}" 23102 \
+        --type tcp --dst-ip "${SERVICE_ADDR}" --dst-port 53
+    assert_packet_seen "${NETNS}" 23103 \
+        --type tcp --dst-ip "${SERVICE_ADDR}" --dst-port 443
+    assert_packet_seen "${NETNS}" 23104 \
+        --type udp --dst-ip "${SERVICE_ADDR}" --dst-port 123
+    assert_packet_blocked "${NETNS}" 23105 \
+        --type vlan-inner-ipv4 --dst-ip "${SERVICE_ADDR}" --dst-port 443
+}
+
+@test "block is the human-facing alias for forbid in examples" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress \
+        --allow arp \
+        --allow "udp/${SERVICE_ADDR}" \
+        --block "udp/${SERVICE_ADDR}:123" >/dev/null 3>&- &
+    wait_for_intent_tc_state
+
+    assert_packet_seen "${NETNS}" 23201 \
+        --type udp --dst-ip "${SERVICE_ADDR}" --dst-port 9999
+    assert_packet_blocked "${NETNS}" 23202 \
+        --type udp --dst-ip "${SERVICE_ADDR}" --dst-port 123
+}

--- a/test/intent_forbid.bats
+++ b/test/intent_forbid.bats
@@ -42,3 +42,37 @@ output_contains() {
     output_contains "forbidden traffic:"
     output_contains "  1. TCP to 10.0.0.10 destination port 22"
 }
+
+@test "--forbid without a permit is rejected before compilation" {
+    run traffico -i lo --at egress \
+        --forbid tcp/10.0.0.10:22 \
+        --dry-run
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: --forbid/--block requires at least one --allow/--permit" ]
+    ! output_contains "at least one permit is required"
+}
+
+@test "--block without a permit is rejected before compilation" {
+    run traffico -i lo --at egress \
+        --block tcp/10.0.0.10:22 \
+        --dry-run
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: --forbid/--block requires at least one --allow/--permit" ]
+    ! output_contains "at least one permit is required"
+}
+
+@test "host-wide TCP and UDP forbids explain the v0.6 boundary" {
+    run traffico -i lo --at egress \
+        --allow arp \
+        --forbid tcp/10.0.0.10 \
+        --dry-run
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: host-wide TCP/UDP forbids are not supported; use tcp/IP:PORT or udp/IP:PORT: 'tcp/10.0.0.10'" ]
+
+    run traffico -i lo --at egress \
+        --allow arp \
+        --forbid udp/10.0.0.20 \
+        --dry-run
+    [ $status -eq 1 ]
+    [ "${lines[0]}" == "traffico: host-wide TCP/UDP forbids are not supported; use tcp/IP:PORT or udp/IP:PORT: 'udp/10.0.0.20'" ]
+}

--- a/test/intent_host_scapy.bats
+++ b/test/intent_host_scapy.bats
@@ -82,3 +82,17 @@ wait_for_intent_tc_state() {
     assert_packet_blocked "${NETNS}" 22004 \
         --type udp --dst-ip "${PEER_ADDR}" --dst-port 123
 }
+
+@test "Intent host-wide TCP and UDP permits drop subsequent fragments" {
+    ip netns exec "${NETNS}" traffico -i "${PEER}" --at egress \
+        --allow arp \
+        --allow "tcp/${VETH_ADDR}" \
+        --allow "udp/${VETH_ADDR}" >/dev/null 3>&- &
+    wait_for_intent_tc_state
+
+    # v0.6 only enforces TCP/UDP Intent rules when the transport header exists.
+    assert_packet_blocked "${NETNS}" 22005 \
+        --type fragment-subsequent --dst-ip "${VETH_ADDR}" --proto-override 6
+    assert_packet_blocked "${NETNS}" 22006 \
+        --type fragment-subsequent --dst-ip "${VETH_ADDR}" --proto-override 17
+}

--- a/test/intent_unit.c
+++ b/test/intent_unit.c
@@ -247,7 +247,7 @@ static int test_rejects_invalid_and_duplicate_forbids(void)
     intent_init(&intent, INTENT_DIRECTION_EGRESS);
 
     CHECK(intent_add_forbid(&intent, "tcp/10.0.0.10", &err) == -1);
-    CHECK(strcmp(err, "invalid forbid") == 0);
+    CHECK(strcmp(err, "host-wide TCP/UDP forbids are not supported; use tcp/IP:PORT or udp/IP:PORT") == 0);
     CHECK(intent_add_forbid(&intent, "dns/10.0.0.53:53", &err) == -1);
     CHECK(strcmp(err, "dns forbids do not accept a port") == 0);
     CHECK(intent_add_forbid(&intent, "arp", &err) == 0);

--- a/test/lima_traffico_runner.bats
+++ b/test/lima_traffico_runner.bats
@@ -1,0 +1,11 @@
+#!/usr/bin/env bats
+
+load helpers
+export BATS_TEST_NAME_PREFIX=$(setsuite)
+bats_require_minimum_version 1.7.0
+
+@test "lima traffico runner unit tests" {
+    run python3 test/lima_traffico_runner_test.py
+    [ $status -eq 0 ]
+    [[ "$output" == *"OK"* ]]
+}

--- a/test/lima_traffico_runner_test.py
+++ b/test/lima_traffico_runner_test.py
@@ -16,7 +16,7 @@ import lima_traffico_runner
 
 
 class LimaTrafficoRunnerTest(unittest.TestCase):
-    def test_guest_command_runs_default_intent_examples(self):
+    def test_guest_command_runs_default_release_smoke_gate(self):
         command = lima_traffico_runner.build_guest_command(
             repo_in_vm="/Users/me/traffico",
             tests=[],
@@ -29,7 +29,10 @@ class LimaTrafficoRunnerTest(unittest.TestCase):
         self.assertIn("cd '/Users/me/traffico'", command)
         self.assertIn("'xmake' 'f' '-c' '-y' '--generate-vmlinux=y' '--require-bpftool=y'", command)
         self.assertIn("'xmake' 'build' '-y'", command)
-        self.assertIn("'xmake' 'run' 'test' 'test/intent_examples.bats'", command)
+        self.assertIn(
+            "'xmake' 'run' 'test' 'test/intent_examples.bats' 'test/intent_verifier.bats'",
+            command,
+        )
         self.assertNotIn("--allow", command)
         self.assertNotIn("--forbid", command)
 
@@ -73,7 +76,7 @@ class LimaTrafficoRunnerTest(unittest.TestCase):
 
             run.assert_not_called()
             self.assertEqual(data["status"], "dry-run")
-            self.assertEqual(data["tests"], ["test/intent_examples.bats"])
+            self.assertEqual(data["tests"], ["test/intent_examples.bats", "test/intent_verifier.bats"])
             self.assertTrue(report.exists())
             written = json.loads(report.read_text())
             self.assertEqual(written["lima_command"][0], "limactl")

--- a/test/lima_traffico_runner_test.py
+++ b/test/lima_traffico_runner_test.py
@@ -1,0 +1,168 @@
+import contextlib
+import io
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "tools"))
+
+import lima_traffico_runner
+
+
+class LimaTrafficoRunnerTest(unittest.TestCase):
+    def test_guest_command_runs_default_intent_examples(self):
+        command = lima_traffico_runner.build_guest_command(
+            repo_in_vm="/Users/me/traffico",
+            tests=[],
+            configure=True,
+            build=True,
+        )
+
+        self.assertIn("test -d '/Users/me/traffico'", command)
+        self.assertIn("test -f '/Users/me/traffico/xmake.lua'", command)
+        self.assertIn("cd '/Users/me/traffico'", command)
+        self.assertIn("'xmake' 'f' '-c' '-y' '--generate-vmlinux=y' '--require-bpftool=y'", command)
+        self.assertIn("'xmake' 'build' '-y'", command)
+        self.assertIn("'xmake' 'run' 'test' 'test/intent_examples.bats'", command)
+        self.assertNotIn("--allow", command)
+        self.assertNotIn("--forbid", command)
+
+    def test_guest_command_accepts_selected_tests(self):
+        command = lima_traffico_runner.build_guest_command(
+            repo_in_vm="/Users/me/traffico",
+            tests=["test/intent_examples.bats", "test/intent_verifier.bats"],
+            configure=False,
+            build=False,
+        )
+
+        self.assertNotIn("'xmake' 'f'", command)
+        self.assertNotIn("'xmake' 'build'", command)
+        self.assertIn("'test/intent_examples.bats' 'test/intent_verifier.bats'", command)
+
+    def test_lima_command_wraps_guest_command(self):
+        command = lima_traffico_runner.build_lima_command(
+            instance="traffico-ebpf",
+            guest_command="cd /repo && xmake run test",
+        )
+
+        self.assertEqual(
+            command,
+            ["limactl", "shell", "traffico-ebpf", "bash", "-lc", "cd /repo && xmake run test"],
+        )
+
+    def test_dry_run_writes_runner_report_without_invoking_limactl(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            report = Path(tmpdir) / "runner.json"
+
+            with mock.patch.object(lima_traffico_runner.subprocess, "run") as run:
+                data = lima_traffico_runner.run_lima_tests(
+                    instance="traffico-ebpf",
+                    repo_in_vm="/Users/me/traffico",
+                    tests=[],
+                    runner_report=report,
+                    configure=True,
+                    build=True,
+                    dry_run=True,
+                )
+
+            run.assert_not_called()
+            self.assertEqual(data["status"], "dry-run")
+            self.assertEqual(data["tests"], ["test/intent_examples.bats"])
+            self.assertTrue(report.exists())
+            written = json.loads(report.read_text())
+            self.assertEqual(written["lima_command"][0], "limactl")
+
+    def test_real_run_records_limactl_success(self):
+        completed = subprocess.CompletedProcess(
+            args=["limactl"],
+            returncode=0,
+            stdout="ok\n",
+            stderr="",
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            report = Path(tmpdir) / "runner.json"
+            with mock.patch.object(
+                lima_traffico_runner.subprocess,
+                "run",
+                return_value=completed,
+            ) as run:
+                data = lima_traffico_runner.run_lima_tests(
+                    instance="traffico-ebpf",
+                    repo_in_vm="/Users/me/traffico",
+                    tests=["test/intent_examples.bats"],
+                    runner_report=report,
+                    configure=True,
+                    build=True,
+                    dry_run=False,
+                )
+
+        run.assert_called_once()
+        self.assertEqual(data["status"], "ok")
+        self.assertEqual(data["returncode"], 0)
+        self.assertEqual(data["stdout"], "ok\n")
+
+    def test_real_run_records_limactl_failure(self):
+        completed = subprocess.CompletedProcess(
+            args=["limactl"],
+            returncode=42,
+            stdout="",
+            stderr="boom\n",
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            report = Path(tmpdir) / "runner.json"
+            with mock.patch.object(
+                lima_traffico_runner.subprocess,
+                "run",
+                return_value=completed,
+            ):
+                data = lima_traffico_runner.run_lima_tests(
+                    instance="traffico-ebpf",
+                    repo_in_vm="/Users/me/traffico",
+                    tests=["test/intent_examples.bats"],
+                    runner_report=report,
+                    configure=True,
+                    build=True,
+                    dry_run=False,
+                )
+
+        self.assertEqual(data["status"], "failed")
+        self.assertEqual(data["returncode"], 42)
+        self.assertEqual(data["stderr"], "boom\n")
+
+    def test_main_returns_one_when_lima_fails(self):
+        completed = subprocess.CompletedProcess(
+            args=["limactl"],
+            returncode=42,
+            stdout="",
+            stderr="boom\n",
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            report = Path(tmpdir) / "runner.json"
+            argv = [
+                "lima_traffico_runner.py",
+                "--runner-report",
+                str(report),
+                "--test",
+                "test/intent_examples.bats",
+            ]
+            with mock.patch.object(sys, "argv", argv):
+                with mock.patch.object(
+                    lima_traffico_runner.subprocess,
+                    "run",
+                    return_value=completed,
+                ):
+                    with contextlib.redirect_stdout(io.StringIO()):
+                        self.assertEqual(lima_traffico_runner.main(), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,3 +1,4 @@
 *
 !xmake.lua
 !.gitignore
+!lima_traffico_runner.py

--- a/tools/lima_traffico_runner.py
+++ b/tools/lima_traffico_runner.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import posixpath
+import subprocess
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping
+
+
+DEFAULT_TESTS = ["test/intent_examples.bats"]
+DEFAULT_REPO_IN_VM = str(Path(__file__).resolve().parents[1])
+
+
+def shell_quote(value: str) -> str:
+    return "'" + value.replace("'", "'\"'\"'") + "'"
+
+
+def join_shell(argv: Iterable[str]) -> str:
+    return " ".join(shell_quote(part) for part in argv)
+
+
+def normalized_tests(tests: List[str]) -> List[str]:
+    return tests if tests else list(DEFAULT_TESTS)
+
+
+def build_guest_command(repo_in_vm: str, tests: List[str], configure: bool, build: bool) -> str:
+    quoted_repo = shell_quote(repo_in_vm)
+    quoted_repo_marker = shell_quote(posixpath.join(repo_in_vm, "xmake.lua"))
+    commands = [
+        f"test -d {quoted_repo}",
+        f"test -f {quoted_repo_marker}",
+        f"cd {quoted_repo}",
+    ]
+    if configure:
+        commands.append(join_shell(["xmake", "f", "-c", "-y", "--generate-vmlinux=y", "--require-bpftool=y"]))
+    if build:
+        commands.append(join_shell(["xmake", "build", "-y"]))
+    commands.append(join_shell(["xmake", "run", "test", *normalized_tests(tests)]))
+    return " && ".join(commands)
+
+
+def build_lima_command(instance: str, guest_command: str) -> List[str]:
+    return ["limactl", "shell", instance, "bash", "-lc", guest_command]
+
+
+def write_report(path: Path, data: Mapping[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+
+
+def run_lima_tests(
+    instance: str,
+    repo_in_vm: str,
+    tests: List[str],
+    runner_report: Path,
+    configure: bool,
+    build: bool,
+    dry_run: bool,
+) -> Mapping[str, object]:
+    selected_tests = normalized_tests(tests)
+    guest_command = build_guest_command(
+        repo_in_vm=repo_in_vm,
+        tests=selected_tests,
+        configure=configure,
+        build=build,
+    )
+    lima_command = build_lima_command(instance, guest_command)
+    data: Dict[str, object] = {
+        "status": "dry-run",
+        "instance": instance,
+        "repo_in_vm": repo_in_vm,
+        "tests": selected_tests,
+        "guest_command": guest_command,
+        "lima_command": lima_command,
+    }
+    if not dry_run:
+        completed = subprocess.run(
+            lima_command,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        data.update(
+            {
+                "returncode": completed.returncode,
+                "stdout": completed.stdout,
+                "stderr": completed.stderr,
+                "status": "ok" if completed.returncode == 0 else "failed",
+            }
+        )
+    write_report(runner_report, data)
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run traffico Linux tests inside Lima.")
+    parser.add_argument("--instance", default="traffico-ebpf")
+    parser.add_argument("--repo-in-vm", default=DEFAULT_REPO_IN_VM)
+    parser.add_argument("--runner-report", type=Path, default=Path("artifacts/lima/traffico-runner-report.json"))
+    parser.add_argument("--test", action="append", default=[])
+    parser.add_argument("--skip-configure", action="store_true")
+    parser.add_argument("--skip-build", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    data = run_lima_tests(
+        instance=args.instance,
+        repo_in_vm=args.repo_in_vm,
+        tests=args.test,
+        runner_report=args.runner_report,
+        configure=not args.skip_configure,
+        build=not args.skip_build,
+        dry_run=args.dry_run,
+    )
+    print(json.dumps(data, indent=2, sort_keys=True))
+    return 0 if data["status"] in {"ok", "dry-run"} else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lima_traffico_runner.py
+++ b/tools/lima_traffico_runner.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Dict, Iterable, List, Mapping
 
 
-DEFAULT_TESTS = ["test/intent_examples.bats"]
+DEFAULT_TESTS = ["test/intent_examples.bats", "test/intent_verifier.bats"]
 DEFAULT_REPO_IN_VM = str(Path(__file__).resolve().parents[1])
 
 

--- a/traffico.c
+++ b/traffico.c
@@ -2,6 +2,7 @@
 #include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <strings.h>
 #include <errno.h>
@@ -19,7 +20,7 @@
 #include "chain.h"
 #include "intent_bpf_loader.h"
 
-const char *argp_program_version = TOOL_NAME " 0.0";
+const char *argp_program_version = TOOL_NAME " 0.6.0";
 const char *argp_program_bug_address = "https://github.com/leodido/traffico/issues";
 // Visibility attribute needed to override glibc's weak symbol
 // when built with -fvisibility=hidden.
@@ -29,6 +30,11 @@ const char argp_program_doc[] =
     "\n"
     "Isolate your host the eBPF way.\n"
     "\v"
+    "  INTENT MODE\n"
+    "  - Intent permits: arp | dns/IP | tcp/IP[:PORT] | udp/IP[:PORT]\n"
+    "  - Intent forbids: arp | dns/IP | tcp/IP:PORT | udp/IP:PORT\n"
+    "  - Intent backend: Linux TC BPF egress only; try --dry-run --explain first\n"
+    "\n"
     "  PROGRAMS\n" PROGRAMS_DESCRIPTION;
 
 const char OPT_VERBOSE_LONG[] = "verbose";
@@ -61,6 +67,8 @@ const char OPT_DRY_RUN_LONG[] = "dry-run";
 #define OPT_EXPLAIN_KEY 0x88
 const char OPT_EXPLAIN_LONG[] = "explain";
 const char OPT_EXPLAIN_ARG[] = "intent";
+#define OPT_VERSION_KEY 0x89
+const char OPT_VERSION_LONG[] = "version";
 
 const struct argp_option argp_opts[] = {
 
@@ -76,6 +84,7 @@ const struct argp_option argp_opts[] = {
     {OPT_BLOCK_LONG, OPT_BLOCK_KEY, OPT_BLOCK_ARG, 0, "Alias for --forbid", 1},
     {OPT_DRY_RUN_LONG, OPT_DRY_RUN_KEY, NULL, 0, "Validate Intent without attaching", 1},
     {OPT_EXPLAIN_LONG, OPT_EXPLAIN_KEY, OPT_EXPLAIN_ARG, OPTION_ARG_OPTIONAL, "Print normalized Intent", 1},
+    {OPT_VERSION_LONG, OPT_VERSION_KEY, NULL, 0, "Print version and exit", 1},
     {"", 0, 0, OPTION_DOC, 0, 0},
     {0} // .
 
@@ -217,6 +226,9 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
             argp_error(state, "unsupported --explain mode: '%s'", arg);
         }
         break;
+    case OPT_VERSION_KEY:
+        printf("%s\n", argp_program_version);
+        exit(0);
 
     // Arguments
     case ARGP_KEY_ARG:
@@ -261,6 +273,10 @@ static error_t parse_cli(int key, char *arg, struct argp_state *state)
         if (g_intent_explain && !g_intent_mode)
         {
             argp_error(state, "--explain currently requires --allow, --permit, --forbid, or --block");
+        }
+        if (g_intent_mode && g_intent.permit_count == 0 && g_intent.forbid_count > 0)
+        {
+            argp_error(state, "--forbid/--block requires at least one --allow/--permit");
         }
         if (g_intent_mode)
         {


### PR DESCRIPTION
## Summary

- adds a Lima Ubuntu 24.04 eBPF VM for host-realistic traffico smoke tests
- adds `tools/lima_traffico_runner.py` as a transport-only xmake/BATS runner
- makes the default Lima release smoke gate run both `test/intent_examples.bats` and `test/intent_verifier.bats`
- adds real-world Intent example tests used by both Docker and Lima smoke gates, including an AI-agent egress quarantine example
- documents and tests the v0.6 host-wide TCP/UDP fragment boundary
- adds unit coverage for Lima command construction and dry-run reports
- adds a dedicated `running-traffico-smoke-tests` skill and cross-links it from the Linux test skill

## Verification

Host checks:

```sh
python3 test/lima_traffico_runner_test.py
python3 tools/lima_traffico_runner.py --dry-run
limactl validate lima/traffico-ebpf.yml
```

Observed host runner unit tests: `Ran 7 tests`, `OK`.
Observed dry-run default tests: `test/intent_examples.bats` and `test/intent_verifier.bats`.

Docker checks:

```sh
docker run --rm --platform linux/amd64 --privileged \
  -v "$PWD:/workspaces/traffico" \
  -v traffico-ubuntu-xmake-cache:/root/.xmake \
  -w /workspaces/traffico \
  traffico-ubuntu-test:latest \
  xmake run test test/lima_traffico_runner.bats
```

```sh
docker run --rm --platform linux/amd64 --privileged \
  -v "$PWD:/workspaces/traffico" \
  -v traffico-ubuntu-xmake-cache:/root/.xmake \
  -w /workspaces/traffico \
  traffico-ubuntu-test:latest \
  bash -lc 'xmake f -c -y --generate-vmlinux=y --require-bpftool=y && xmake build -y && xmake run test'
```

Observed full Docker suite: `1..205`, all 205 tests passed.

Lima checks:

```sh
limactl start --name=traffico-ebpf lima/traffico-ebpf.yml
limactl shell traffico-ebpf bash -lc 'command -v xmake && xmake --version | head -n 1'
python3 tools/lima_traffico_runner.py
limactl stop traffico-ebpf
```

Observed fresh Lima VM xmake:

```text
/home/leodido.linux/.local/bin/xmake
xmake v3.0.9+20260529, A cross-platform build utility based on Lua
```

Observed default Lima release gate: `status: ok`, `1..6`, all 6 tests passed.
The default gate now includes both examples and verifier evidence.

## Notes

The initial `https://xmake.io/shget.text` bootstrap failed during Lima cloud-init, and Ubuntu 24.04 apt ships xmake 2.8.7, which is too old for this repo. The VM now installs xmake through the versioned `xmake-v3.0.9.gz.run` installer.

Examples-only Lima output is useful for narrowing failures, but it is not release-complete evidence.
